### PR TITLE
Fix the path to jacoco report for sonarcloud

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -144,6 +144,17 @@ android {
         resources.setSrcDirs(emptyList<File>())
     }
 
+    sonar {
+        properties {
+            property ("sonar.projectKey", "Signify-epfl_signify-app")
+            property ("sonar.organization", "signify-epfl")
+            property ("sonar.host.url", "https://sonarcloud.io")
+            property ("sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
+            property ("sonar.junit.ReportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugUnitTest/")
+            property ("sonar.androidLint.reportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
+        }
+    }
+
 
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,4 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
     alias(libs.plugins.ktfmt) apply false
     alias(libs.plugins.gms) apply false
-
-
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
 # Required metadata
-sonar.projectKey=Signify-epfl_signify-app  # The unique key for your project on SonarCloud
-sonar.organization=signify-epfl            # Your SonarCloud organization
-sonar.host.url=https://sonarcloud.io       # The URL for SonarCloud or your local SonarQube instance
+sonar.projectKey=Signify-epfl_signify-app
+sonar.organization=signify-epfl
+sonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
### Pull Request Description

#### 1. **Moved the SonarQube Configuration**
Previously, the **SonarQube configuration** block was located at the end of the `build.gradle.kts` file, outside the main `android` configuration. I moved the **SonarQube configuration** into the correct location within the `android` block to ensure that it is properly integrated and applied during the build process. This change aligns the SonarQube setup with the rest of the project configurations.

#### 2. **Updated the Jacoco XML Report Path**
The **`sonar.coverage.jacoco.xmlReportPaths`** property in the SonarQube configuration was updated. Initially, it did not include the **`jacocoTestReport`** folder in the path, which resulted in incorrect report generation.
This ensures that the correct Jacoco test report is generated and included in the SonarQube analysis.

#### 3. **Work on SonarCloud Analysis**
I also did additional work on configuring **SonarCloud** integration, but some methods were not resolving the analysis issues. These adjustments were aimed at improving the connection and results of the analysis with SonarCloud.

#### 4. **Code Cleaning in SonarQube Configuration**
In addition to these changes, I performed some **code cleaning** in the SonarQube configuration by organizing properties such as `sonar.projectKey`, `sonar.organization`, and `sonar.host.url`. This cleanup ensures the configuration is clear and easier to maintain.
