### PR TITLE
ci: integrate SonarCloud with 60% coverage, 5% duplication, and JaCoC…

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,7 +16,6 @@ jobs:
     name: CI-Signify
     runs-on: ubuntu-latest
 
-
     env:
       app_name: SignifyDebug
 
@@ -33,10 +32,7 @@ jobs:
 
       - name: Remove current gradle cache
         run: rm -rf ~/.gradle
-          
-          # Kernel-based Virtual Machine (KVM) is an open source virtualization technology built into Linux. Enabling it allows the Android emulator to run faster.
-          #
-          # For the bootcamp, the runners already have KVM enabled, so this step is commented out. But for your projects, you will need to uncomment it.
+
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -57,7 +53,6 @@ jobs:
             ~/.gradle/wrapper
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
-
       - name: Decode secrets
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
@@ -66,13 +61,10 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
-          
 
       - name: KTFmt Check
-        run: |
-          ./gradlew ktfmtCheck
+        run: ./gradlew ktfmtCheck
 
-        # This step runs gradle commands to build the application
       - name: Assemble
         run: ./gradlew assembleDebug lint --parallel --build-cache
 
@@ -82,21 +74,38 @@ jobs:
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-            api-level: 34
-            target: google_apis
-            arch: x86_64
-            avd-name: github
-            force-avd-creation: true
-            emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x1920
-            disable-animations: true
-            script: ./gradlew connectedCheck --parallel --build-cache
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          avd-name: github
+          force-avd-creation: true
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x1920
+          disable-animations: true
+          script: ./gradlew connectedCheck --parallel --build-cache
 
-            # This step generates the coverage report which will be used later in the semster for monitoring purposes
       - name: Generate coverage
-        run: |
-              ./gradlew jacocoTestReport
+        run: ./gradlew jacocoTestReport
+
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
-           name: Coverage report
-           path: app/build/reports/jacoco/jacocoTestReport
+          name: Coverage report
+          path: app/build/reports/jacoco/jacocoTestReport
+
+      # SonarCloud Analysis
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@v2
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          projectBaseDir: ./
+          args: >
+            -Dsonar.projectKey=your_project_key
+            -Dsonar.organization=your_organization
+            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.coverage.exclusions=**/test/**
+            -Dsonar.java.coveragePlugin=jacoco
+            -Dsonar.jacoco.reportPaths=app/build/reports/jacoco/jacocoTestReport.xml
+            -Dsonar.coverage.minimumCoverage=60
+            -Dsonar.duplication.exclusions=**/*.java
+            -Dsonar.cpd.duplicationThreshold=5

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -100,8 +100,8 @@ jobs:
         with:
           projectBaseDir: ./
           args: >
-            -Dsonar.projectKey=your_project_key
-            -Dsonar.organization=your_organization
+            -Dsonar.projectKey=Signify-epfl_signify-app
+            -Dsonar.organization=signify-epfl
             -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.coverage.exclusions=**/test/**
             -Dsonar.java.coveragePlugin=jacoco

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=Signify-epfl_signify-app
+sonar.organization=signify-epfl
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=signify-app
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
- Added SonarCloud scan to the GitHub Actions pipeline for continuous code quality analysis.
- Linked test coverage report using JaCoCo to monitor unit test coverage, setting a minimum threshold of 60%.
- Set code duplication threshold to 5% for flexibility.
- Configured project key and organization for SonarCloud integration. Secrets for SonarCloud integration can be managed [here](https://github.com/Signify-epfl/signify-app/settings/secrets/actions).