### PR TITLE
Add MainActivityTest to test the MainActivity for higher coverage (80%)

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/MainActivityTest.kt
@@ -1,0 +1,72 @@
+package com.github.se.signify.ui.screens
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.github.se.signify.SignifyAppPreview
+import com.github.se.signify.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.Route
+import com.github.se.signify.ui.navigation.Screen
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class MainActivityTest {
+  @get:Rule val composeTestRule = createComposeRule()
+  val navigationState = MutableStateFlow<NavigationActions?>(null)
+
+  @Test
+  fun testNavigationFromMainActivityAndEveryScreenIsDisplayed() {
+    val context = mock(Context::class.java)
+    // Set the content with the mocked context
+    composeTestRule.setContent { SignifyAppPreview(context, navigationState) }
+    composeTestRule.onNodeWithTag("WelcomeScreen").assertIsDisplayed()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.PROFILE) }
+    composeTestRule.onNodeWithTag("ProfileScreen").assertIsDisplayed()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Screen.AUTH) }
+    composeTestRule.onNodeWithTag("LoginScreen").assertIsDisplayed()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.FRIENDS) }
+    composeTestRule.onNodeWithTag("FriendsListScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("OnSearchButton").performClick()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Screen.EXERCISE_EASY) }
+    composeTestRule.onNodeWithTag("ExerciseScreenEasy").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Success").performClick()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Screen.EXERCISE_HARD) }
+    composeTestRule.onNodeWithTag("ExerciseScreenHard").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Success").performClick()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.SETTINGS) }
+    composeTestRule.onNodeWithTag("SettingsScreen").assertIsDisplayed()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.HOME) }
+    composeTestRule.onNodeWithTag("HomeScreen").assertIsDisplayed()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.HOME) }
+    composeTestRule.onNodeWithTag("HomeScreen").assertIsDisplayed()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.STATS) }
+    composeTestRule.onNodeWithTag("StatsScreen").assertIsDisplayed()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.QUEST) }
+    composeTestRule.onNodeWithTag("QuestScreen").assertIsDisplayed()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.CHALLENGE_HISTORY) }
+    composeTestRule.onNodeWithTag("ChallengeHistoryScreen").assertIsDisplayed()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.NEW_CHALLENGE) }
+    composeTestRule.onNodeWithTag("NewChallengeScreen").assertIsDisplayed()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Screen.CHALLENGE) }
+    composeTestRule.onNodeWithTag("ChallengeScreenContent").assertIsDisplayed()
+
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Screen.PRACTICE) }
+  }
+}

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.github.se.signify
 
+import android.annotation.SuppressLint
+import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -31,21 +33,28 @@ import com.github.se.signify.ui.screens.profile.MyStatsScreen
 import com.github.se.signify.ui.screens.profile.ProfileScreen
 import com.github.se.signify.ui.screens.profile.SettingsScreen
 import com.github.se.signify.ui.theme.SignifyTheme
+import kotlinx.coroutines.flow.MutableStateFlow
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
-      SignifyTheme { Surface(modifier = Modifier.fillMaxSize()) { SignifyAppPreview() } }
+      SignifyTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {
+          val context = LocalContext.current
+          val navigationState = MutableStateFlow<NavigationActions?>(null)
+          SignifyAppPreview(context, navigationState)
+        }
+      }
     }
   }
 }
 
+@SuppressLint("StateFlowValueCalledInComposition")
 @Composable
