### PR TITLE
Rename screen packages to be lowercase

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/ChallengeHistoryScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/ChallengeHistoryScreenTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.github.se.signify.ui.navigation.NavigationActions
-import com.github.se.signify.ui.screens.Challenge.ChallengeHistoryScreen
+import com.github.se.signify.ui.screens.challenge.ChallengeHistoryScreen
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/ChallengeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/ChallengeScreenTest.kt
@@ -3,7 +3,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.github.se.signify.ui.navigation.NavigationActions
-import com.github.se.signify.ui.screens.Challenge.ChallengeScreen
+import com.github.se.signify.ui.screens.challenge.ChallengeScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/ExerciseScreenEasyTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/ExerciseScreenEasyTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.signify.ui.navigation.NavigationActions
-import com.github.se.signify.ui.screens.Home.ExerciseScreenEasy
+import com.github.se.signify.ui.screens.home.ExerciseScreenEasy
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/ExerciseScreenHardTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/ExerciseScreenHardTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.signify.ui.navigation.NavigationActions
-import com.github.se.signify.ui.screens.Home.ExerciseScreenHard
+import com.github.se.signify.ui.screens.home.ExerciseScreenHard
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/HomeScreenTest.kt
@@ -8,9 +8,9 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.github.se.signify.ui.navigation.NavigationActions
 import com.github.se.signify.ui.navigation.Screen
-import com.github.se.signify.ui.screens.Home.Exercise
-import com.github.se.signify.ui.screens.Home.ExerciseList
-import com.github.se.signify.ui.screens.Home.HomeScreen
+import com.github.se.signify.ui.screens.home.Exercise
+import com.github.se.signify.ui.screens.home.ExerciseList
+import com.github.se.signify.ui.screens.home.HomeScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/NewChallengeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/NewChallengeScreenTest.kt
@@ -3,7 +3,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.github.se.signify.ui.navigation.NavigationActions
-import com.github.se.signify.ui.screens.Challenge.NewChallengeScreen
+import com.github.se.signify.ui.screens.challenge.NewChallengeScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/ProfileScreenTest.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.github.se.signify.ui.navigation.NavigationActions
 import com.github.se.signify.ui.navigation.Screen
-import com.github.se.signify.ui.screens.Profile.ProfileScreen
+import com.github.se.signify.ui.screens.profile.ProfileScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -18,18 +18,18 @@ import com.github.se.signify.ui.navigation.NavigationActions
 import com.github.se.signify.ui.navigation.Route
 import com.github.se.signify.ui.navigation.Screen
 import com.github.se.signify.ui.screens.*
-import com.github.se.signify.ui.screens.Challenge.ChallengeHistoryScreen
-import com.github.se.signify.ui.screens.Challenge.ChallengeScreen
-import com.github.se.signify.ui.screens.Challenge.NewChallengeScreen
-import com.github.se.signify.ui.screens.Home.ASLRecognition
-import com.github.se.signify.ui.screens.Home.ExerciseScreenEasy
-import com.github.se.signify.ui.screens.Home.ExerciseScreenHard
-import com.github.se.signify.ui.screens.Home.HomeScreen
-import com.github.se.signify.ui.screens.Home.QuestScreen
-import com.github.se.signify.ui.screens.Profile.FriendsListScreen
-import com.github.se.signify.ui.screens.Profile.MyStatsScreen
-import com.github.se.signify.ui.screens.Profile.ProfileScreen
-import com.github.se.signify.ui.screens.Profile.SettingsScreen
+import com.github.se.signify.ui.screens.challenge.ChallengeHistoryScreen
+import com.github.se.signify.ui.screens.challenge.ChallengeScreen
+import com.github.se.signify.ui.screens.challenge.NewChallengeScreen
+import com.github.se.signify.ui.screens.home.ASLRecognition
+import com.github.se.signify.ui.screens.home.ExerciseScreenEasy
+import com.github.se.signify.ui.screens.home.ExerciseScreenHard
+import com.github.se.signify.ui.screens.home.HomeScreen
+import com.github.se.signify.ui.screens.home.QuestScreen
+import com.github.se.signify.ui.screens.profile.FriendsListScreen
+import com.github.se.signify.ui.screens.profile.MyStatsScreen
+import com.github.se.signify.ui.screens.profile.ProfileScreen
+import com.github.se.signify.ui.screens.profile.SettingsScreen
 import com.github.se.signify.ui.theme.SignifyTheme
 
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.signify.ui.screens.Challenge
+package com.github.se.signify.ui.screens.challenge
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.signify.ui.screens.Challenge
+package com.github.se.signify.ui.screens.challenge
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.signify.ui.screens.Challenge
+package com.github.se.signify.ui.screens.challenge
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/ASLRecognition.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/ASLRecognition.kt
@@ -1,4 +1,4 @@
-package com.github.se.signify.ui.screens.Home
+package com.github.se.signify.ui.screens.home
 
 import android.Manifest
 import android.annotation.SuppressLint

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/ExerciseScreenEasy.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/ExerciseScreenEasy.kt
@@ -1,4 +1,4 @@
-package com.github.se.signify.ui.screens.Home
+package com.github.se.signify.ui.screens.home
 
 import android.widget.Toast
 import androidx.compose.foundation.Image

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/ExerciseScreenHard.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/ExerciseScreenHard.kt
@@ -1,4 +1,4 @@
-package com.github.se.signify.ui.screens.Home
+package com.github.se.signify.ui.screens.home
 
 import android.widget.Toast
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.signify.ui.screens.Home
+package com.github.se.signify.ui.screens.home
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/QuestScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/QuestScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.signify.ui.screens.Home
+package com.github.se.signify.ui.screens.home
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.signify.ui.screens.Profile
+package com.github.se.signify.ui.screens.profile
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.signify.ui.screens.Profile
+package com.github.se.signify.ui.screens.profile
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.signify.ui.screens.Profile
+package com.github.se.signify.ui.screens.profile
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Image

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.signify.ui.screens.Profile
+package com.github.se.signify.ui.screens.profile
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border


### PR DESCRIPTION
I've renamed screen packages (Challenge, Home, Profile) to not be capitalized, as required by Kotlin conventions.

This is a simple but broad refactor, that should be approved asap to avoid merge conflicts.