### PR TITLE
Link ci with sonarcloud

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -93,7 +93,7 @@ jobs:
 
 
       - name: Run SonarQube analysis
-        run: ./gradlew sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonar
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -30,8 +30,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Remove current gradle cache
-        run: rm -rf ~/.gradle
+
 
       - name: Enable KVM group perms
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -92,20 +92,9 @@ jobs:
           name: Coverage report
           path: app/build/reports/jacoco/jacocoTestReport
 
-      # SonarCloud Analysis
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@v2
+
+      - name: Run SonarQube analysis
+        run: ./gradlew sonarqube
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          projectBaseDir: ./
-          args: >
-            -Dsonar.projectKey=Signify-epfl_signify-app
-            -Dsonar.organization=signify-epfl
-            -Dsonar.host.url=https://sonarcloud.io
-            -Dsonar.coverage.exclusions=**/test/**
-            -Dsonar.java.coveragePlugin=jacoco
-            -Dsonar.jacoco.reportPaths=app/build/reports/jacoco/jacocoTestReport.xml
-            -Dsonar.coverage.minimumCoverage=60
-            -Dsonar.duplication.exclusions=**/*.java
-            -Dsonar.cpd.duplicationThreshold=5
+

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -93,7 +93,7 @@ jobs:
 
 
       - name: Run SonarQube analysis
-        run: ./gradlew sonarqube
+        run: ./gradlew sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -265,6 +265,7 @@ sonarqube {
     properties {
         property ("sonar.projectKey", "Signify-epfl_signify-app")
         property ("sonar.organization", "signify-epfl")
+        property ("sonar.projectName", "signify-app")
         property ("sonar.java.coveragePlugin", "jacoco")
         property ("sonar.sources", "app/src/main/java")
         property ("sonar.login", "<SONAR_TOKEN>")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.ktfmt)
     alias(libs.plugins.gms)
-    id ("org.sonarqube") version "3.3"
+    alias(libs.plugins.sonar)
 }
 
 
@@ -260,17 +260,16 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
 
 }
 
-sonarqube {
+sonar {
     properties {
         property ("sonar.projectKey", "Signify-epfl_signify-app")
         property ("sonar.organization", "signify-epfl")
+        property ("sonar.projectName", "signify-app")
         property ("sonar.host.url", "https://sonarcloud.io")
         property ("sonar.androidLint.reportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
         property ("sonar.jacoco.reportPaths", "build/reports/jacoco/jacocoTestReport.xml")
         property ("sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml$")
         property ("sonar.junit.ReportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugUnitTest/")
-        property ("sonar.coverage.minimumCoverage", "60")
-        property ("sonar.cpd.duplicationThreshold", "5")
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -261,24 +261,7 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
 
 }
 
-sonarqube {
-    properties {
-        property ("sonar.projectKey", "Signify-epfl_signify-app")
-        property ("sonar.organization", "signify-epfl")
-        property ("sonar.java.coveragePlugin", "jacoco")
-        property ("sonar.sources", "src/main/java")
-        property ("sonar.host.url", "https://sonarcloud.io")
-        property ("sonar.jacoco.reportPaths", "build/reports/jacoco/jacocoTestReport.xml")
-        property ("sonar.coverage.exclusions", "**/test/**")
-        property ("sonar.java.coveragePlugin", "jacoco")
-        property ("sonar.coverage.minimumCoverage", "60")
-        property ("sonar.duplication.exclusions", "**/*.java")
-        property ("sonar.cpd.duplicationThreshold", "5")
 
-        // Use the Sonar token from the environment variable
-        property ("sonar.login", System.getenv("SONAR_TOKEN"))
-    }
-}
 
 
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ import com.android.build.api.dsl.Packaging
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.toLowerCaseAsciiOnly
 import java.io.FileInputStream
 import java.util.Properties
+import kotlin.script.experimental.api.ScriptCompilationConfiguration.Default.properties
 
 plugins {
     jacoco
@@ -9,8 +10,13 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.ktfmt)
     alias(libs.plugins.gms)
+    id("org.sonarqube") version "3.3"
 
 }
+
+
+
+
 
 android {
     namespace = "com.github.se.signify"
@@ -124,6 +130,8 @@ android {
         res.setSrcDirs(emptyList<File>())
         resources.setSrcDirs(emptyList<File>())
     }
+
+
 }
 
 
@@ -213,6 +221,7 @@ dependencies {
 }
 
 
+
 tasks.withType<Test> {
     // Configure Jacoco for each tests
     configure<JacocoTaskExtension> {
@@ -249,7 +258,24 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
         include("outputs/code_coverage/debugAndroidTest/connected/*/coverage.ec")
     })
+
 }
+
+sonarqube {
+    properties {
+        property ("sonar.projectKey", "Signify-epfl_signify-app")
+        property ("sonar.organization", "signify-epfl")
+        property ("sonar.host.url", "https://sonarcloud.io")
+        property ("sonar.jacoco.reportPaths", "app/build/reports/jacoco/jacocoTestReport.xml")
+        property ("sonar.coverage.exclusions", "**/test/**")
+        property ("sonar.java.coveragePlugin", "jacoco")
+        property ("sonar.coverage.minimumCoverage", "60")
+        property ("sonar.duplication.exclusions", "**/*.java")
+        property ("sonar.cpd.duplicationThreshold", "5")
+    }
+}
+
+
 
 
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -266,14 +266,17 @@ sonarqube {
         property ("sonar.projectKey", "Signify-epfl_signify-app")
         property ("sonar.organization", "signify-epfl")
         property ("sonar.java.coveragePlugin", "jacoco")
-        property ("sonar.sources", "app/src/main/java")
+        property ("sonar.sources", "src/main/java")
         property ("sonar.host.url", "https://sonarcloud.io")
-        property ("sonar.jacoco.reportPaths", "app/build/reports/jacoco/jacocoTestReport.xml")
+        property ("sonar.jacoco.reportPaths", "build/reports/jacoco/jacocoTestReport.xml")
         property ("sonar.coverage.exclusions", "**/test/**")
         property ("sonar.java.coveragePlugin", "jacoco")
         property ("sonar.coverage.minimumCoverage", "60")
         property ("sonar.duplication.exclusions", "**/*.java")
         property ("sonar.cpd.duplicationThreshold", "5")
+
+        // Use the Sonar token from the environment variable
+        property ("sonar.login", System.getenv("SONAR_TOKEN"))
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,7 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.ktfmt)
     alias(libs.plugins.gms)
-    id("org.sonarqube") version "3.3"
-
+    id ("org.sonarqube") version "3.3"
 }
 
 