-fun SignifyAppPreview() {
+fun SignifyAppPreview(context: Context, navigationState: MutableStateFlow<NavigationActions?>) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
-  val context = LocalContext.current
   val handLandMarkImplementation =
       HandLandMarkImplementation("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
   val handLandMarkViewModel = HandLandMarkViewModel(handLandMarkImplementation, context)
@@ -123,4 +132,5 @@ fun SignifyAppPreview() {
     composable(Screen.EXERCISE_EASY) { ExerciseScreenEasy(navigationActions) }
     composable(Screen.EXERCISE_HARD) { ExerciseScreenHard(navigationActions) }
   }
+  navigationState.value = navigationActions
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/LoginScreen.kt
@@ -84,7 +84,7 @@ fun LoginScreen(navigationActions: NavigationActions) {
       modifier = Modifier.fillMaxSize(),
       content = { padding ->
         Column(
-            modifier = Modifier.fillMaxSize().background(brush = gradient),
+            modifier = Modifier.fillMaxSize().background(brush = gradient).testTag("LoginScreen"),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {

--- a/app/src/main/java/com/github/se/signify/ui/screens/WelcomeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/WelcomeScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
@@ -64,7 +65,10 @@ fun WelcomeScreen(navigationActions: NavigationActions) {
     navigationActions.navigateTo("Auth")
   }
   Column(
-      modifier = Modifier.fillMaxSize().background(color = colorResource(R.color.blue)),
+      modifier =
+          Modifier.fillMaxSize()
+              .testTag("WelcomeScreen")
+              .background(color = colorResource(R.color.blue)),
       horizontalAlignment = Alignment.CenterHorizontally,
       verticalArrangement = Arrangement.Center) {
         Image(

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreen.kt
@@ -46,7 +46,7 @@ fun ChallengeHistoryScreen(
                     .testTag("TopBlueBar"))
       },
       content = { padding ->
-        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+        Box(modifier = Modifier.fillMaxSize().padding(padding).testTag("ChallengeHistoryScreen")) {
           // Back button aligned to the top-left corner
           BackButton { navigationActions.goBack() }
 

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
@@ -38,7 +38,7 @@ fun NewChallengeScreen(navigationActions: NavigationActions) {
                     .testTag("TopBlueBar"))
       },
       content = { padding ->
-        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+        Box(modifier = Modifier.fillMaxSize().padding(padding).testTag("NewChallengeScreen")) {
           // Back button aligned to the top-left corner
           BackButton { navigationActions.goBack() }
 

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/ExerciseScreenEasy.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/ExerciseScreenEasy.kt
@@ -62,7 +62,10 @@ fun ExerciseScreenEasy(navigationActions: NavigationActions) {
   val currentLetter = words[currentWordIndex][currentLetterIndex]
 
   Box(
-      modifier = Modifier.fillMaxSize().background(colorResource(R.color.white)),
+      modifier =
+          Modifier.fillMaxSize()
+              .background(colorResource(R.color.white))
+              .testTag("ExerciseScreenEasy"),
       contentAlignment = Alignment.Center) {
         IconButton(
             onClick = { navigationActions.goBack() },

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/ExerciseScreenHard.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/ExerciseScreenHard.kt
@@ -46,7 +46,10 @@ fun ExerciseScreenHard(navigationActions: NavigationActions) {
   var currentLetterIndex by rememberSaveable { mutableIntStateOf(0) }
 
   Box(
-      modifier = Modifier.fillMaxSize().background(colorResource(R.color.white)),
+      modifier =
+          Modifier.fillMaxSize()
+              .background(colorResource(R.color.white))
+              .testTag("ExerciseScreenHard"),
       contentAlignment = Alignment.Center // Center all content in the Box
       ) {
         IconButton(

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
@@ -91,7 +91,8 @@ fun HomeScreen(navigationActions: NavigationActions) {
                 Modifier.fillMaxSize()
                     .padding(padding)
                     .padding(16.dp)
-                    .verticalScroll(rememberScrollState()),
+                    .verticalScroll(rememberScrollState())
+                    .testTag("HomeScreen"),
             horizontalAlignment = Alignment.CenterHorizontally) {
               Row(
                   modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/QuestScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/QuestScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import com.github.se.signify.ui.navigation.BottomNavigationMenu
 import com.github.se.signify.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.signify.ui.navigation.NavigationActions
@@ -18,5 +19,7 @@ fun QuestScreen(navigationActions: NavigationActions) {
             tabList = LIST_TOP_LEVEL_DESTINATION,
             selectedItem = navigationActions.currentRoute())
       },
-      content = { pd -> Text(modifier = Modifier.padding(pd), text = "Quest Screen") })
+      content = { pd ->
+        Text(modifier = Modifier.padding(pd).testTag("QuestScreen"), text = "Quest Screen")
+      })
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -50,7 +51,7 @@ fun FriendsListScreen(
 ) {
   var searchQuery by remember { mutableStateOf("") }
 
-  Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+  Column(modifier = Modifier.fillMaxSize().padding(16.dp).testTag("FriendsListScreen")) {
     // Back Button
     BackButton { navigationActions.goBack() }
 
@@ -67,12 +68,14 @@ fun FriendsListScreen(
         colors = TextFieldDefaults.colors(),
         singleLine = true,
         trailingIcon = {
-          IconButton(onClick = { onSearchUser(searchQuery) }) {
-            Icon(
-                imageVector = Icons.Default.Search,
-                contentDescription = "Search",
-                tint = colorResource(R.color.blue))
-          }
+          IconButton(
+              onClick = { onSearchUser(searchQuery) },
+              modifier = Modifier.testTag("OnSearchButton")) {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = "Search",
+                    tint = colorResource(R.color.blue))
+              }
         })
 
     Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
@@ -3,9 +3,11 @@ package com.github.se.signify.ui.screens.profile
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import com.github.se.signify.ui.navigation.NavigationActions
 
 @Composable
 fun MyStatsScreen(navigationActions: NavigationActions) {
-  Column { Text(text = "My stats Screen") }
+  Column(modifier = Modifier.testTag("StatsScreen")) { Text(text = "My stats Screen") }
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
@@ -76,7 +76,8 @@ fun ProfileScreen(
                 Modifier.fillMaxSize()
                     .verticalScroll(rememberScrollState())
                     .padding(padding)
-                    .padding(16.dp),
+                    .padding(16.dp)
+                    .testTag("ProfileScreen"),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
           var isHelpBoxVisible by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -42,7 +43,7 @@ fun SettingsScreen(profilePictureUrl: String?, navigationActions: NavigationActi
   var showEditOptions by remember { mutableStateOf(false) }
 
   Column(
-      modifier = Modifier.fillMaxSize().padding(16.dp),
+      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("SettingsScreen"),
       horizontalAlignment = Alignment.CenterHorizontally,
       verticalArrangement = Arrangement.spacedBy(64.dp)) {
 


### PR DESCRIPTION
 - Added MainActivityTest that basically go trough different screens from SignifyAppPreview and check if that's the case.
 - Changed the composable functions of different screen to add testtags important for testing.
 - Changed Reference of SignifyAppPreview to receive context & navigationActions in order to test
 - Achieved 73% coverage :
![image](https://github.com/user-attachments/assets/6c5b6ab7-9723-4786-98a1-617254711876)

 - And finally we achieved 80% for all the app : 
![image](https://github.com/user-attachments/assets/dbe6b889-8eb2-4561-9b10-d0e249810a77)
