### PR TITLE
Replace all the occurences of 'bootcamp' with 'signify'

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,7 +40,7 @@ jobs:
 
       # Kernel-based Virtual Machine (KVM) is an open source virtualization technology built into Linux. Enabling it allows the Android emulator to run faster.
       #
-      # For the bootcamp, the runners already have KVM enabled, so this step is commented out. But for your projects, you will need to uncomment it.
+      # For the signify, the runners already have KVM enabled, so this step is commented out. But for your projects, you will need to uncomment it.
       #- name: Enable KVM group perms
       #  run: |
       #    echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -97,7 +97,7 @@ jobs:
           ./gradlew check --parallel --build-cache
 
       - name: Run instrumentation tests
-        # This action assumes that Android sdk is already present inthe runner. Which is true for the bootcamp, but won't be for your own project.
+        # This action assumes that Android sdk is already present inthe runner. Which is true for the signify, but won't be for your own project.
         # If you want to use this CI for your project, replace the following line with: uses: reactivecircus/android-emulator-runner@v2
         uses: RandyLutcavich/android-emulator-runner-without-sdk-setup@v1.0.3
         with:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,6 +1,5 @@
-name: Bootcamp CI - Test Runner
+name: Signify CI - Test Runner
 
-# Run the workflow when commits are pushed on main or when a PR is modified
 on:
   push:
     branches:
@@ -13,118 +12,13 @@ on:
       - reopened
 
 jobs:
-  bootcamp-ci:
-    name: CI-Bootcamp
-    # Execute the CI on the course's runners
+  signify-ci:
+    name: CI-Signify
     runs-on:
       group: runners_v1
 
     env:
-      app_name: BootcampDebug
-
-    defaults:
-      run:
-        working-directory: ./${{ env.base_folder }}
-
-    steps:
-      # First step : Checkout the repository on the runner
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of Sonar analysis (if we use Sonar Later)
-
-      # This step removes the current gradle cache to avoid any caching issues
-      - name: Remove current gradle cache
-        run: rm -rf ~/.gradle
-
-      # Kernel-based Virtual Machine (KVM) is an open source virtualization technology built into Linux. Enabling it allows the Android emulator to run faster.
-      #
-      # For the signify, the runners already have KVM enabled, so this step is commented out. But for your projects, you will need to uncomment it.
-      #- name: Enable KVM group perms
-      #  run: |
-      #    echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-      #    sudo udevadm control --reload-rules
-      #    sudo udevadm trigger --name-match=kvm
-
-      - name: Setup JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: "17"
-
-
-      # Caching is a very useful part of a CI, as a workflow is executed in a clean environement every time,
-      # this means that one would need to re-download and re-process gradle files for every run. Which is very time consuming.
-      #
-      # To avoid that, we cache the the gradle folder to reuse it later.
-      - name: Retrieve gradle cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-
-      # Load google-services.json and local.properties from the secrets
-      - name: Decode secrets
-        env:
-          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
-          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
-        run: |
-          echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
-          echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
-
-      - name: Grant execute permission for gradlew
-        run: |
-          chmod +x ./gradlew
-
-      # Remove the "#" if you want to enforce the formatting check when pushing on your repo
-      #- name: KTFmt Check
-      #  run: |
-      #    # To run the CI with debug informations, add --info
-      #    ./gradlew ktfmtCheck
-
-      # This step runs gradle commands to build the application
-      - name: Assemble
-        run: |
-          # To run the CI with debug information, add --info
-          ./gradlew assembleDebug lint --parallel --build-cache
-
-      - name: Run tests
-        run: |
-          # To run the CI with debug information, add --info
-          ./gradlew check --parallel --build-cache
-
-      - name: Run instrumentation tests
-        # This action assumes that Android sdk is already present inthe runner. Which is true for the signify, but won't be for your own project.
-        # If you want to use this CI for your project, replace the following line with: uses: reactivecircus/android-emulator-runner@v2
-        uses: RandyLutcavich/android-emulator-runner-without-sdk-setup@v1.0.3
-        with:
-          api-level: 34
-          target: google_apis
-          arch: x86_64
-          avd-name: github
-          force-avd-creation: true
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x1920
-          disable-animations: true
-          script: ./gradlew connectedCheck --parallel --build-cache
-
-      # This step generates the coverage report which will be used later in the semster for monitoring purposes
-      - name: Generate coverage
-        run: |
-          ./gradlew jacocoTestReport
-
-      - name: Upload coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: Coverage report
-          path: app/build/reports/jacoco/jacocoTestReport
-
-  exercises:
-    name: Exercises
-    # Execute the CI on the course's runners
-    runs-on: ubuntu-latest
+      app_name: SignifyDebug
 
     defaults:
       run:
@@ -137,9 +31,39 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Check that userStories.txt exists
-        run: stat userStories.txt
+      - name: Remove current gradle cache
+        run: rm -rf ~/.gradle
 
-      # Couting non-empty lines https://stackoverflow.com/a/114861
-      - name: Check that userStories.txt has at least two lines
-        run: '[ $(grep -cve "^\s*$" userStories.txt) -ge "2" ]'
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Retrieve gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+
+      - name: Decode secrets
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+        run: |
+          echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Assemble
+        run: ./gradlew assembleDebug lint --parallel --build-cache
+
+      - name: Run tests
+        run: ./gradlew check --parallel --build-cache
+
+      - name: Run instrumentation tests
+        uses: RandyLutcavich/android-emulator-runner-without-sdk-setup@v1.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 android {
-    namespace = "com.github.se.bootcamp"
+    namespace = "com.github.se.signify"
     compileSdk = 34
 
 
@@ -28,7 +28,7 @@ android {
 
 
     defaultConfig {
-        applicationId = "com.github.se.bootcamp"
+        applicationId = "com.github.se.signify"
         minSdk = 29
         targetSdk = 34
         versionCode = 1

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp
+package com.github.se.signify
 
 import android.annotation.SuppressLint
 import android.os.Bundle
@@ -13,16 +13,15 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
-import com.github.se.bootcamp.model.hand.HandLandMarkImplementation
-import com.github.se.bootcamp.model.hand.HandLandMarkViewModel
-import com.github.se.bootcamp.ui.navigation.BottomNavigationMenu
-import com.github.se.bootcamp.ui.navigation.LIST_TOP_LEVEL_DESTINATION
-import com.github.se.bootcamp.ui.navigation.NavigationActions
-import com.github.se.bootcamp.ui.navigation.Route
-import com.github.se.bootcamp.ui.navigation.Screen
-import com.github.se.bootcamp.ui.navigation.TopLevelDestination
-import com.github.se.bootcamp.ui.screens.*
-import com.github.se.bootcamp.ui.theme.BootcampTheme
+import com.github.se.signify.model.hand.HandLandMarkImplementation
+import com.github.se.signify.model.hand.HandLandMarkViewModel
+import com.github.se.signify.ui.navigation.BottomNavigationMenu
+import com.github.se.signify.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.github.se.signify.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.Route
+import com.github.se.signify.ui.navigation.Screen
+import com.github.se.signify.ui.screens.*
+import com.github.se.signify.ui.theme.BootcampTheme
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkImplementation.kt
+++ b/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkImplementation.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.model.hand
+package com.github.se.signify.model.hand
 
 import ai.onnxruntime.OnnxTensor
 import ai.onnxruntime.OrtEnvironment

--- a/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkRepository.kt
@@ -1,8 +1,7 @@
-package com.github.se.bootcamp.model.hand
+package com.github.se.signify.model.hand
 
 import android.content.Context
 import androidx.camera.core.ImageProxy
-import com.google.mediapipe.tasks.vision.handlandmarker.HandLandmark
 import com.google.mediapipe.tasks.vision.handlandmarker.HandLandmarker
 import com.google.mediapipe.tasks.vision.handlandmarker.HandLandmarkerResult
 

--- a/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkViewModel.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.model.hand
+package com.github.se.signify.model.hand
 
 import android.content.Context
 import android.util.Log

--- a/app/src/main/java/com/github/se/signify/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/se/signify/ui/navigation/BottomNavigationMenu.kt
@@ -1,8 +1,7 @@
-package com.github.se.bootcamp.ui.navigation
+package com.github.se.signify.ui.navigation
 
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
@@ -12,7 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 
 @Composable

--- a/app/src/main/java/com/github/se/signify/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/signify/ui/navigation/NavigationActions.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.ui.navigation
+package com.github.se.signify.ui.navigation
 
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController

--- a/app/src/main/java/com/github/se/signify/ui/navigation/Route.kt
+++ b/app/src/main/java/com/github/se/signify/ui/navigation/Route.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.ui.navigation
+package com.github.se.signify.ui.navigation
 
 object Route {
     const val MAIN_AIM = "MainAim"

--- a/app/src/main/java/com/github/se/signify/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/navigation/Screen.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.ui.navigation
+package com.github.se.signify.ui.navigation
 
 object Screen {
     const val MAIN_AIM = "Main Aim Screen"

--- a/app/src/main/java/com/github/se/signify/ui/navigation/TopLevelDestinations.kt
+++ b/app/src/main/java/com/github/se/signify/ui/navigation/TopLevelDestinations.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.ui.navigation
+package com.github.se.signify.ui.navigation
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*

--- a/app/src/main/java/com/github/se/signify/ui/screens/ChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/ChallengeScreen.kt
@@ -1,10 +1,9 @@
-package com.github.se.bootcamp.ui.screens
+package com.github.se.signify.ui.screens
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
@@ -27,9 +26,9 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.material3.Surface
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
-import com.github.se.bootcamp.ui.navigation.BottomNavigationMenu
-import com.github.se.bootcamp.ui.navigation.LIST_TOP_LEVEL_DESTINATION
-import com.github.se.bootcamp.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.BottomNavigationMenu
+import com.github.se.signify.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.github.se.signify.ui.navigation.NavigationActions
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable

--- a/app/src/main/java/com/github/se/signify/ui/screens/FriendsListScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/FriendsListScreen.kt
@@ -1,7 +1,6 @@
-package com.github.se.bootcamp.ui.screens
+package com.github.se.signify.ui.screens
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -24,7 +23,6 @@ import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
@@ -41,7 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.github.se.bootcamp.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.NavigationActions
 
 
 @Composable

--- a/app/src/main/java/com/github/se/signify/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/LoginScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.ui.screens
+package com.github.se.signify.ui.screens
 
 import android.content.Intent
 import android.util.Log
@@ -10,7 +10,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
@@ -24,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -32,8 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.github.se.bootcamp.R
-import com.github.se.bootcamp.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.NavigationActions
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException

--- a/app/src/main/java/com/github/se/signify/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/MainScreen.kt
@@ -1,6 +1,5 @@
-package com.github.se.bootcamp.ui.screens
+package com.github.se.signify.ui.screens
 import android.Manifest
-import android.content.Context
 import android.content.pm.PackageManager
 import android.util.Log
 import android.widget.Toast
@@ -22,15 +21,12 @@ import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.graphics.vector.DefaultStrokeLineWidth
-import androidx.compose.ui.graphics.vector.VectorProperty
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
-import com.github.se.bootcamp.model.hand.HandLandMarkViewModel
+import com.github.se.signify.model.hand.HandLandMarkViewModel
 import com.google.mediapipe.tasks.components.containers.NormalizedLandmark
-import com.google.mediapipe.tasks.vision.handlandmarker.HandLandmarker
 import java.util.concurrent.Executors
 
 @Composable

--- a/app/src/main/java/com/github/se/signify/ui/screens/PracticeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/PracticeScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.ui.screens
+package com.github.se.signify.ui.screens
 
 
 import androidx.compose.foundation.layout.padding
@@ -6,12 +6,12 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.github.se.bootcamp.ui.navigation.BottomNavigationMenu
-import com.github.se.bootcamp.ui.navigation.LIST_TOP_LEVEL_DESTINATION
-import com.github.se.bootcamp.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.BottomNavigationMenu
+import com.github.se.signify.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.github.se.signify.ui.navigation.NavigationActions
 
 @Composable
-fun QuestScreen(navigationActions: NavigationActions) {
+fun PracticeScreen(navigationActions: NavigationActions) {
     Scaffold (
         bottomBar = {
             BottomNavigationMenu(
@@ -22,7 +22,7 @@ fun QuestScreen(navigationActions: NavigationActions) {
         content = { pd ->
             Text(
                 modifier = Modifier.padding(pd),
-                text = "Quest Screen"
+                text = "Practice Screen"
             )
         }
     )

--- a/app/src/main/java/com/github/se/signify/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/ProfileScreen.kt
@@ -1,11 +1,9 @@
-package com.github.se.bootcamp.ui.screens
+package com.github.se.signify.ui.screens
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,7 +23,6 @@ import androidx.compose.foundation.verticalScroll
 //noinspection UsingMaterialAndMaterial3Libraries
 import androidx.compose.material.Icon
 //noinspection UsingMaterialAndMaterial3Libraries
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
@@ -49,10 +46,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import coil.compose.rememberImagePainter
-import com.github.se.bootcamp.R
-import com.github.se.bootcamp.ui.navigation.BottomNavigationMenu
-import com.github.se.bootcamp.ui.navigation.LIST_TOP_LEVEL_DESTINATION
-import com.github.se.bootcamp.ui.navigation.NavigationActions
+import com.github.se.signify.R
+import com.github.se.signify.ui.navigation.BottomNavigationMenu
+import com.github.se.signify.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.github.se.signify.ui.navigation.NavigationActions
 
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")

--- a/app/src/main/java/com/github/se/signify/ui/screens/QuestScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/QuestScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.ui.screens
+package com.github.se.signify.ui.screens
 
 
 import androidx.compose.foundation.layout.padding
@@ -6,12 +6,12 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.github.se.bootcamp.ui.navigation.BottomNavigationMenu
-import com.github.se.bootcamp.ui.navigation.LIST_TOP_LEVEL_DESTINATION
-import com.github.se.bootcamp.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.BottomNavigationMenu
+import com.github.se.signify.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.github.se.signify.ui.navigation.NavigationActions
 
 @Composable
-fun PracticeScreen(navigationActions: NavigationActions) {
+fun QuestScreen(navigationActions: NavigationActions) {
     Scaffold (
         bottomBar = {
             BottomNavigationMenu(
@@ -22,7 +22,7 @@ fun PracticeScreen(navigationActions: NavigationActions) {
         content = { pd ->
             Text(
                 modifier = Modifier.padding(pd),
-                text = "Practice Screen"
+                text = "Quest Screen"
             )
         }
     )

--- a/app/src/main/java/com/github/se/signify/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/SettingsScreen.kt
@@ -1,28 +1,24 @@
-package com.github.se.bootcamp.ui.screens
+package com.github.se.signify.ui.screens
 
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.github.se.bootcamp.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.NavigationActions
 
 @Composable
 fun SettingsScreen(profilePictureUrl: String?,

--- a/app/src/main/java/com/github/se/signify/ui/screens/WelcomeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/WelcomeScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.ui.screens
+package com.github.se.signify.ui.screens
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -26,11 +25,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.github.se.bootcamp.R
-import com.github.se.bootcamp.ui.navigation.NavigationActions
+import com.github.se.signify.R
+import com.github.se.signify.ui.navigation.NavigationActions
 import kotlinx.coroutines.delay
 
 @Composable fun WelcomeScreen(navigationActions: NavigationActions) {

--- a/app/src/main/java/com/github/se/signify/ui/theme/Color.kt
+++ b/app/src/main/java/com/github/se/signify/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.ui.theme
+package com.github.se.signify.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/github/se/signify/ui/theme/Theme.kt
+++ b/app/src/main/java/com/github/se/signify/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.ui.theme
+package com.github.se.signify.ui.theme
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme

--- a/app/src/main/java/com/github/se/signify/ui/theme/Type.kt
+++ b/app/src/main/java/com/github/se/signify/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.github.se.bootcamp.ui.theme
+package com.github.se.signify.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,6 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "bootcamp"
+rootProject.name = "signify"
 include(":app")
  


### PR DESCRIPTION
Replaced all instances of the word 'bootcamp' with 'signify' across the project to align with the new project name and branding. This includes changes in code comments, variable names, function names, documentation, and any other relevant occurrences where 'bootcamp' was used.
