### PR TITLE
Practice screen implementation

### DIFF
--- a/app/src/main/java/com/github/se/bootcamp/MainActivity.kt
+++ b/app/src/main/java/com/github/se/bootcamp/MainActivity.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.github.se.bootcamp.ui.navigation.BottomNavigationMenu
 import com.github.se.bootcamp.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.bootcamp.ui.navigation.NavigationActions
@@ -27,7 +29,7 @@ class MainActivity : ComponentActivity() {
     setContent {
       BootcampTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
-          MainAimScreen()
+          SignifyAppPreview()
         }
       }
     }
@@ -106,6 +108,25 @@ fun SignifyAppPreview() {
       route = Route.PRACTICE,
     ) {
       composable(Screen.PRACTICE) { PracticeScreen(navigationActions) }
+      composable(
+        route = "${Screen.EXERCISE}/{difficulty}/{word}",
+        arguments = listOf(
+          navArgument("difficulty") { type = NavType.StringType }, // Define difficulty argument
+          navArgument("word") { type = NavType.StringType } // Define word argument
+        )
+      ) { backStackEntry ->
+        // Get the arguments from the backStackEntry
+        val difficulty = backStackEntry.arguments?.getString("difficulty") ?: "EASY" // Default to EASY
+        val word = backStackEntry.arguments?.getString("word") ?: "default"
+
+        // Pass the arguments to ExerciseScreen
+        ExerciseScreen(
+          difficulty = DifficultyLevel.valueOf(difficulty), // Convert string to enum
+          word = word,
+          navigationActions = navigationActions
+
+        )
+      }
     }
 
     navigation(

--- a/app/src/main/java/com/github/se/bootcamp/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/bootcamp/ui/navigation/NavigationActions.kt
@@ -25,6 +25,11 @@ open class NavigationActions(
             //}
         }
     }
