### PR TITLE
Configure release signing and integrate Firebase SHA-1 for Google Auth

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,19 +43,30 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
-        //manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
+
 
         ndk {
             abiFilters.addAll(listOf("armeabi-v7a", "arm64-v8a"))
         }
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = file("keystore/signify.jks")
+            storePassword = "signinsignify"
+            keyAlias = "signifykey"
+            keyPassword = "signinsignifykey"
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
+            isShrinkResources = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.getByName("release")
         }
         debug {
             enableUnitTestCoverage = true
@@ -72,6 +83,9 @@ android {
     buildFeatures {
         compose = true
     }
+
+
+
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"
     }


### PR DESCRIPTION
### Summary
This PR adds the necessary configuration for generating a signed APK for the app, including setting up the keystore and key credentials in the `build.gradle` file. It also integrates Firebase by adding the SHA-1 and SHA-256 fingerprints to enable Google Authentication in the release build.

### Changes
- Configured the `signingConfigs` block in `build.gradle` to reference the release keystore (`signify.jks`).
- Added store and key credentials to sign the APK with the release key.
- Verified that the SHA-1 and SHA-256 fingerprints for the release key are added to Firebase.
- Downloaded the updated `google-services.json` file from Firebase to ensure that the release build is correctly integrated with Google services.
- Verified that Google Authentication works in both debug and release builds.

### How to Test
1. Run `./gradlew signingReport` to verify that the correct SHA-1 and SHA-256 fingerprints are generated for the release variant.
2. Build the signed APK using `Build → Generate Signed Bundle / APK...`.
3. Install the signed APK on a physical device and ensure that Google Authentication works correctly.
4. Verify that Firebase services (e.g., Auth, Database) are fully functional in the release environment.

### Notes
- Make sure to keep the keystore file (`signify.jks`) secure and never commit it to version control. 
- Ensure that all future releases are signed with the same keystore to maintain consistency.
