### PR TITLE
Update the profile screen to match its new design

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/ProfileScreenTest.kt
@@ -1,0 +1,165 @@
+package com.github.se.signify.ui.screens
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import com.github.se.signify.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.Screen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class ProfileScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var navigationActions: NavigationActions
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+
+    `when`(navigationActions.currentRoute()).thenReturn(Screen.PROFILE)
+  }
+
+  @Test
+  fun buttonsAreCorrectlyDisplayed() {
+
+    composeTestRule.setContent {
+      ProfileScreen(
+          userId = "Test ID 1",
+          userName = "Test Name 1",
+          profilePictureUrl = null, // Replace with actual URL or null
+          numberOfDays = 30,
+          lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F'),
+          navigationActions)
+    }
+
+    composeTestRule.onNodeWithTag("settingsButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("helpButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("My FriendsButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("My FriendsButton").assertTextEquals("My Friends")
+    composeTestRule.onNodeWithTag("My StatsButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("My StatsButton").assertTextEquals("My Stats")
+  }
+
+  @Test
+  fun buttonsHaveClickAction() {
+
+    composeTestRule.setContent {
+      ProfileScreen(
+          userId = "Test ID 1",
+          userName = "Test Name 1",
+          profilePictureUrl = null, // Replace with actual URL or null
+          numberOfDays = 30,
+          lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F'),
+          navigationActions)
+    }
+
+    composeTestRule.onNodeWithTag("settingsButton").assertHasClickAction()
+    composeTestRule.onNodeWithTag("helpButton").assertHasClickAction()
+    composeTestRule.onNodeWithTag("My FriendsButton").assertHasClickAction()
+    composeTestRule.onNodeWithTag("My StatsButton").assertHasClickAction()
+  }
+
+  @Test
+  fun buttonsPerformClick() {
+    composeTestRule.setContent {
+      ProfileScreen(
+          userId = "Test ID 1",
+          userName = "Test Name 1",
+          profilePictureUrl = null, // Replace with actual URL or null
+          numberOfDays = 30,
+          lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F'),
+          navigationActions)
+    }
+
+    composeTestRule.onNodeWithTag("settingsButton").performClick()
+    composeTestRule.onNodeWithTag("helpButton").performClick()
+    composeTestRule.onNodeWithTag("My FriendsButton").performClick()
+    composeTestRule.onNodeWithTag("My StatsButton").performClick()
+  }
+
+  @Test
+  fun userInfoAreDisplayed() {
+    composeTestRule.setContent {
+      ProfileScreen(
+          userId = "Test ID 1",
+          userName = "Test Name 1",
+          profilePictureUrl = null, // Replace with actual URL or null
+          numberOfDays = 30,
+          lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F'),
+          navigationActions)
+    }
+
+    composeTestRule.onNodeWithTag("userInfo").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("flameIcon").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("lettersBox").assertIsDisplayed()
+  }
+
+  @Test
+  fun letterListScrolls() {
+    composeTestRule.setContent {
+      ProfileScreen(
+          userId = "Test ID 1",
+          userName = "Test Name 1",
+          profilePictureUrl = null, // Replace with actual URL or null
+          numberOfDays = 30,
+          lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F'),
+          navigationActions)
+    }
+
+    composeTestRule.onNodeWithTag("lettersList").performScrollTo()
+  }
+
+  @Test
+  fun dialogIsDisplayed_whenHelpBoxIsVisible() {
+    // Initialize the state of isHelpBoxVisible to true
+    composeTestRule.setContent {
+      ProfileScreen(
+          userId = "Test ID 1",
+          userName = "Test Name 1",
+          profilePictureUrl = null, // Replace with actual URL or null
+          numberOfDays = 30,
+          lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F'),
+          navigationActions)
+    }
+
+    // Assert that the help dialog is displayed when the help button is clicked
+    composeTestRule.onNodeWithTag("helpButton").performClick()
+    composeTestRule.onNodeWithTag("helpProfileText").assertIsDisplayed()
+  }
+
+  @Test
+  fun dialogCloses_whenCloseButtonClicked() {
+    // Initialize the state of isHelpBoxVisible to true
+    composeTestRule.setContent {
+      val isHelpBoxVisible = remember { mutableStateOf(true) }
+      ProfileScreen(
+          userId = "Test ID 1",
+          userName = "Test Name 1",
+          profilePictureUrl = null, // Replace with actual URL or null
+          numberOfDays = 30,
+          lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F'),
+          navigationActions)
+    }
+
+    // Click the 'Close' button in the dialog
+    composeTestRule.onNodeWithTag("helpButton").performClick()
+    composeTestRule.onNodeWithTag("closeButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("closeButton").assertHasClickAction()
+    composeTestRule.onNodeWithTag("closeButton").performClick()
+
+    // After clicking, the dialog should no longer be displayed
+    composeTestRule.onNodeWithTag("helpProfileText").assertDoesNotExist()
+  }
+}

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -118,11 +118,6 @@ fun SignifyAppPreview() {
             profilePictureUrl = null, // Replace with actual URL or null
             numberOfDays = 30,
             lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F'),
-            easyExercises = 1,
-            hardExercises = 0,
-            dailyQuests = 1,
-            weeklyQuests = 0,
-            onGraphClick = { /* Handle graph click */},
             navigationActions = navigationActions)
       }
 

--- a/app/src/main/java/com/github/se/signify/ui/Utils.kt
+++ b/app/src/main/java/com/github/se/signify/ui/Utils.kt
@@ -1,20 +1,15 @@
 package com.github.se.signify.ui
 
-
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.colorResource
@@ -24,26 +19,17 @@ import androidx.compose.ui.unit.sp
 import com.github.se.signify.R
 
 @Composable
-fun ReusableButtonWithIcon(
-    onClickAction: () -> Unit,
-    icon: ImageVector,
-    iconDescription: String
-) {
-    OutlinedButton(
-        onClick = onClickAction,
-        modifier = Modifier.padding(8.dp),
-        border = ButtonDefaults.outlinedButtonBorder.copy(
-            width = 2.dp,
-            brush = SolidColor(colorResource(R.color.dark_gray))
-        ),
-        colors = ButtonDefaults.outlinedButtonColors(colorResource(R.color.blue)),
-    ) {
-        Icon(
-            icon,
-            tint = colorResource(R.color.dark_gray),
-            contentDescription = iconDescription
-        )
-    }
+fun ReusableButtonWithIcon(onClickAction: () -> Unit, icon: ImageVector, iconDescription: String) {
+  OutlinedButton(
+      onClick = onClickAction,
+      modifier = Modifier.padding(8.dp),
+      border =
+          ButtonDefaults.outlinedButtonBorder.copy(
+              width = 2.dp, brush = SolidColor(colorResource(R.color.dark_gray))),
+      colors = ButtonDefaults.outlinedButtonColors(colorResource(R.color.blue)),
+  ) {
+    Icon(icon, tint = colorResource(R.color.dark_gray), contentDescription = iconDescription)
+  }
 }
 
 @Composable
@@ -51,22 +37,17 @@ fun ReusableTextButton(
     onClickAction: () -> Unit,
     text: String,
 ) {
-    OutlinedButton(
-        onClick = onClickAction,
-        border = ButtonDefaults.outlinedButtonBorder.copy(
-            width = 2.dp,
-            brush = SolidColor(colorResource(R.color.dark_gray))
-        ),
-        colors = ButtonDefaults.buttonColors(colorResource(R.color.blue)),
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(40.dp)
-    ) {
+  OutlinedButton(
+      onClick = onClickAction,
+      border =
+          ButtonDefaults.outlinedButtonBorder.copy(
+              width = 2.dp, brush = SolidColor(colorResource(R.color.dark_gray))),
+      colors = ButtonDefaults.buttonColors(colorResource(R.color.blue)),
+      modifier = Modifier.fillMaxWidth().height(40.dp)) {
         Text(
             text,
             fontWeight = FontWeight.Bold,
             color = colorResource(R.color.dark_gray),
-            fontSize = 16.sp
-        )
-    }
+            fontSize = 16.sp)
+      }
 }

--- a/app/src/main/java/com/github/se/signify/ui/Utils.kt
+++ b/app/src/main/java/com/github/se/signify/ui/Utils.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -22,7 +23,7 @@ import com.github.se.signify.R
 fun ReusableButtonWithIcon(onClickAction: () -> Unit, icon: ImageVector, iconDescription: String) {
   OutlinedButton(
       onClick = onClickAction,
-      modifier = Modifier.padding(8.dp),
+      modifier = Modifier.padding(8.dp).testTag(iconDescription + "Button"),
       border =
           ButtonDefaults.outlinedButtonBorder.copy(
               width = 2.dp, brush = SolidColor(colorResource(R.color.dark_gray))),
@@ -43,7 +44,7 @@ fun ReusableTextButton(
           ButtonDefaults.outlinedButtonBorder.copy(
               width = 2.dp, brush = SolidColor(colorResource(R.color.dark_gray))),
       colors = ButtonDefaults.buttonColors(colorResource(R.color.blue)),
-      modifier = Modifier.fillMaxWidth().height(40.dp)) {
+      modifier = Modifier.fillMaxWidth().height(40.dp).testTag(text + "Button")) {
         Text(
             text,
             fontWeight = FontWeight.Bold,

--- a/app/src/main/java/com/github/se/signify/ui/Utils.kt
+++ b/app/src/main/java/com/github/se/signify/ui/Utils.kt
@@ -1,0 +1,72 @@
+package com.github.se.signify.ui
+
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.signify.R
+
+@Composable
+fun ReusableButtonWithIcon(
+    onClickAction: () -> Unit,
+    icon: ImageVector,
+    iconDescription: String
+) {
+    OutlinedButton(
+        onClick = onClickAction,
+        modifier = Modifier.padding(8.dp),
+        border = ButtonDefaults.outlinedButtonBorder.copy(
+            width = 2.dp,
+            brush = SolidColor(colorResource(R.color.dark_gray))
+        ),
+        colors = ButtonDefaults.outlinedButtonColors(colorResource(R.color.blue)),
+    ) {
+        Icon(
+            icon,
+            tint = colorResource(R.color.dark_gray),
+            contentDescription = iconDescription
+        )
+    }
+}
+
+@Composable
+fun ReusableTextButton(
+    onClickAction: () -> Unit,
+    text: String,
+) {
+    OutlinedButton(
+        onClick = onClickAction,
+        border = ButtonDefaults.outlinedButtonBorder.copy(
+            width = 2.dp,
+            brush = SolidColor(colorResource(R.color.dark_gray))
+        ),
+        colors = ButtonDefaults.buttonColors(colorResource(R.color.blue)),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(40.dp)
+    ) {
+        Text(
+            text,
+            fontWeight = FontWeight.Bold,
+            color = colorResource(R.color.dark_gray),
+            fontSize = 16.sp
+        )
+    }
+}

--- a/app/src/main/java/com/github/se/signify/ui/navigation/Route.kt
+++ b/app/src/main/java/com/github/se/signify/ui/navigation/Route.kt
@@ -10,4 +10,5 @@ object Route {
   const val WELCOME = "Welcome"
   const val FRIENDS = "Friends"
   const val SETTINGS = "Settings"
+  const val STATS = "Stats"
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/MyStatsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/MyStatsScreen.kt
@@ -1,0 +1,11 @@
+package com.github.se.signify.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.github.se.signify.ui.navigation.NavigationActions
+
+@Composable
+fun MyStatsScreen(navigationActions: NavigationActions) {
+  Column { Text(text = "My stats Screen") }
+}

--- a/app/src/main/java/com/github/se/signify/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/ProfileScreen.kt
@@ -1,7 +1,5 @@
 package com.github.se.signify.ui.screens
 
-//noinspection UsingMaterialAndMaterial3Libraries
-//noinspection UsingMaterialAndMaterial3Libraries
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -22,8 +20,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Icon
-import androidx.compose.material.Surface
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Settings
@@ -40,13 +38,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import coil.compose.rememberImagePainter
 import com.github.se.signify.R
+import com.github.se.signify.ui.ReusableButtonWithIcon
+import com.github.se.signify.ui.ReusableTextButton
 import com.github.se.signify.ui.navigation.BottomNavigationMenu
 import com.github.se.signify.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.signify.ui.navigation.NavigationActions
@@ -59,295 +61,219 @@ fun ProfileScreen(
     profilePictureUrl: String?,
     numberOfDays: Int,
     lettersLearned: List<Char>,
-    easyExercises: Int,
-    hardExercises: Int,
-    dailyQuests: Int,
-    weeklyQuests: Int,
-    onGraphClick: () -> Unit,
     navigationActions: NavigationActions
 ) {
-  Scaffold(
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute())
-      },
-      content = {
-        Column(
-            modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-          var isHelpBoxVisible by remember { mutableStateOf(false) }
+    Scaffold(
+        bottomBar = {
+            BottomNavigationMenu(
+                onTabSelect = { route -> navigationActions.navigateTo(route) },
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = navigationActions.currentRoute()
+            )
+        },
+        content = {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                var isHelpBoxVisible by remember { mutableStateOf(false) }
 
-          // Top row with Settings and Help buttons
-          Row(
-              modifier = Modifier.fillMaxWidth(),
-              horizontalArrangement = Arrangement.SpaceBetween) {
-                Button(
-                    onClick = { isHelpBoxVisible = !isHelpBoxVisible },
-                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF05A9FB))) {
-                      Icon(Icons.Outlined.Info, tint = Color.White, contentDescription = "Help")
-                    }
-
-                Button(
-                    onClick = { navigationActions.navigateTo("Settings") },
-                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF05A9FB))) {
-                      Icon(
-                          Icons.Outlined.Settings,
-                          tint = Color.White,
-                          contentDescription = "Settings")
-                    }
-
-                if (isHelpBoxVisible) {
-                  Dialog(onDismissRequest = { isHelpBoxVisible = false }) {
-                    Surface(
-                        shape = RoundedCornerShape(8.dp),
-                        color = Color.LightGray,
-                        modifier =
-                            Modifier.padding(16.dp)
-                                .border(2.dp, Color.Gray, RoundedCornerShape(12.dp))
-                                .clip(RoundedCornerShape(12.dp))) {
-                          Column(
-                              modifier = Modifier.padding(16.dp).fillMaxWidth(),
-                              horizontalAlignment = Alignment.CenterHorizontally) {
-                                Text(
-                                    "This is your personal space where you can:\n" +
-                                        "\n" +
-                                        "- View and edit your profile.\n" +
-                                        "\n" +
-                                        "- Track your progress: See how far you have come in your ASL journey, with clear insights into what you have learned and what is next.",
-                                    color = Color.Black)
-                                Spacer(modifier = Modifier.height(16.dp))
-                                Button(
-                                    onClick = { isHelpBoxVisible = false },
-                                    colors =
-                                        ButtonDefaults.buttonColors(
-                                            containerColor = Color(0xFF05A9FB))) {
-                                      Text("Close")
-                                    }
-                              }
-                        }
-                  }
-                }
-              }
-
-          Spacer(modifier = Modifier.height(24.dp))
-
-          Row(
-              modifier = Modifier.fillMaxWidth(),
-              horizontalArrangement = Arrangement.Center,
-              verticalAlignment = Alignment.CenterVertically) {
-                // User Info: Display Test ID and Test Name in a Column
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    // modifier = Modifier.fillMaxWidth()
+                // Top row with Settings and Help buttons
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                  Text(text = userId, fontWeight = FontWeight.Bold) // Test ID
-                  Text(text = userName, fontWeight = FontWeight.Bold) // Test Name
+
+                    ReusableButtonWithIcon(
+                        { isHelpBoxVisible = !isHelpBoxVisible },
+                        Icons.Outlined.Info,
+                        "Help"
+                    )
+
+                    ReusableButtonWithIcon(
+                        { navigationActions.navigateTo("Settings") },
+                        Icons.Outlined.Settings,
+                        "Settings"
+                    )
+
+
+                    if (isHelpBoxVisible) {
+                        Dialog(onDismissRequest = { isHelpBoxVisible = false }) {
+                            Surface(
+                                shape = RoundedCornerShape(8.dp),
+                                color = Color.LightGray,
+                                modifier =
+                                Modifier
+                                    .padding(16.dp)
+                                    .clip(RoundedCornerShape(12.dp))
+                                    .border(
+                                        4.dp,
+                                        colorResource(R.color.dark_gray),
+                                        RoundedCornerShape(12.dp)
+                                    )
+                            )
+                            {
+                                Column(
+                                    modifier = Modifier
+                                        .padding(16.dp)
+                                        .fillMaxWidth(),
+                                    horizontalAlignment = Alignment.CenterHorizontally
+                                ) {
+                                    Text(
+                                        stringResource(R.string.help_profile_screen),
+                                        color = colorResource(R.color.dark_gray)
+                                    )
+                                    Spacer(modifier = Modifier.height(16.dp))
+                                    Button(
+                                        onClick = { isHelpBoxVisible = false },
+                                        colors =
+                                        ButtonDefaults.buttonColors(
+                                            containerColor = colorResource(R.color.blue)
+                                        )
+                                    ) {
+                                        Text("Close")
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
-                Spacer(modifier = Modifier.width(24.dp))
+                Spacer(modifier = Modifier.height(24.dp))
 
-                // Profile Picture and Number of Days
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
 
-                ProfilePicture(profilePictureUrl)
+                    // User Info : user id and user name
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            text = userId,
+                            fontWeight = FontWeight.Bold,
+                            color = colorResource(R.color.dark_gray)
+                        )
+                        Text(
+                            text = userName,
+                            fontWeight = FontWeight.Bold,
+                            color = colorResource(R.color.dark_gray)
+                        )
+                    }
 
-                Spacer(modifier = Modifier.width(24.dp))
+                    Spacer(modifier = Modifier.width(24.dp))
 
-                Box(
-                    modifier =
-                        Modifier
-                            // .background(Color.Blue, shape = RoundedCornerShape(8.dp))
-                            .padding(vertical = 4.dp, horizontal = 16.dp)) {
-                      Row(verticalAlignment = Alignment.CenterVertically) {
+                    // Profile Picture
+                    ProfilePicture(profilePictureUrl)
+
+                    Spacer(modifier = Modifier.width(24.dp))
+
+                    // Number of days
+
+                    Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
                             painter =
-                                painterResource(
-                                    id = R.drawable.flame), // Replace with your icon resource
+                            painterResource(
+                                id = R.drawable.flame
+                            ), // Replace with your icon resource
                             contentDescription = "Days Icon",
                             tint = Color.Red,
-                            modifier = Modifier.size(16.dp))
+                            modifier = Modifier.size(32.dp)
+                        )
                         Spacer(modifier = Modifier.width(4.dp))
                         Text(
                             text = "$numberOfDays days",
-                            // color = Color.White,
-                            fontWeight = FontWeight.Bold)
-                      }
+                            fontWeight = FontWeight.Bold
+                        )
                     }
-              }
 
-          Spacer(modifier = Modifier.height(64.dp))
-
-          // Letters learned
-          Text(text = "All letters learned", fontWeight = FontWeight.Bold)
-
-          Box(
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .border(2.dp, Color.Gray, RoundedCornerShape(12.dp))
-                      .clip(RoundedCornerShape(8.dp))
-                      .padding(12.dp)
-              // .background(Color(0xFFDCF1FA))
-              ) {
-                HorizontalLetterList(lettersLearned)
-              }
-
-          Spacer(modifier = Modifier.height(64.dp))
-
-          Row(
-              modifier = Modifier.fillMaxWidth(),
-              horizontalArrangement = Arrangement.SpaceBetween,
-              verticalAlignment = Alignment.CenterVertically) {
-
-                // Number of exercises achieved (Easy & Hard boxes)
-                Text(text = "Exercises \n achieved", fontWeight = FontWeight.Bold)
-
-                // Easy Exercises
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                  Text(text = "Easy :")
-                  Spacer(modifier = Modifier.width(8.dp))
-                  Box(
-                      modifier =
-                          Modifier.size(48.dp)
-                              .border(2.dp, Color.Gray, RoundedCornerShape(8.dp))
-                              .clip(RoundedCornerShape(8.dp))
-                              .background(Color(0xFFDCF1FA)),
-                      contentAlignment = Alignment.Center) {
-                        Text(
-                            text = if (easyExercises > 0) "$easyExercises" else "Ø",
-                            color = Color.Black,
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 16.sp)
-                      }
                 }
 
-                // Spacer(modifier = Modifier.width(32.dp)) // Space between Easy and Hard
+                Spacer(modifier = Modifier.height(64.dp))
 
-                // Hard Exercises
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                  Text(text = "Hard :")
-                  Spacer(modifier = Modifier.width(8.dp))
-                  Box(
-                      modifier =
-                          Modifier.size(48.dp)
-                              .border(2.dp, Color.Gray, RoundedCornerShape(8.dp))
-                              .clip(RoundedCornerShape(8.dp))
-                              .background(Color(0xFFDCF1FA)),
-                      contentAlignment = Alignment.Center) {
-                        Text(
-                            text = if (hardExercises > 0) "$hardExercises" else "Ø",
-                            color = Color.Black,
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 16.sp)
-                      }
-                }
-              }
+                // Letters learned
+                Text(
+                    text = "All letters learned",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp,
+                    color = colorResource(R.color.dark_gray)
+                )
 
-          Spacer(modifier = Modifier.height(16.dp))
-
-          Row(
-              modifier = Modifier.fillMaxWidth(),
-              horizontalArrangement = Arrangement.SpaceBetween,
-              verticalAlignment = Alignment.CenterVertically) {
-
-                // Number of quests achieved
-                Text(text = "Questions \n achieved", fontWeight = FontWeight.Bold)
-
-                // Daily Quests
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                  Text(text = "Daily :")
-                  Spacer(modifier = Modifier.width(8.dp))
-                  Box(
-                      modifier =
-                          Modifier.size(48.dp)
-                              .border(2.dp, Color.Gray, RoundedCornerShape(8.dp))
-                              .clip(RoundedCornerShape(8.dp))
-                              .background(Color(0xFFDCF1FA)),
-                      contentAlignment = Alignment.Center) {
-                        Text(
-                            text = if (dailyQuests > 0) "$dailyQuests" else "Ø",
-                            color = Color.Black,
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 16.sp)
-                      }
+                Box(
+                    modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .border(2.dp, colorResource(R.color.dark_gray), RoundedCornerShape(12.dp))
+                        .clip(RoundedCornerShape(8.dp))
+                        .padding(12.dp)
+                ) {
+                    HorizontalLetterList(lettersLearned)
                 }
 
-                // Spacer(modifier = Modifier.width(24.dp))
 
-                // Weekly Quests
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                  Text(text = "Weekly :")
-                  Spacer(modifier = Modifier.width(8.dp))
-                  Box(
-                      modifier =
-                          Modifier.size(48.dp)
-                              .border(2.dp, Color.Gray, RoundedCornerShape(8.dp))
-                              .clip(RoundedCornerShape(8.dp))
-                              .background(Color(0xFFDCF1FA)),
-                      contentAlignment = Alignment.Center) {
-                        Text(
-                            text = if (weeklyQuests > 0) "$weeklyQuests" else "Ø",
-                            color = Color.Black,
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 16.sp)
-                      }
-                }
-              }
 
-          Spacer(modifier = Modifier.height(64.dp))
+                Spacer(modifier = Modifier.height(64.dp))
 
-          // Friends List button
-          Button(
-              onClick = { navigationActions.navigateTo("Friends") },
-              colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF05A9FB)),
-              modifier = Modifier.fillMaxWidth()) {
-                Text("My Friends", fontWeight = FontWeight.Bold)
-              }
+                // Friends List button
+                ReusableTextButton({ navigationActions.navigateTo("Friends") }, "My Friends")
 
-          Spacer(modifier = Modifier.height(32.dp))
+                Spacer(modifier = Modifier.height(32.dp))
 
-          // Performance Graph Button
+                // Performance Graph Button
+                ReusableTextButton({ /**navigationActions.navigateTo()**/ }, "My Stats")
 
-          Button(
-              onClick = onGraphClick,
-              colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF05A9FB)),
-              modifier = Modifier.fillMaxWidth()) {
-                Text("Performance Graph", fontWeight = FontWeight.Bold)
-              }
-
-          Spacer(modifier = Modifier.height(64.dp))
-        }
-      })
+                Spacer(modifier = Modifier.height(64.dp))
+            }
+        })
 }
 
 @Composable
 fun HorizontalLetterList(lettersLearned: List<Char>) {
-  val allLetters = ('A'..'Z').toList() // All capital letters from A to Z
-  val scrollState = rememberScrollState()
+    val allLetters = ('A'..'Z').toList() // All capital letters from A to Z
+    val scrollState = rememberScrollState()
 
-  Row(modifier = Modifier.fillMaxWidth().horizontalScroll(scrollState)) {
-    allLetters.forEach { letter ->
-      val isLearned = letter in lettersLearned
-      Text(
-          text = letter.toString(),
-          fontSize = 24.sp,
-          fontWeight = FontWeight.Bold,
-          color = if (isLearned) Color(0xFF2E7D32) else Color.Gray,
-          modifier = Modifier.padding(horizontal = 8.dp))
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(scrollState)
+    ) {
+        allLetters.forEach { letter ->
+            val isLearned = letter in lettersLearned
+            Text(
+                text = letter.toString(),
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                color = if (isLearned) colorResource(R.color.blue) else Color.Gray,
+                modifier = Modifier.padding(horizontal = 8.dp)
+            )
+        }
     }
-  }
 }
 
 @Composable
 fun ProfilePicture(profilePictureUrl: String?) {
-  Box(modifier = Modifier.size(80.dp).clip(CircleShape).background(Color.LightGray)) {
-    profilePictureUrl?.let {
-      // Load image with Coil or any other image loading library
-      Image(
-          painter = rememberImagePainter(data = it),
-          contentDescription = "Profile picture",
-          modifier = Modifier.fillMaxSize())
-    } ?: Text(text = "Profile", modifier = Modifier.align(Alignment.Center))
-  }
+    Box(
+        modifier = Modifier
+            .size(80.dp)
+            .clip(CircleShape)
+            .background(colorResource(R.color.dark_gray))
+    ) {
+        profilePictureUrl?.let {
+            // Load image with Coil or any other image loading library
+            Image(
+                painter = rememberImagePainter(data = it),
+                contentDescription = "Profile picture",
+                modifier = Modifier.fillMaxSize()
+            )
+        } ?: Text(
+            text = "Profile",
+            modifier = Modifier.align(Alignment.Center),
+            color = Color.White
+        )
+    }
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/ProfileScreen.kt
@@ -191,7 +191,7 @@ fun ProfileScreen(
           // Performance Graph Button
           ReusableTextButton(
               {
-              /** navigationActions.navigateTo()* */
+                /** navigationActions.navigateTo()* */
               },
               "My Stats")
 

--- a/app/src/main/java/com/github/se/signify/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/ProfileScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -82,12 +83,12 @@ fun ProfileScreen(
               modifier = Modifier.fillMaxWidth(),
               horizontalArrangement = Arrangement.SpaceBetween) {
                 ReusableButtonWithIcon(
-                    { isHelpBoxVisible = !isHelpBoxVisible }, Icons.Outlined.Info, "Help")
+                    { isHelpBoxVisible = !isHelpBoxVisible }, Icons.Outlined.Info, "help")
 
                 ReusableButtonWithIcon(
                     { navigationActions.navigateTo("Settings") },
                     Icons.Outlined.Settings,
-                    "Settings")
+                    "settings")
 
                 if (isHelpBoxVisible) {
                   Dialog(onDismissRequest = { isHelpBoxVisible = false }) {
@@ -106,10 +107,12 @@ fun ProfileScreen(
                               horizontalAlignment = Alignment.CenterHorizontally) {
                                 Text(
                                     stringResource(R.string.help_profile_screen),
+                                    modifier = Modifier.testTag("helpProfileText"),
                                     color = colorResource(R.color.dark_gray))
                                 Spacer(modifier = Modifier.height(16.dp))
                                 Button(
                                     onClick = { isHelpBoxVisible = false },
+                                    modifier = Modifier.testTag("closeButton"),
                                     colors =
                                         ButtonDefaults.buttonColors(
                                             containerColor = colorResource(R.color.blue))) {
@@ -124,7 +127,7 @@ fun ProfileScreen(
           Spacer(modifier = Modifier.height(24.dp))
 
           Row(
-              modifier = Modifier.fillMaxWidth(),
+              modifier = Modifier.fillMaxWidth().testTag("userInfo"),
               horizontalArrangement = Arrangement.Center,
               verticalAlignment = Alignment.CenterVertically) {
 
@@ -157,7 +160,7 @@ fun ProfileScreen(
                           painterResource(id = R.drawable.flame), // Replace with your icon resource
                       contentDescription = "Days Icon",
                       tint = Color.Red,
-                      modifier = Modifier.size(32.dp))
+                      modifier = Modifier.size(32.dp).testTag("flameIcon"))
                   Spacer(modifier = Modifier.width(4.dp))
                   Text(text = "$numberOfDays days", fontWeight = FontWeight.Bold)
                 }
@@ -177,7 +180,8 @@ fun ProfileScreen(
                   Modifier.fillMaxWidth()
                       .border(2.dp, colorResource(R.color.dark_gray), RoundedCornerShape(12.dp))
                       .clip(RoundedCornerShape(8.dp))
-                      .padding(12.dp)) {
+                      .padding(12.dp)
+                      .testTag("lettersBox")) {
                 HorizontalLetterList(lettersLearned)
               }
 
@@ -189,11 +193,7 @@ fun ProfileScreen(
           Spacer(modifier = Modifier.height(32.dp))
 
           // Performance Graph Button
-          ReusableTextButton(
-              {
-                /** navigationActions.navigateTo()* */
-              },
-              "My Stats")
+          ReusableTextButton({ navigationActions.navigateTo("Stats") }, "My Stats")
 
           Spacer(modifier = Modifier.height(64.dp))
         }
@@ -205,7 +205,7 @@ fun HorizontalLetterList(lettersLearned: List<Char>) {
   val allLetters = ('A'..'Z').toList() // All capital letters from A to Z
   val scrollState = rememberScrollState()
 
-  Row(modifier = Modifier.fillMaxWidth().horizontalScroll(scrollState)) {
+  Row(modifier = Modifier.fillMaxWidth().horizontalScroll(scrollState).testTag("lettersList")) {
     allLetters.forEach { letter ->
       val isLearned = letter in lettersLearned
       Text(
@@ -222,7 +222,10 @@ fun HorizontalLetterList(lettersLearned: List<Char>) {
 fun ProfilePicture(profilePictureUrl: String?) {
   Box(
       modifier =
-          Modifier.size(80.dp).clip(CircleShape).background(colorResource(R.color.dark_gray))) {
+          Modifier.size(80.dp)
+              .clip(CircleShape)
+              .background(colorResource(R.color.dark_gray))
+              .testTag("profilePicture")) {
         profilePictureUrl?.let {
           // Load image with Coil or any other image loading library
           Image(

--- a/app/src/main/java/com/github/se/signify/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/ProfileScreen.kt
@@ -20,14 +20,14 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Surface
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -63,217 +63,174 @@ fun ProfileScreen(
     lettersLearned: List<Char>,
     navigationActions: NavigationActions
 ) {
-    Scaffold(
-        bottomBar = {
-            BottomNavigationMenu(
-                onTabSelect = { route -> navigationActions.navigateTo(route) },
-                tabList = LIST_TOP_LEVEL_DESTINATION,
-                selectedItem = navigationActions.currentRoute()
-            )
-        },
-        content = {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
-                    .padding(16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                var isHelpBoxVisible by remember { mutableStateOf(false) }
+  Scaffold(
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute())
+      },
+      content = {
+        Column(
+            modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+          var isHelpBoxVisible by remember { mutableStateOf(false) }
 
-                // Top row with Settings and Help buttons
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
+          // Top row with Settings and Help buttons
+          Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.SpaceBetween) {
+                ReusableButtonWithIcon(
+                    { isHelpBoxVisible = !isHelpBoxVisible }, Icons.Outlined.Info, "Help")
 
-                    ReusableButtonWithIcon(
-                        { isHelpBoxVisible = !isHelpBoxVisible },
-                        Icons.Outlined.Info,
-                        "Help"
-                    )
+                ReusableButtonWithIcon(
+                    { navigationActions.navigateTo("Settings") },
+                    Icons.Outlined.Settings,
+                    "Settings")
 
-                    ReusableButtonWithIcon(
-                        { navigationActions.navigateTo("Settings") },
-                        Icons.Outlined.Settings,
-                        "Settings"
-                    )
-
-
-                    if (isHelpBoxVisible) {
-                        Dialog(onDismissRequest = { isHelpBoxVisible = false }) {
-                            Surface(
-                                shape = RoundedCornerShape(8.dp),
-                                color = Color.LightGray,
-                                modifier =
-                                Modifier
-                                    .padding(16.dp)
-                                    .clip(RoundedCornerShape(12.dp))
-                                    .border(
-                                        4.dp,
-                                        colorResource(R.color.dark_gray),
-                                        RoundedCornerShape(12.dp)
-                                    )
-                            )
-                            {
-                                Column(
-                                    modifier = Modifier
-                                        .padding(16.dp)
-                                        .fillMaxWidth(),
-                                    horizontalAlignment = Alignment.CenterHorizontally
-                                ) {
-                                    Text(
-                                        stringResource(R.string.help_profile_screen),
-                                        color = colorResource(R.color.dark_gray)
-                                    )
-                                    Spacer(modifier = Modifier.height(16.dp))
-                                    Button(
-                                        onClick = { isHelpBoxVisible = false },
-                                        colors =
+                if (isHelpBoxVisible) {
+                  Dialog(onDismissRequest = { isHelpBoxVisible = false }) {
+                    Surface(
+                        shape = RoundedCornerShape(8.dp),
+                        color = Color.LightGray,
+                        modifier =
+                            Modifier.padding(16.dp)
+                                .clip(RoundedCornerShape(12.dp))
+                                .border(
+                                    4.dp,
+                                    colorResource(R.color.dark_gray),
+                                    RoundedCornerShape(12.dp))) {
+                          Column(
+                              modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                              horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(
+                                    stringResource(R.string.help_profile_screen),
+                                    color = colorResource(R.color.dark_gray))
+                                Spacer(modifier = Modifier.height(16.dp))
+                                Button(
+                                    onClick = { isHelpBoxVisible = false },
+                                    colors =
                                         ButtonDefaults.buttonColors(
-                                            containerColor = colorResource(R.color.blue)
-                                        )
-                                    ) {
-                                        Text("Close")
+                                            containerColor = colorResource(R.color.blue))) {
+                                      Text("Close")
                                     }
-                                }
-                            }
+                              }
                         }
-                    }
+                  }
                 }
+              }
 
-                Spacer(modifier = Modifier.height(24.dp))
+          Spacer(modifier = Modifier.height(24.dp))
 
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically
+          Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.Center,
+              verticalAlignment = Alignment.CenterVertically) {
+
+                // User Info : user id and user name
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-
-                    // User Info : user id and user name
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Text(
-                            text = userId,
-                            fontWeight = FontWeight.Bold,
-                            color = colorResource(R.color.dark_gray)
-                        )
-                        Text(
-                            text = userName,
-                            fontWeight = FontWeight.Bold,
-                            color = colorResource(R.color.dark_gray)
-                        )
-                    }
-
-                    Spacer(modifier = Modifier.width(24.dp))
-
-                    // Profile Picture
-                    ProfilePicture(profilePictureUrl)
-
-                    Spacer(modifier = Modifier.width(24.dp))
-
-                    // Number of days
-
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            painter =
-                            painterResource(
-                                id = R.drawable.flame
-                            ), // Replace with your icon resource
-                            contentDescription = "Days Icon",
-                            tint = Color.Red,
-                            modifier = Modifier.size(32.dp)
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Text(
-                            text = "$numberOfDays days",
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-
+                  Text(
+                      text = userId,
+                      fontWeight = FontWeight.Bold,
+                      color = colorResource(R.color.dark_gray))
+                  Text(
+                      text = userName,
+                      fontWeight = FontWeight.Bold,
+                      color = colorResource(R.color.dark_gray))
                 }
 
-                Spacer(modifier = Modifier.height(64.dp))
+                Spacer(modifier = Modifier.width(24.dp))
 
-                // Letters learned
-                Text(
-                    text = "All letters learned",
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 16.sp,
-                    color = colorResource(R.color.dark_gray)
-                )
+                // Profile Picture
+                ProfilePicture(profilePictureUrl)
 
-                Box(
-                    modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .border(2.dp, colorResource(R.color.dark_gray), RoundedCornerShape(12.dp))
-                        .clip(RoundedCornerShape(8.dp))
-                        .padding(12.dp)
-                ) {
-                    HorizontalLetterList(lettersLearned)
+                Spacer(modifier = Modifier.width(24.dp))
+
+                // Number of days
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                  Icon(
+                      painter =
+                          painterResource(id = R.drawable.flame), // Replace with your icon resource
+                      contentDescription = "Days Icon",
+                      tint = Color.Red,
+                      modifier = Modifier.size(32.dp))
+                  Spacer(modifier = Modifier.width(4.dp))
+                  Text(text = "$numberOfDays days", fontWeight = FontWeight.Bold)
                 }
+              }
 
+          Spacer(modifier = Modifier.height(64.dp))
 
+          // Letters learned
+          Text(
+              text = "All letters learned",
+              fontWeight = FontWeight.Bold,
+              fontSize = 16.sp,
+              color = colorResource(R.color.dark_gray))
 
-                Spacer(modifier = Modifier.height(64.dp))
+          Box(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .border(2.dp, colorResource(R.color.dark_gray), RoundedCornerShape(12.dp))
+                      .clip(RoundedCornerShape(8.dp))
+                      .padding(12.dp)) {
+                HorizontalLetterList(lettersLearned)
+              }
 
-                // Friends List button
-                ReusableTextButton({ navigationActions.navigateTo("Friends") }, "My Friends")
+          Spacer(modifier = Modifier.height(64.dp))
 
-                Spacer(modifier = Modifier.height(32.dp))
+          // Friends List button
+          ReusableTextButton({ navigationActions.navigateTo("Friends") }, "My Friends")
 
-                // Performance Graph Button
-                ReusableTextButton({ /**navigationActions.navigateTo()**/ }, "My Stats")
+          Spacer(modifier = Modifier.height(32.dp))
 
-                Spacer(modifier = Modifier.height(64.dp))
-            }
-        })
+          // Performance Graph Button
+          ReusableTextButton(
+              {
+              /** navigationActions.navigateTo()* */
+              },
+              "My Stats")
+
+          Spacer(modifier = Modifier.height(64.dp))
+        }
+      })
 }
 
 @Composable
 fun HorizontalLetterList(lettersLearned: List<Char>) {
-    val allLetters = ('A'..'Z').toList() // All capital letters from A to Z
-    val scrollState = rememberScrollState()
+  val allLetters = ('A'..'Z').toList() // All capital letters from A to Z
+  val scrollState = rememberScrollState()
 
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .horizontalScroll(scrollState)
-    ) {
-        allLetters.forEach { letter ->
-            val isLearned = letter in lettersLearned
-            Text(
-                text = letter.toString(),
-                fontSize = 24.sp,
-                fontWeight = FontWeight.Bold,
-                color = if (isLearned) colorResource(R.color.blue) else Color.Gray,
-                modifier = Modifier.padding(horizontal = 8.dp)
-            )
-        }
+  Row(modifier = Modifier.fillMaxWidth().horizontalScroll(scrollState)) {
+    allLetters.forEach { letter ->
+      val isLearned = letter in lettersLearned
+      Text(
+          text = letter.toString(),
+          fontSize = 24.sp,
+          fontWeight = FontWeight.Bold,
+          color = if (isLearned) colorResource(R.color.blue) else Color.Gray,
+          modifier = Modifier.padding(horizontal = 8.dp))
     }
+  }
 }
 
 @Composable
 fun ProfilePicture(profilePictureUrl: String?) {
-    Box(
-        modifier = Modifier
-            .size(80.dp)
-            .clip(CircleShape)
-            .background(colorResource(R.color.dark_gray))
-    ) {
+  Box(
+      modifier =
+          Modifier.size(80.dp).clip(CircleShape).background(colorResource(R.color.dark_gray))) {
         profilePictureUrl?.let {
-            // Load image with Coil or any other image loading library
-            Image(
-                painter = rememberImagePainter(data = it),
-                contentDescription = "Profile picture",
-                modifier = Modifier.fillMaxSize()
-            )
-        } ?: Text(
-            text = "Profile",
-            modifier = Modifier.align(Alignment.Center),
-            color = Color.White
-        )
-    }
+          // Load image with Coil or any other image loading library
+          Image(
+              painter = rememberImagePainter(data = it),
+              contentDescription = "Profile picture",
+              modifier = Modifier.fillMaxSize())
+        }
+            ?: Text(
+                text = "Profile", modifier = Modifier.align(Alignment.Center), color = Color.White)
+      }
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,6 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="blue">#05A9FB</color>
+    <color name="dark_gray">#333333</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="blue">#05A9FB</color>
     <color name="dark_gray">#333333</color>
+    <color name="red">#FFD32F2F</color>
+    <color name="green">#FF2E7D32</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,9 @@
 <resources>
     <string name="app_name">signify</string>
     <string name="default_web_client_id">480370863906-8deqtn8nq63qk01efb5pudici2c805ek.apps.googleusercontent.com</string>
+    <string name="help_profile_screen"> Profile
+        \n
+        \nHere, you can change your settings and customize your profile.
+        \nYou’ll also get to add your friends to learn together.
+        \nYou’ll find a recap of your progress in the statistics board.</string>
 </resources>


### PR DESCRIPTION
Improving the quality of the code and updating the profile screen to match its new design

- Putting the text displayed by the help section in the file strings.xml to avoid hardcoded text
- Removing the part about the exercises and questions achieved from the profile screen  
- Changing the colors used to align with the Figma design
- Adding the colors to the file colors.xml to avoid hardcoded colors 
- Adding a file Utils functions that can be reused in multiple screen to avoid duplication
- Creation of the function ReusableButtonWithIcon and ReusableTextButton

In the 4th commit : 
- adding the tests for the Profile Screen
- Adding new file for the Screen MyStats
- Implementing the navigation to the new screen from the Profile Screen 


