### PR TITLE
feat: Add a web link to the ASL alphabet on the practice screen and format files

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/ASLRecognitionTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/ASLRecognitionTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -21,6 +22,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.times
 
 @RunWith(AndroidJUnit4::class)
 class ASLRecognitionTest : LifecycleOwner {
@@ -64,6 +66,11 @@ class ASLRecognitionTest : LifecycleOwner {
     composeTestRule.onNodeWithTag("gestureOverlayView").assertIsDisplayed()
     composeTestRule.onNodeWithTag("aslRecognitionTitle").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+  }
+
+  @Test
+  fun buttonIsWorkingAsIntended() {
+    composeTestRule.onNodeWithTag("practiceButton").performClick()
   }
 
   override val lifecycle: Lifecycle

--- a/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkImplementation.kt
+++ b/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkImplementation.kt
@@ -128,7 +128,9 @@ class HandLandMarkImplementation(private val pathToTask: String, private val pat
           if (handLandMarkerResult != null && handLandMarkerResult?.landmarks()?.size != 0) {
             onSuccess(handLandMarkerResult!!)
           } else {
-            solution = ""
+            if (handLandMarkerResult != null) {
+              onSuccess(handLandMarkerResult!!)
+            }
           }
         }
       } else {

--- a/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkViewModel.kt
@@ -52,7 +52,9 @@ class HandLandMarkViewModel(
         imageProxy = imageProxy,
         onSuccess = { result ->
           viewModelScope.launch {
-            _handLandmarks.value = result.landmarks()[0] // Process the first hand's landmarks
+            _handLandmarks.value =
+                result.landmarks().firstOrNull()
+                    ?: emptyList() // Process the first hand's landmarks
           }
         },
         onFailure = { exception ->

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/ASLRecognition.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/ASLRecognition.kt
@@ -2,7 +2,9 @@ package com.github.se.signify.ui.screens.home
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -63,6 +65,8 @@ import com.github.se.signify.ui.navigation.NavigationActions
 import com.google.mediapipe.tasks.components.containers.NormalizedLandmark
 import java.util.concurrent.Executors
 
+const val buttonUriString =
+    "https://www.google.com/imgres?q=asl%20alphabet&imgurl=https%3A%2F%2Fwww.researchgate.net%2Fpublication%2F269306646%2Ffigure%2Ffig1%2FAS%3A295027705171970%401447351494295%2FThe-American-Manual-Alphabet-Signs-with-a-are-pictured-from-the-side-Reproduced-from.png&imgrefurl=https%3A%2F%2Fwww.researchgate.net%2Ffigure%2FThe-American-Manual-Alphabet-Signs-with-a-are-pictured-from-the-side-Reproduced-from_fig1_269306646&docid=8H-KdI-bjGB48M&tbnid=KndHLcvycA_XpM&vet=12ahUKEwjSipzz7LCJAxUyg_0HHblcB9gQM3oECBUQAA..i&w=514&h=668&hcb=2&itg=1&ved=2ahUKEwjSipzz7LCJAxUyg_0HHblcB9gQM3oECBUQAA"
 // Map to associate each letter with its corresponding drawable resource for ASL gestures
 val gestureImageMap =
     mapOf(
@@ -163,18 +167,22 @@ fun ASLRecognition(
 
                 item {
                   // Button: "More on American Sign Language"
-                  Button(
-                      onClick = { /* For now, do nothing */},
-                      colors =
-                          ButtonDefaults.buttonColors(colorResource(R.color.blue)), // Blue color
-                      modifier =
-                          Modifier.width(336.dp) // Match the width of the box above
-                              .height(50.dp)
-                              .testTag("practiceButton")) {
+                    Button(
+                        onClick = {
+                            val intent = Intent(Intent.ACTION_VIEW).apply {
+                                data = Uri.parse(buttonUriString)
+                            }
+                            context.startActivity(intent)
+                        },
+                        colors = ButtonDefaults.buttonColors(colorResource(R.color.blue)),
+                        modifier = Modifier.width(336.dp).height(50.dp).testTag("practiceButton")
+                    ) {
                         Text(
                             text = "More on ASL Alphabet",
-                            color = colorResource(R.color.white)) // One-line text with white color
-                  }
+                            color = colorResource(R.color.white)
+                        )
+                    }
+
                 }
               }
         },

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/ASLRecognition.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/ASLRecognition.kt
@@ -167,22 +167,16 @@ fun ASLRecognition(
 
                 item {
                   // Button: "More on American Sign Language"
-                    Button(
-                        onClick = {
-                            val intent = Intent(Intent.ACTION_VIEW).apply {
-                                data = Uri.parse(buttonUriString)
-                            }
-                            context.startActivity(intent)
-                        },
-                        colors = ButtonDefaults.buttonColors(colorResource(R.color.blue)),
-                        modifier = Modifier.width(336.dp).height(50.dp).testTag("practiceButton")
-                    ) {
-                        Text(
-                            text = "More on ASL Alphabet",
-                            color = colorResource(R.color.white)
-                        )
-                    }
-
+                  Button(
+                      onClick = {
+                        val intent =
+                            Intent(Intent.ACTION_VIEW).apply { data = Uri.parse(buttonUriString) }
+                        context.startActivity(intent)
+                      },
+                      colors = ButtonDefaults.buttonColors(colorResource(R.color.blue)),
+                      modifier = Modifier.width(336.dp).height(50.dp).testTag("practiceButton")) {
+                        Text(text = "More on ASL Alphabet", color = colorResource(R.color.white))
+                      }
                 }
               }
         },

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/ASLRecognition.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/ASLRecognition.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
@@ -65,8 +66,6 @@ import com.github.se.signify.ui.navigation.NavigationActions
 import com.google.mediapipe.tasks.components.containers.NormalizedLandmark
 import java.util.concurrent.Executors
 
-const val buttonUriString =
-    "https://www.google.com/imgres?q=asl%20alphabet&imgurl=https%3A%2F%2Fwww.researchgate.net%2Fpublication%2F269306646%2Ffigure%2Ffig1%2FAS%3A295027705171970%401447351494295%2FThe-American-Manual-Alphabet-Signs-with-a-are-pictured-from-the-side-Reproduced-from.png&imgrefurl=https%3A%2F%2Fwww.researchgate.net%2Ffigure%2FThe-American-Manual-Alphabet-Signs-with-a-are-pictured-from-the-side-Reproduced-from_fig1_269306646&docid=8H-KdI-bjGB48M&tbnid=KndHLcvycA_XpM&vet=12ahUKEwjSipzz7LCJAxUyg_0HHblcB9gQM3oECBUQAA..i&w=514&h=668&hcb=2&itg=1&ved=2ahUKEwjSipzz7LCJAxUyg_0HHblcB9gQM3oECBUQAA"
 // Map to associate each letter with its corresponding drawable resource for ASL gestures
 val gestureImageMap =
     mapOf(
@@ -105,6 +104,7 @@ fun ASLRecognition(
     handLandMarkViewModel: HandLandMarkViewModel,
     navigationActions: NavigationActions
 ) {
+  val buttonUriString = stringResource(id = R.string.button_uri_string)
   val context = LocalContext.current
   var permissionGranted by remember { mutableStateOf(false) }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,5 +8,7 @@
         \nYou’ll find a recap of your progress in the statistics board.</string>
     <string name="description_challenge">Here you can challenge your friends to sign language face-offs.</string>
     <string name="graphs_history">Graphs and statistics for the challenges</string>
-
+    <string name="button_uri_string">
+        https://www.google.com/imgres?q=asl%20alphabet&amp;imgurl=https%3A%2F%2Fwww.researchgate.net%2Fpublication%2F269306646%2Ffigure%2Ffig1%2FAS%3A295027705171970%401447351494295%2FThe-American-Manual-Alphabet-Signs-with-a-are-pictured-from-the-side-Reproduced-from.png&amp;imgrefurl=https%3A%2F%2Fwww.researchgate.net%2Ffigure%2FThe-American-Manual-Alphabet-Signs-with-a-are-pictured-from-the-side-Reproduced-from_fig1_269306646&amp;docid=8H-KdI-bjGB48M&amp;tbnid=KndHLcvycA_XpM&amp;vet=12ahUKEwjSipzz7LCJAxUyg_0HHblcB9gQM3oECBUQAA..i&amp;w=514&amp;h=668&amp;hcb=2&amp;itg=1&amp;ved=2ahUKEwjSipzz7LCJAxUyg_0HHblcB9gQM3oECBUQAA
+    </string>
 </resources>


### PR DESCRIPTION
 - Added the necessary imports such as Intent & Uri
 -  added a constant value that contains the Uri to the webpage
 - link the button to the webpage and launch it when the user click on it (a set of image that contains the ASL alphabet)
Related issue : #138 