### PR TITLE
Add keystore signing setup, GitHub Actions workflow, and stop trackin…

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -97,3 +97,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --info
+
+      # New Steps: Building the Signed APK
+
+      - name: Decode the base64-encoded keystore
+        run: echo "${{ secrets.SIGNING_KEY }}" | base64 --decode > ./keystore.jks
+
+      - name: Build Signed APK
+        env:
+          KEYSTORE_PATH: ${{ github.workspace }}/keystore.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          ./gradlew assembleRelease \
+          -Pandroid.injected.signing.store.file=$KEYSTORE_PATH \
+          -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
+          -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
+          -Pandroid.injected.signing.key.password=$KEY_PASSWORD
+      - name: Upload Signed APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: release apk
+          path: app/build/outputs/apk/release/app-release.apk

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,6 @@ keystore.properties
 /app/release
 upload-keystore.jks
 /scraping/firebase_credentials.json
-
+gradle.properties
 # MacOS
 **/.DS_Store

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,10 +52,12 @@ android {
 
     signingConfigs {
         create("release") {
+
+            // Resolve the keystore path safely
             storeFile = file("keystore/signify.jks")
-            storePassword = "signinsignify"
-            keyAlias = "signifykey"
-            keyPassword = "signinsignifykey"
+            storePassword = (System.getenv("KEYSTORE_PASSWORD") ?: properties["KEYSTORE_PASSWORD"]) as String?
+            keyAlias = (System.getenv("KEY_ALIAS") ?: properties["KEY_ALIAS"]) as String?
+            keyPassword = (System.getenv("KEY_PASSWORD") ?: properties["KEY_PASSWORD"]) as String?
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+KEYSTORE_PASSWORD=
+KEY_ALIAS=
+KEY_PASSWORD=


### PR DESCRIPTION
**Add Keystore Signing Configuration and GitHub Actions Workflow for APK Generation**

---

### **Description**:

This pull request introduces the following changes:

1. **Keystore Configuration for APK Signing**:
   - Added support for signing the release APK using the `signify.jks` keystore.
   - Keystore credentials (path, alias, passwords) are referenced from either:
     - **Environment variables** (for CI/CD via GitHub Actions).
     - **`gradle.properties` file** (for local development).

2. **GitHub Actions Workflow**:
   - Configured **GitHub Actions** to automatically build and sign the APK using secrets stored in the repository.
   - Secrets include the keystore path, password, key alias, and key password for secure APK signing during the CI/CD process.
   - The signed APK will be generated in the following location:
     ```
     app/build/outputs/apk/release/app-release.apk
     ```

3. **Instructions for Teammates**:
   - **Local Development**: Update your local `gradle.properties` file with the provided keystore credentials I sent in private.
   - **Generating APK**: After setting up the local `gradle.properties`, you can generate the signed APK by running:
     ```bash
     ./gradlew assembleRelease
     ```