### PR TITLE
Move scrum task instructions from README.md to wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,49 +45,8 @@ You can view the Figma project here: [Signify Figma Project](https://www.figma.c
 
 ## Contributing
 
-All steps of the development of new features and bug fixes are organized through the [scrum board](https://github.com/orgs/Signify-epfl/projects/2) on Github. Tasks are compartmentalized as entries in the [scrum board](https://github.com/orgs/Signify-epfl/projects/2) and distributed into 1 week sprints.
-
-### User stories
-
-Any new feature must be associated with a user story.
-A user story must match the following format:
-`As a <role>, I want to <action>, so that <reason>.`
-e.g. `As an active user, I want to log in to the app using my email, so that my data can be saved between sessions.`
-New user stories must be added to the scrum board under the status `Product Backlog`.
-
-### Issues
-
-To signal a bug, create an task on the scrum board detailing the fix. Then convert that task to a Github issue.
-Once an assignee fixes the issue, they must create a pull request linking their fix to that issue.
-A different developer will then need to approve the request to merge it with the app's main development branch.
-
-### Task Anatomy
-
-Before making any contribution, you **must** mark a task in the scrum board with the status `In Development`.
-Once completed, mark it as `In Review`.
-After a separate developer reviews your change, the task shall finally be marked as `Done`.
-
-The following fields in a task detail what the objective of your work is:
-
-- title: What does this task aim to do?
-- description: What specific changes will be made when this task is completed?
-- nature: Is this a user story or a single sprint task?
-- priority: How important is this task?
-- status: What stage of development is this task in?
-  - Product Backlog: this is an unimplemented user story.
-  - Sprint Backlog: this task should be considered for the current sprint.
-  - In Development: this task is currently being worked on.
-  - In Review: this task is awaiting review from another developer.
-  - Done in Sn: this task was reviewed and marked as done in sprint n.
-- assignee: Who is or will be working on this task? (set before status `In Development`)
-- estimated time: How long do you estimate this task to take to complete?
-- actual time: How long did this task take to complete? (set after status `Done`)
-- scope: Which part of the project does this task primarily affect?
-- epic: Which broad set of features does this task aim to build up?
-
-The title and description of a change should match the conventions for git commit messages.
-Task fields are to be set as soon as possible in the task's life cycle.
-Each of these fields must be filled in by the time a task is marked as `Done`.
+All steps of the development of new features and bug fixes are organized through the [scrum board](https://github.com/orgs/Signify-epfl/projects/2) on Github.  
+Check [this wiki page](https://github.com/Signify-epfl/signify-app/wiki/Scrum-Tasks) on how to handle scrum tasks.
 
 ## Acknowledgments
 


### PR DESCRIPTION
Remove scrum task instructions section from README.md after moving them to this repository's wiki, as suggested by the coaches.