### PR TITLE
docs: add Figma M1 file link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 
 The design and user interface mockups for **Signify** are available on Figma. This includes wireframes, high-fidelity screens, and prototypes that showcase the overall user experience and visual flow of the app.  
 You can view the Figma project here: [Signify Figma Project](https://www.figma.com/files/team/1415806088953386120/project/284550251/Signify-Team?fuid=1415806084792420415)
+For the first milestone we provide also the following file with the figma wireframe and mockup: [Signify Figma M1](https://www.figma.com/design/hJsdCTG31DOo51A86W5NNC/Signify-App-M1?node-id=0-1&t=l3DbUOdq31qw9t4P-1)
 
 ## Contributing
 

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,4 @@
 /build
+
+google-services.json
+/src/main/assets/RFC_model_ir9_opset19.onnx


### PR DESCRIPTION
I added the figma link for the M1 in the README.md file.
As the "app/src/main/assets/RFC_model_ir9_opset19.onnx" file is too big to be push by git I added it in the gitignore.

This PR is related to task #103 