+    // New function to navigate to ExerciseScreen with arguments
+    open fun navigateToExerciseScreen(difficulty: String, word: String) {
+        val route = "${Screen.EXERCISE}/$difficulty/$word"
+        navController.navigate(route)
+    }
 
     open fun navigateTo(screen: String) {
         navController.navigate(screen)

--- a/app/src/main/java/com/github/se/bootcamp/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/github/se/bootcamp/ui/navigation/Screen.kt
@@ -8,4 +8,5 @@ object Screen {
     const val CHALLENGE = "Challenge Screen"
     const val AUTH = "Auth Screen"
     const val WELCOME = "Welcome Screen"
+    const val EXERCISE = "Exercise screen"
 }

--- a/app/src/main/java/com/github/se/bootcamp/ui/screens/ExerciseScreen.kt
+++ b/app/src/main/java/com/github/se/bootcamp/ui/screens/ExerciseScreen.kt
@@ -1,0 +1,193 @@
+package com.github.se.bootcamp.ui.screens
+
+import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.bootcamp.ui.navigation.NavigationActions
+
+@Composable
+fun ExerciseScreen(navigationActions : NavigationActions, difficulty : DifficultyLevel, word : String) {
+
+    val context = LocalContext.current
+
+    // MutableState to keep track of the current letter
+    var currentLetterIndex by rememberSaveable { mutableStateOf(0) }
+
+    // Get the current letter based on the index
+    val currentLetter = word[currentLetterIndex].toString()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFF333333)),
+
+        contentAlignment = Alignment.Center // Center all content in the Box
+    ) {
+
+        IconButton(
+            onClick = { navigationActions.goBack() },
+            modifier = Modifier
+                .padding(16.dp) // Add some padding to position it away from the edges
+                .align(Alignment.TopStart) // Align the button to the top-left corner
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = Color.White // Customize icon color if needed
+            )
+        }
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center // Center content in the Column as well
+        ) {
+
+            // Display instructions based on difficulty level
+            if (difficulty == DifficultyLevel.EASY) {
+
+                val imageName = "letter_${currentLetter.lowercase()}"
+                val imageResId = context.resources.getIdentifier(imageName, "drawable", context.packageName)
+
+                // Display the image if the resource exists
+                if (imageResId != 0) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding( horizontal = 16.dp)
+                            .height(200.dp)
+                            .background(Color(0xFF05A9FB), shape = RoundedCornerShape(16.dp))
+                            .border(2.dp, Color.White, shape = RoundedCornerShape(16.dp)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Image(
+                            painter = painterResource(id = imageResId),
+                            contentDescription = "Sign image",
+                            modifier = Modifier
+                                .size(120.dp)
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                } else {
+                    Text("Image for letter $currentLetter not found.")
+                }
+
+            }
+
+            // Display the current word and letter
+
+            val wordDisplay = buildString {
+
+                append(word.substring(0, currentLetterIndex).lowercase())
+
+                append(" ${word[currentLetterIndex].uppercase()} ")
+
+                append(word.substring(currentLetterIndex + 1).lowercase())
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .height(50.dp)
+                    .background(Color(0xFF05A9FB), shape = RoundedCornerShape(16.dp))
+                    .border(2.dp, Color.White, shape = RoundedCornerShape(16.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    wordDisplay,
+                    color = Color.White,
+                    style = TextStyle(
+                        fontSize = 24.sp // Set the font size to 24sp
+                    )
+                )
+                //Text("Current Letter: $currentLetter",color = Color.White)
+            }
+
+            // CAMERA BOX
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .height(350.dp)
+                    .background(Color.Black, shape = RoundedCornerShape(16.dp))
+                    .border(2.dp, Color.White, shape = RoundedCornerShape(16.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                //Text("Current Letter: $currentLetter",color = Color.White)
+            }
+
+        }
+
+        // REMOVE THIS WHEN CAMERA SUCCESS
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize().padding(30.dp),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Button(
+                onClick = {
+                    onSuccess(
+                        currentLetterIndex = currentLetterIndex,
+                        word = word,
+                        onNextLetter = { nextIndex -> currentLetterIndex = nextIndex },
+                        onWordComplete = {
+                            Toast.makeText(context, "Word Completed!", Toast.LENGTH_SHORT).show()
+                        }
+                    )
+                },
+                modifier = Modifier
+                    .width(150.dp)  // Adjust the width of the button
+                    .height(50.dp)  // Adjust the height of the button
+            ) {
+                Text(text = "Success")
+            }
+
+        }
+
+
+    }
+}
+fun onSuccess(
+    currentLetterIndex: Int,
+    word: String,
+    onNextLetter: (Int) -> Unit,
+    onWordComplete: () -> Unit
+) {
+    if (currentLetterIndex < word.length - 1) {
+        // Move to the next letter
+        onNextLetter(currentLetterIndex + 1)
+    } else {
+        // If at the end of the word, display success
+        onWordComplete()
+    }
+}
+
+enum class DifficultyLevel {
+    EASY, HARD
+}

--- a/app/src/main/java/com/github/se/bootcamp/ui/screens/PracticeScreen.kt
+++ b/app/src/main/java/com/github/se/bootcamp/ui/screens/PracticeScreen.kt
@@ -1,29 +1,216 @@
 package com.github.se.bootcamp.ui.screens
 
-
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.bootcamp.R
 import com.github.se.bootcamp.ui.navigation.BottomNavigationMenu
 import com.github.se.bootcamp.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.bootcamp.ui.navigation.NavigationActions
 
