### PR TITLE
Address the ASLRecognition screen's tests failing on some aspect ratios

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/ASLRecognitionTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/ASLRecognitionTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -22,12 +23,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import org.mockito.kotlin.times
 
 @RunWith(AndroidJUnit4::class)
 class ASLRecognitionTest : LifecycleOwner {
 
-  @get:Rule val cameraAccess = GrantPermissionRule.grant(Manifest.permission.CAMERA)
+  @get:Rule
+  val cameraAccess: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.CAMERA)
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -61,16 +62,17 @@ class ASLRecognitionTest : LifecycleOwner {
 
   @Test
   fun allComponentsAreDisplayed() {
-    composeTestRule.onNodeWithTag("practiceButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("cameraPreview").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("gestureOverlayView").assertIsDisplayed()
+    // Modify this to scroll to each component
+    composeTestRule.onNodeWithTag("practiceButton").performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cameraPreview").performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("gestureOverlayView").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("aslRecognitionTitle").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
   }
 
   @Test
   fun buttonIsWorkingAsIntended() {
-    composeTestRule.onNodeWithTag("practiceButton").performClick()
+    composeTestRule.onNodeWithTag("practiceButton").performScrollTo().performClick()
   }
 
   override val lifecycle: Lifecycle

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/ASLRecognition.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/ASLRecognition.kt
@@ -19,14 +19,16 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
@@ -142,42 +144,39 @@ fun ASLRecognition(
               })
         },
         content = { paddingValues ->
-          LazyColumn(
+          Column(
               modifier =
-                  Modifier.background(colorResource(R.color.white))
+                  Modifier.verticalScroll(rememberScrollState())
+                      .background(colorResource(R.color.white))
                       .padding(paddingValues)
                       .padding(start = 40.dp, end = 40.dp),
               horizontalAlignment = Alignment.CenterHorizontally) {
-                item {
-                  Box(
-                      modifier =
-                          Modifier.width(336.dp)
-                              .height(252.dp)
-                              .background(color = colorResource(R.color.white)),
-                  ) {
-                    CameraPreviewWithAnalysisView(handLandMarkViewModel)
-                  }
+                Box(
+                    modifier =
+                        Modifier.width(336.dp)
+                            .height(252.dp)
+                            .background(color = colorResource(R.color.white)),
+                ) {
+                  CameraPreviewWithAnalysisView(handLandMarkViewModel)
                 }
 
-                item { Spacer(modifier = Modifier.height(30.dp)) }
+                Spacer(modifier = Modifier.height(30.dp))
 
-                item { GestureOverlayView(handLandMarkViewModel) }
+                GestureOverlayView(handLandMarkViewModel)
 
-                item { Spacer(modifier = Modifier.height(20.dp)) }
+                Spacer(modifier = Modifier.height(20.dp))
 
-                item {
-                  // Button: "More on American Sign Language"
-                  Button(
-                      onClick = {
-                        val intent =
-                            Intent(Intent.ACTION_VIEW).apply { data = Uri.parse(buttonUriString) }
-                        context.startActivity(intent)
-                      },
-                      colors = ButtonDefaults.buttonColors(colorResource(R.color.blue)),
-                      modifier = Modifier.width(336.dp).height(50.dp).testTag("practiceButton")) {
-                        Text(text = "More on ASL Alphabet", color = colorResource(R.color.white))
-                      }
-                }
+                // Button: "More on American Sign Language"
+                Button(
+                    onClick = {
+                      val intent =
+                          Intent(Intent.ACTION_VIEW).apply { data = Uri.parse(buttonUriString) }
+                      context.startActivity(intent)
+                    },
+                    colors = ButtonDefaults.buttonColors(colorResource(R.color.blue)),
+                    modifier = Modifier.width(336.dp).height(50.dp).testTag("practiceButton")) {
+                      Text(text = "More on ASL Alphabet", color = colorResource(R.color.white))
+                    }
               }
         },
         bottomBar = {


### PR DESCRIPTION
The ASLRecognition screen (or practice screen) would fail tests on some devices, since it was implemented using a LazyColumn, and wouldn't load and scroll to the elements it was testing.
I have fixed it by changing the screen to use a Column, like the other screens do.
The tests were changed to scroll to elements on the screen, so they will work on any aspect ratio.

All tests now pass for me locally.