@@ -261,7 +260,19 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
 
 }
 
-
+sonarqube {
+    properties {
+        property ("sonar.projectKey", "Signify-epfl_signify-app")
+        property ("sonar.organization", "signify-epfl")
+        property ("sonar.host.url", "https://sonarcloud.io")
+        property ("sonar.androidLint.reportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
+        property ("sonar.jacoco.reportPaths", "build/reports/jacoco/jacocoTestReport.xml")
+        property ("sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml$")
+        property ("sonar.junit.ReportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugUnitTest/")
+        property ("sonar.coverage.minimumCoverage", "60")
+        property ("sonar.cpd.duplicationThreshold", "5")
+    }
+}
 
 
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -265,6 +265,9 @@ sonarqube {
     properties {
         property ("sonar.projectKey", "Signify-epfl_signify-app")
         property ("sonar.organization", "signify-epfl")
+        property ("sonar.java.coveragePlugin", "jacoco")
+        property ("sonar.sources", "app/src/main/java")
+        property ("sonar.login", "<SONAR_TOKEN>")
         property ("sonar.host.url", "https://sonarcloud.io")
         property ("sonar.jacoco.reportPaths", "app/build/reports/jacoco/jacocoTestReport.xml")
         property ("sonar.coverage.exclusions", "**/test/**")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -265,10 +265,8 @@ sonarqube {
     properties {
         property ("sonar.projectKey", "Signify-epfl_signify-app")
         property ("sonar.organization", "signify-epfl")
-        property ("sonar.projectName", "signify-app")
         property ("sonar.java.coveragePlugin", "jacoco")
         property ("sonar.sources", "app/src/main/java")
-        property ("sonar.login", "<SONAR_TOKEN>")
         property ("sonar.host.url", "https://sonarcloud.io")
         property ("sonar.jacoco.reportPaths", "app/build/reports/jacoco/jacocoTestReport.xml")
         property ("sonar.coverage.exclusions", "**/test/**")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
     alias(libs.plugins.ktfmt) apply false
     alias(libs.plugins.gms) apply false
-
+    id("org.sonarqube") version "3.3" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,5 +4,6 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
     alias(libs.plugins.ktfmt) apply false
     alias(libs.plugins.gms) apply false
-    id("org.sonarqube") version "3.3" apply false
+    alias(libs.plugins.sonar) apply false
+
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ json = "20240303"
 kotlin = "1.9.0"
 gms = "4.4.2"
 ktfmt = "0.17.0"
+sonar = "4.4.1.3373"
 
 # UI Compose
 mockitoAndroid = "5.13.0"
@@ -66,7 +67,6 @@ lifecycleRuntimeKtx = "2.8.4"
 fragmentKtx = "1.8.2"
 kotlinxSerializationJson = "1.6.2"
 androidxCoreKtx = "1.6.1"
-sonar = "3.3"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ lifecycleRuntimeKtx = "2.8.4"
 fragmentKtx = "1.8.2"
 kotlinxSerializationJson = "1.6.2"
 androidxCoreKtx = "1.6.1"
+sonar = "3.3"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -128,3 +129,4 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 gms = { id = "com.google.gms.google-services", version.ref = "gms" }
+sonar = { id = "org.sonarqube", version.ref = "sonar" }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,13 +1,21 @@
-sonar.projectKey=Signify-epfl_signify-app
-sonar.organization=signify-epfl
+# Required metadata
+sonar.projectKey=Signify-epfl_signify-app  # The unique key for your project on SonarCloud
+sonar.organization=signify-epfl            # Your SonarCloud organization
+sonar.host.url=https://sonarcloud.io       # The URL for SonarCloud or your local SonarQube instance
 
-# This is the name and version displayed in the SonarCloud UI.
-#sonar.projectName=signify-app
-#sonar.projectVersion=1.0
+# Path to your source code
+sonar.sources=app/src/main/java            # Define the directory where your source code is located
 
+# Exclude test files from analysis
+sonar.exclusions=**/*Test.java,**/test/**  # Exclude test directories and files
 
-# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-#sonar.sources=.
+# Path to test coverage reports
+sonar.java.coveragePlugin=jacoco           # Use JaCoCo as the coverage plugin
+sonar.jacoco.reportPaths=app/build/reports/jacoco/jacocoTestReport.xml  # Path to your Jacoco XML report
 
-# Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8
+# Optional: Set minimum coverage threshold
+sonar.coverage.minimumCoverage=60          # Minimum code coverage percentage for the project
+
+# Optional: Duplication settings
+sonar.duplication.exclusions=**/*.java     # Exclude certain files from duplication checks
+sonar.cpd.duplicationThreshold=5           # Set the number of lines that trigger code duplication detection

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,20 +2,3 @@
 sonar.projectKey=Signify-epfl_signify-app  # The unique key for your project on SonarCloud
 sonar.organization=signify-epfl            # Your SonarCloud organization
 sonar.host.url=https://sonarcloud.io       # The URL for SonarCloud or your local SonarQube instance
-
-# Path to your source code
-sonar.sources=app/src/main/java            # Define the directory where your source code is located
-
-# Exclude test files from analysis
-sonar.exclusions=**/*Test.java,**/test/**  # Exclude test directories and files
-
-# Path to test coverage reports
-sonar.java.coveragePlugin=jacoco           # Use JaCoCo as the coverage plugin
-sonar.jacoco.reportPaths=app/build/reports/jacoco/jacocoTestReport.xml  # Path to your Jacoco XML report
-
-# Optional: Set minimum coverage threshold
-sonar.coverage.minimumCoverage=60          # Minimum code coverage percentage for the project
-
-# Optional: Duplication settings
-sonar.duplication.exclusions=**/*.java     # Exclude certain files from duplication checks
-sonar.cpd.duplicationThreshold=5           # Set the number of lines that trigger code duplication detection


### PR DESCRIPTION


- **SonarQube Configuration:**
  - Added and updated properties in the `sonarqube` block to correctly configure the SonarCloud project and set paths for reports.
  - Set up the project key (`sonar.projectKey`) and organization (`sonar.organization`) to ensure the project is identified on SonarCloud.
  - Configured paths for **Android Lint**, **JaCoCo**, and **JUnit** reports to ensure proper analysis and coverage reports.
  - Defined minimum coverage threshold (`sonar.coverage.minimumCoverage`) as 60%, ensuring coverage alerts if this threshold is not met.
  - Configured the **duplication threshold** for code duplication detection using `sonar.cpd.duplicationThreshold` set to 5.

- **Gradle Build Updates:**
  - Ensured that the SonarQube plugin (`id = "org.sonarqube"`) is applied with the correct version in all necessary files.
  - Adjusted the `sonarqube` block to use the correct `project.layout.buildDirectory.get()` path for reporting.
  
- **GitHub Actions Integration:**
  - Updated the GitHub Actions workflow to run the SonarQube analysis using `./gradlew sonarqube`.
  - Ensured that the **Sonar token** (`SONAR_TOKEN`) is securely passed from GitHub Secrets for authentication during the CI process.