+
 @Composable
 fun PracticeScreen(navigationActions: NavigationActions) {
-    Scaffold (
+
+    var showHelp by remember { mutableStateOf(false) }
+
+
+    Scaffold(
         bottomBar = {
             BottomNavigationMenu(
                 onTabSelect = { route -> navigationActions.navigateTo(route) },
                 tabList = LIST_TOP_LEVEL_DESTINATION,
-                selectedItem = navigationActions.currentRoute())
+                selectedItem = navigationActions.currentRoute()
+            )
         },
         content = { pd ->
             Text(
                 modifier = Modifier.padding(pd),
                 text = "Practice Screen"
             )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.DarkGray)
+            ) {
+                // Help button in the top-right corner
+                HelpButton(modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(16.dp),
+                    onClick = {
+                        showHelp = true
+                    }
+                )
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize(),
+                    verticalArrangement = Arrangement.Center, // Center buttons vertically
+                    horizontalAlignment = Alignment.CenterHorizontally // Center buttons horizontally
+                ) {
+                    DifficultyButton(text = "Easy", onClick =
+                    {
+                        val word = "FGINSY" // You can modify this dynamically
+                        navigationActions.navigateToExerciseScreen(
+                            DifficultyLevel.EASY.toString(),
+                            word
+                        )
+                    })
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    DifficultyButton(text = "Hard", onClick = {
+                        val word = "FGINSY" // You can modify this dynamically
+                        navigationActions.navigateToExerciseScreen(
+                            DifficultyLevel.HARD.toString(),
+                            word
+                        )
+                    })
+                }
+
+                FlameIcon(modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(16.dp))
+
+                if (showHelp) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color(0xAA000000)) // Semi-transparent background
+                            .padding(16.dp)
+                            .clickable(
+                                enabled = true,
+                                onClick = {}, // Block other clicks
+                            )
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .background(Color.White)
+                                .padding(16.dp)
+                        ) {
+                            Text(
+                                text = buildAnnotatedString {
+                                    append("Here, you can put your ASL knowledge to the test with fun and interactive exercises. ")
+                                    append("\n\n")
+
+                                    append("You will find two levels of difficulty to challenge yourself: ")
+                                    append("\n\n")
+
+                                    withStyle(
+                                        style = SpanStyle(
+                                            fontWeight = FontWeight.Bold,
+                                            color = Color.Green
+                                        )
+                                    ) {
+                                        append("• Easy mode: ")
+                                    }
+                                    append("You will have the support of sign demos to guide you as you practice.")
+                                    append("\n\n")
+
+                                    withStyle(
+                                        style = SpanStyle(
+                                            fontWeight = FontWeight.Bold,
+                                            color = Color.Red
+                                        )
+                                    ) {
+                                        append("• Hard mode: ")
+                                    }
+                                    append("No sign demos, you have to rely on your memory to recall the ASL signs you have learned.")
+                                },
+                                fontSize = 16.sp,
+                                lineHeight = 24.sp,
+                                color = Color.Black
+                            )
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            // Close button to hide the help text
+                            TextButton(onClick = { showHelp = false }) {
+                                Text("Close")
+                            }
+                        }
+                    }
+                }
+
+            }
         }
+    )
+}
+
+@Composable
+fun DifficultyButton(text: String, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = Color(0xFF05A9FB),
+            contentColor = Color.White
+        ),
+        shape = RoundedCornerShape(16.dp),
+        modifier = Modifier
+            .width(300.dp)
+            .height(200.dp)
+            .shadow(20.dp, RoundedCornerShape(16.dp))
+            .border(2.dp, Color.White, RoundedCornerShape(16.dp))
+    ) {
+        Text(text = text, fontSize = 30.sp, color = Color.White)
+    }
+
+}
+
+@Composable
+fun HelpButton(modifier: Modifier, onClick: () -> Unit) {
+    TextButton(
+        onClick = onClick,
+        modifier = modifier
+    ) {
+        Text(
+            text = "?",
+            fontSize = 40.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.White
+        )
+    }
+}
+
+@Composable
+fun FlameIcon(modifier: Modifier) {
+    Icon(
+        painter = painterResource(id = R.drawable.flame),
+        contentDescription = "Flame",
+        tint = Color.Red,
+        modifier = modifier.size(24.dp)
     )
 }


### PR DESCRIPTION
Ignore "WIP: Working on the practice screen" commit
main interactions : 
PracticeScreen : Easy/Hard buttons, Help button 
ExerciceScreen : Back button, success button

I modified main activity to use SignifyAppPreview and added the Exercise screen navigation there. I think the profile screen navigation also needs to be moved in SignifyAppPreview. 
I didnt implement the camera as maybe someone else is better suited for this, but I put a success function in a button to use when you succesfully see the sign. 
Decided to only use 1 screen for both the Easy/Hard versions as you only add the symbol preview.
Added text formatting with colors to the help button and a clickable layer to block clicks 
 Modified navigationsActions as well to add a function to pass the arguments to the Exercise screen. 
 Didnt add ExerciceScreen to routes as it is only accessed through PracticeScreen and not through the bottom menu
 
 Additional Features to turn into tasks : Add success animation and current letter animation that are not very good rn (toast and uppercase/lowercase)