### PR TITLE
Stats Screen implementation and test

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/MainActivityTest.kt
@@ -70,7 +70,7 @@ class MainActivityTest {
     composeTestRule.onNodeWithTag("HomeScreen").assertIsDisplayed()
 
     composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.STATS) }
-    composeTestRule.onNodeWithTag("StatsScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("MyStatsScreen").assertIsDisplayed()
 
     composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.QUEST) }
     composeTestRule.onNodeWithTag("QuestScreen").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/MyStatsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/MyStatsScreenTest.kt
@@ -1,0 +1,113 @@
+package com.github.se.signify.ui.screens.profile
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.github.se.signify.ui.navigation.NavigationActions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+class MyStatsScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var navigationActions: NavigationActions
+
+  // User statistics test to be displayed
+  private val numberOfDays = 10
+  private val lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F')
+  private val exercisesAchieved = listOf(10, 3)
+  private val questsAchieved = listOf(4, 0)
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+
+    composeTestRule.setContent {
+      MyStatsScreen(
+          navigationActions = navigationActions,
+          numberOfDays = numberOfDays,
+          lettersLearned = lettersLearned,
+          exercisesAchieved = exercisesAchieved,
+          questsAchieved = questsAchieved)
+    }
+  }
+
+  @Test
+  fun testMyStatsScreenDisplaysCorrectInformation() {
+    // Verify top blue bar is displayed
+    composeTestRule.onNodeWithTag("TopBlueBar").assertIsDisplayed()
+
+    // Verify days count is displayed with correct text
+    composeTestRule.onNodeWithTag("flameIcon").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("numberOfDays").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("numberOfDays").assertTextEquals("10 days")
+
+    // Verify letters learned section displays correctly
+    composeTestRule.onNodeWithTag("allLetterLearned").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("allLetterLearned").assertTextEquals("All letters learned")
+    composeTestRule.onNodeWithTag("lettersBox").assertIsDisplayed()
+    lettersLearned.forEach { letter ->
+      composeTestRule.onNodeWithText(letter.toString()).assertIsDisplayed()
+    }
+
+    // Verify exercises achieved section is displayed with counts
+    composeTestRule.onNodeWithTag("ExercisesText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ExercisesText").assertTextEquals("Number of exercises achieved")
+    composeTestRule.onNodeWithTag("ExercisesEasyCountBox").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Easy").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Easy").assertTextEquals("EASY")
+    composeTestRule.onNodeWithTag("ExercisesEasyCount").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ExercisesEasyCount").assertTextEquals("10")
+    composeTestRule.onNodeWithTag("ExercisesHardCountBox").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Hard").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Hard").assertTextEquals("HARD")
+    composeTestRule.onNodeWithTag("ExercisesHardCount").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("ExercisesHardCount").assertTextEquals("3")
+
+    // Verify quests achieved section is displayed with counts
+    composeTestRule.onNodeWithTag("QuestsText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("QuestsText").assertTextEquals("Number of quests achieved")
+    composeTestRule.onNodeWithTag("DailyQuestCountBox").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Daily").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Daily").assertTextEquals("DAILY")
+    composeTestRule.onNodeWithTag("DailyQuestCount").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DailyQuestCount").assertTextEquals("4")
+    composeTestRule.onNodeWithTag("WeeklyQuestsCountBox").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Weekly").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Weekly").assertTextEquals("WEEKLY")
+    composeTestRule.onNodeWithTag("WeeklyQuestsCount").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("WeeklyQuestsCount").assertTextEquals("0")
+
+    // Verify graph placeholder is displayed
+    composeTestRule.onNodeWithTag("GraphsAndStats").assertIsDisplayed()
+  }
+
+  @Test
+  fun testLettersBoxIsHorizontallyScrollable() {
+    // Perform a horizontal scroll action on the letters list
+    val scrollableList = composeTestRule.onNodeWithTag("lettersList")
+
+    // Test scroll from left to right by passing by each letter
+    for (letter in 'A'..'Z') {
+      // Scroll to the current letter
+      scrollableList.performScrollToNode(hasTestTag(letter.toString()))
+      // Assert the current letter is displayed
+      composeTestRule.onNodeWithTag(letter.toString()).assertIsDisplayed()
+    }
+
+    // Test scroll from right to left directly from end to start
+    scrollableList.performScrollToNode(hasTestTag("A"))
+    // Assert the current letter is displayed
+    composeTestRule.onNodeWithTag("A").assertIsDisplayed()
+  }
+
+  @Test
+  fun testPressingBackArrowNavigatesBack() {
+    // Click the back button and verify the action is triggered
+    composeTestRule.onNodeWithTag("BackButton").performClick()
+    verify(navigationActions).goBack()
+  }
+}

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -112,13 +112,12 @@ fun SignifyAppPreview(context: Context, navigationState: MutableStateFlow<Naviga
 
       composable(Route.FRIENDS) { FriendsListScreen(navigationActions) }
       composable(Route.STATS) {
-          MyStatsScreen(
-              navigationActions = navigationActions,
-              numberOfDays = 30,
-              lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F'),
-              exercisesAchieved = listOf(10, 3),
-              questsAchieved = listOf(3, 0)
-          )
+        MyStatsScreen(
+            navigationActions = navigationActions,
+            numberOfDays = 30,
+            lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F'),
+            exercisesAchieved = listOf(10, 3),
+            questsAchieved = listOf(3, 0))
       }
 
       composable(Route.SETTINGS) {

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -111,7 +111,7 @@ fun SignifyAppPreview(context: Context, navigationState: MutableStateFlow<Naviga
       }
 
       composable(Route.FRIENDS) { FriendsListScreen(navigationActions) }
-      
+
       composable(Route.STATS) {
         MyStatsScreen(
             navigationActions = navigationActions,
@@ -120,7 +120,7 @@ fun SignifyAppPreview(context: Context, navigationState: MutableStateFlow<Naviga
             exercisesAchieved = listOf(10, 3),
             questsAchieved = listOf(3, 0))
       }
-      
+
       composable(Route.SETTINGS) { SettingsScreen(navigationActions) }
     }
     composable(Screen.PRACTICE) { ASLRecognition(handLandMarkViewModel, navigationActions) }

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -111,7 +111,15 @@ fun SignifyAppPreview(context: Context, navigationState: MutableStateFlow<Naviga
       }
 
       composable(Route.FRIENDS) { FriendsListScreen(navigationActions) }
-      composable(Route.STATS) { MyStatsScreen(navigationActions) }
+      composable(Route.STATS) {
+          MyStatsScreen(
+              navigationActions = navigationActions,
+              numberOfDays = 30,
+              lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F'),
+              exercisesAchieved = listOf(10, 3),
+              questsAchieved = listOf(3, 0)
+          )
+      }
 
       composable(Route.SETTINGS) {
         SettingsScreen(

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
@@ -34,223 +34,252 @@ import com.github.se.signify.ui.navigation.NavigationActions
 
 @Composable
 fun MyStatsScreen(
-  navigationActions: NavigationActions,
-  numberOfDays: Int,
-  lettersLearned: List<Char>,
-  exercisesAchieved: List<Int>,
-  questsAchieved: List<Int>
+    navigationActions: NavigationActions,
+    numberOfDays: Int,
+    lettersLearned: List<Char>,
+    exercisesAchieved: List<Int>,
+    questsAchieved: List<Int>
 ) {
-  Scaffold(
-    topBar = {
-      // Top blue bar
-      Box(
-        modifier = Modifier.fillMaxWidth()
-          .height(4.dp)
-          .background(MaterialTheme.colorScheme.primary)
-          .testTag("TopBlueBar")
-      )
-    },
-    content = { padding ->
-      Box(modifier = Modifier.fillMaxSize().padding(padding).testTag("MyStatsScreen")) {
-        // Back button aligned to the top-left corner
-        BackButton { navigationActions.goBack() }
-        Column(
-          modifier = Modifier.fillMaxSize()
-            .padding(
-              top = 80.dp,
-              start = 16.dp,
-              end = 16.dp) // Padding to avoid overlap with the back button
-            .testTag("MyStatsContent"),
-          horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-          // Number of days
-          Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically
-          ) {
-            Icon(
-              painter = painterResource(id = R.drawable.flame),
-              contentDescription = "Days Icon",
-              tint = colorResource(R.color.red),
-              modifier = Modifier.size(32.dp).testTag("flameIcon")
-            )
-            Spacer(modifier = Modifier.width(4.dp))
-            Text(text = "$numberOfDays days", fontWeight = FontWeight.Bold)
-          }
-          Spacer(modifier = Modifier.height(32.dp))
-          // Letters learned
-          Text(
-            text = "All letters learned",
-            fontWeight = FontWeight.Bold,
-            fontSize = 16.sp,
-            color = colorResource(R.color.dark_gray)
-          )
-          Box(
-            modifier = Modifier.fillMaxWidth()
-              .border(2.dp, colorResource(R.color.dark_gray), RoundedCornerShape(12.dp))
-              .clip(RoundedCornerShape(8.dp))
-              .padding(12.dp)
-              .testTag("lettersBox")
-          ) {
-            HorizontalLetterList(lettersLearned)
-          }
-          Spacer(modifier = Modifier.height(64.dp))
-          // Number of exercises achieved
-          Row(
-            modifier = Modifier.fillMaxWidth()
-              .padding(vertical = 8.dp)
-              .testTag("ExercisesRow"),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-          ) {
-            Text(
-              text = "Number of exercises achieved",
-              fontSize = 16.sp,
-              color = colorResource(R.color.black),
-              modifier = Modifier.testTag("ExercisesText")
-            )
+    Scaffold(
+        topBar = {
+            // Top blue bar
             Box(
-              modifier = Modifier.size(50.dp)
-                .border(2.dp, colorResource(R.color.blue))
-                .clip(RoundedCornerShape(12.dp))
-                .background(colorResource(R.color.white))
-                .testTag("ExercisesEasyCountBox"),
-              contentAlignment = Alignment.Center
-            ) {
-              Column(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally
-              ) {
-                Text(
-                  text = "EASY",
-                  fontSize = 12.sp,
-                  color = colorResource(R.color.black),
-                  modifier = Modifier.testTag("Easy")
-                )
-                Text(
-                  text = "${exercisesAchieved[0]}",
-                  fontSize = 20.sp,
-                  color = colorResource(R.color.black),
-                  modifier = Modifier.testTag("ExercisesEasyCount")
-                )
-              }
-            }
-            Box(
-              modifier = Modifier.size(50.dp)
-                .border(2.dp, colorResource(R.color.blue))
-                .clip(RoundedCornerShape(12.dp))
-                .background(colorResource(R.color.white))
-                .testTag("ExercisesHardCountBox"),
-              contentAlignment = Alignment.Center
-            ) {
-              Column(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally
-              ) {
-                Text(
-                  text = "HARD",
-                  fontSize = 12.sp,
-                  color = colorResource(R.color.black),
-                  modifier = Modifier.testTag("Hard")
-                )
-                Text(
-                  text = "${exercisesAchieved[1]}",
-                  fontSize = 20.sp,
-                  color = colorResource(R.color.black),
-                  modifier = Modifier.testTag("ExercisesHardCount")
-                )
-              }
-            }
-          }
-          Spacer(modifier = Modifier.height(12.dp))
-          // Number of quests achieved
-          Row(
-            modifier = Modifier.fillMaxWidth()
-              .padding(vertical = 8.dp)
-              .testTag("QuestsRow"),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-          ) {
-            Text(
-              text = "Number of quests achieved",
-              fontSize = 16.sp,
-              color = colorResource(R.color.black),
-              modifier = Modifier.testTag("QuestsText")
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(4.dp)
+                    .background(MaterialTheme.colorScheme.primary)
+                    .testTag("TopBlueBar")
             )
+        },
+        content = { padding ->
             Box(
-              modifier = Modifier.size(50.dp)
-                .border(2.dp, colorResource(R.color.blue))
-                .clip(RoundedCornerShape(12.dp))
-                .background(colorResource(R.color.white))
-                .testTag("DailyQuestCountBox"),
-              contentAlignment = Alignment.Center
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .testTag("MyStatsScreen")
             ) {
-              Column(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally
-              ) {
-                Text(
-                  text = "DAILY",
-                  fontSize = 12.sp,
-                  color = colorResource(R.color.black),
-                  modifier = Modifier.testTag("Daily")
-                )
-                Text(
-                  text = "${questsAchieved[0]}",
-                  fontSize = 20.sp,
-                  color = colorResource(R.color.black),
-                  modifier = Modifier.testTag("DailyQuestCount")
-                )
-              }
-            }
-            Box(
-              modifier = Modifier.size(50.dp)
-                .border(2.dp, colorResource(R.color.blue))
-                .clip(RoundedCornerShape(12.dp))
-                .background(colorResource(R.color.white))
-                .testTag("WeeklyQuestsCountBox"),
-              contentAlignment = Alignment.Center
-            ) {
-              Column(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally
-              ) {
-                Text(
-                  text = "WEEKLY",
-                  fontSize = 12.sp,
-                  color = colorResource(R.color.black),
-                  modifier = Modifier.testTag("Weekly")
-                )
-                Text(
-                  text = "${questsAchieved[1]}",
-                  fontSize = 20.sp,
-                  color = colorResource(R.color.black),
-                  modifier = Modifier.testTag("WeeklyQuestsCount")
-                )
-              }
-            }
-          }
-          Spacer(modifier = Modifier.height(60.dp))
-          // Graphs and statistics
-          Box(
-            modifier = Modifier.fillMaxWidth()
-              .height(240.dp)
-              .clip(RoundedCornerShape(12.dp))
-              .background(colorResource(R.color.dark_gray))
-              .padding(16.dp),
-            contentAlignment = Alignment.Center
-          ) {
-            Text(
-              text = "Graphs and stats",
-              fontSize = 16.sp,
-              color = colorResource(R.color.black),
-              fontWeight = FontWeight.Normal
-            )
-          }
+                // Back button aligned to the top-left corner
+                BackButton { navigationActions.goBack() }
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(
+                            top = 80.dp,
+                            start = 16.dp,
+                            end = 16.dp
+                        ) // Padding to avoid overlap with the back button
+                        .testTag("MyStatsContent"),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    // Number of days
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.flame),
+                            contentDescription = "Days Icon",
+                            tint = colorResource(R.color.red),
+                            modifier = Modifier
+                                .size(32.dp)
+                                .testTag("flameIcon")
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(text = "$numberOfDays days", fontWeight = FontWeight.Bold)
+                    }
 
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    // Letters learned
+                    Text(
+                        text = "All letters learned",
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 16.sp,
+                        color = colorResource(R.color.dark_gray)
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .border(
+                                2.dp,
+                                colorResource(R.color.dark_gray),
+                                RoundedCornerShape(12.dp)
+                            )
+                            .clip(RoundedCornerShape(8.dp))
+                            .padding(12.dp)
+                            .testTag("lettersBox")
+                    ) {
+                        HorizontalLetterList(lettersLearned)
+                    }
+
+                    Spacer(modifier = Modifier.height(64.dp))
+
+                    // Number of exercises achieved
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp)
+                            .testTag("ExercisesRow"),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Number of exercises achieved",
+                            fontSize = 16.sp,
+                            color = colorResource(R.color.black),
+                            modifier = Modifier.testTag("ExercisesText")
+                        )
+                        Box(
+                            modifier = Modifier
+                                .size(50.dp)
+                                .border(2.dp, colorResource(R.color.blue))
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(colorResource(R.color.white))
+                                .testTag("ExercisesEasyCountBox"),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(
+                                modifier = Modifier.fillMaxSize(),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = "EASY",
+                                    fontSize = 12.sp,
+                                    color = colorResource(R.color.black),
+                                    modifier = Modifier.testTag("Easy")
+                                )
+                                Text(
+                                    text = "${exercisesAchieved[0]}",
+                                    fontSize = 20.sp,
+                                    color = colorResource(R.color.black),
+                                    modifier = Modifier.testTag("ExercisesEasyCount")
+                                )
+                            }
+                        }
+                        Box(
+                            modifier = Modifier
+                                .size(50.dp)
+                                .border(2.dp, colorResource(R.color.blue))
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(colorResource(R.color.white))
+                                .testTag("ExercisesHardCountBox"),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(
+                                modifier = Modifier.fillMaxSize(),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = "HARD",
+                                    fontSize = 12.sp,
+                                    color = colorResource(R.color.black),
+                                    modifier = Modifier.testTag("Hard")
+                                )
+                                Text(
+                                    text = "${exercisesAchieved[1]}",
+                                    fontSize = 20.sp,
+                                    color = colorResource(R.color.black),
+                                    modifier = Modifier.testTag("ExercisesHardCount")
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    // Number of quests achieved
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp)
+                            .testTag("QuestsRow"),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Number of quests achieved",
+                            fontSize = 16.sp,
+                            color = colorResource(R.color.black),
+                            modifier = Modifier.testTag("QuestsText")
+                        )
+                        Box(
+                            modifier = Modifier
+                                .size(50.dp)
+                                .border(2.dp, colorResource(R.color.blue))
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(colorResource(R.color.white))
+                                .testTag("DailyQuestCountBox"),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(
+                                modifier = Modifier.fillMaxSize(),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = "DAILY",
+                                    fontSize = 12.sp,
+                                    color = colorResource(R.color.black),
+                                    modifier = Modifier.testTag("Daily")
+                                )
+                                Text(
+                                    text = "${questsAchieved[0]}",
+                                    fontSize = 20.sp,
+                                    color = colorResource(R.color.black),
+                                    modifier = Modifier.testTag("DailyQuestCount")
+                                )
+                            }
+                        }
+                        Box(
+                            modifier = Modifier
+                                .size(50.dp)
+                                .border(2.dp, colorResource(R.color.blue))
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(colorResource(R.color.white))
+                                .testTag("WeeklyQuestsCountBox"),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(
+                                modifier = Modifier.fillMaxSize(),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = "WEEKLY",
+                                    fontSize = 12.sp,
+                                    color = colorResource(R.color.black),
+                                    modifier = Modifier.testTag("Weekly")
+                                )
+                                Text(
+                                    text = "${questsAchieved[1]}",
+                                    fontSize = 20.sp,
+                                    color = colorResource(R.color.black),
+                                    modifier = Modifier.testTag("WeeklyQuestsCount")
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(60.dp))
+
+                    // Graphs and statistics
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(240.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(colorResource(R.color.dark_gray))
+                            .padding(16.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Graphs and stats",
+                            fontSize = 16.sp,
+                            color = colorResource(R.color.black),
+                            fontWeight = FontWeight.Normal
+                        )
+                    }
+                }
+            }
         }
-      }
-    }
-  )
+    )
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
@@ -40,246 +40,207 @@ fun MyStatsScreen(
     exercisesAchieved: List<Int>,
     questsAchieved: List<Int>
 ) {
-    Scaffold(
-        topBar = {
-            // Top blue bar
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
+  Scaffold(
+      topBar = {
+        // Top blue bar
+        Box(
+            modifier =
+                Modifier.fillMaxWidth()
                     .height(4.dp)
                     .background(MaterialTheme.colorScheme.primary)
-                    .testTag("TopBlueBar")
-            )
-        },
-        content = { padding ->
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .testTag("MyStatsScreen")
-            ) {
-                // Back button aligned to the top-left corner
-                BackButton { navigationActions.goBack() }
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(
-                            top = 80.dp,
-                            start = 16.dp,
-                            end = 16.dp
-                        ) // Padding to avoid overlap with the back button
-                        .testTag("MyStatsContent"),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    // Number of days
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.Center,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.flame),
-                            contentDescription = "Days Icon",
-                            tint = colorResource(R.color.red),
-                            modifier = Modifier
-                                .size(32.dp)
-                                .testTag("flameIcon")
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Text(text = "$numberOfDays days", fontWeight = FontWeight.Bold)
+                    .testTag("TopBlueBar"))
+      },
+      content = { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding).testTag("MyStatsScreen")) {
+          // Back button aligned to the top-left corner
+          BackButton { navigationActions.goBack() }
+          Column(
+              modifier =
+                  Modifier.fillMaxSize()
+                      .padding(
+                          top = 80.dp,
+                          start = 16.dp,
+                          end = 16.dp) // Padding to avoid overlap with the back button
+                      .testTag("MyStatsContent"),
+              horizontalAlignment = Alignment.CenterHorizontally) {
+                // Number of days
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically) {
+                      Icon(
+                          painter = painterResource(id = R.drawable.flame),
+                          contentDescription = "Days Icon",
+                          tint = colorResource(R.color.red),
+                          modifier = Modifier.size(32.dp).testTag("flameIcon"))
+                      Spacer(modifier = Modifier.width(4.dp))
+                      Text(
+                          text = "$numberOfDays days",
+                          fontWeight = FontWeight.Bold,
+                          modifier = Modifier.testTag("numberOfDays"))
                     }
 
-                    Spacer(modifier = Modifier.height(32.dp))
+                Spacer(modifier = Modifier.height(32.dp))
 
-                    // Letters learned
-                    Text(
-                        text = "All letters learned",
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 16.sp,
-                        color = colorResource(R.color.dark_gray)
-                    )
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
+                // Letters learned
+                Text(
+                    text = "All letters learned",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp,
+                    color = colorResource(R.color.dark_gray),
+                    modifier = Modifier.testTag("allLetterLearned"))
+                Box(
+                    modifier =
+                        Modifier.fillMaxWidth()
                             .border(
-                                2.dp,
-                                colorResource(R.color.dark_gray),
-                                RoundedCornerShape(12.dp)
-                            )
+                                2.dp, colorResource(R.color.dark_gray), RoundedCornerShape(12.dp))
                             .clip(RoundedCornerShape(8.dp))
                             .padding(12.dp)
-                            .testTag("lettersBox")
-                    ) {
-                        HorizontalLetterList(lettersLearned)
+                            .testTag("lettersBox")) {
+                      HorizontalLetterList(lettersLearned)
                     }
 
-                    Spacer(modifier = Modifier.height(64.dp))
+                Spacer(modifier = Modifier.height(64.dp))
 
-                    // Number of exercises achieved
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp)
-                            .testTag("ExercisesRow"),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Number of exercises achieved",
-                            fontSize = 16.sp,
-                            color = colorResource(R.color.black),
-                            modifier = Modifier.testTag("ExercisesText")
-                        )
-                        Box(
-                            modifier = Modifier
-                                .size(50.dp)
-                                .border(2.dp, colorResource(R.color.blue))
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(colorResource(R.color.white))
-                                .testTag("ExercisesEasyCountBox"),
-                            contentAlignment = Alignment.Center
-                        ) {
+                // Number of exercises achieved
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth().padding(vertical = 8.dp).testTag("ExercisesRow"),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically) {
+                      Text(
+                          text = "Number of exercises achieved",
+                          fontSize = 16.sp,
+                          color = colorResource(R.color.black),
+                          modifier = Modifier.testTag("ExercisesText"))
+                      Box(
+                          modifier =
+                              Modifier.size(50.dp)
+                                  .border(2.dp, colorResource(R.color.blue))
+                                  .clip(RoundedCornerShape(12.dp))
+                                  .background(colorResource(R.color.white))
+                                  .testTag("ExercisesEasyCountBox"),
+                          contentAlignment = Alignment.Center) {
                             Column(
                                 modifier = Modifier.fillMaxSize(),
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                Text(
-                                    text = "EASY",
-                                    fontSize = 12.sp,
-                                    color = colorResource(R.color.black),
-                                    modifier = Modifier.testTag("Easy")
-                                )
-                                Text(
-                                    text = "${exercisesAchieved[0]}",
-                                    fontSize = 20.sp,
-                                    color = colorResource(R.color.black),
-                                    modifier = Modifier.testTag("ExercisesEasyCount")
-                                )
-                            }
-                        }
-                        Box(
-                            modifier = Modifier
-                                .size(50.dp)
-                                .border(2.dp, colorResource(R.color.blue))
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(colorResource(R.color.white))
-                                .testTag("ExercisesHardCountBox"),
-                            contentAlignment = Alignment.Center
-                        ) {
+                                horizontalAlignment = Alignment.CenterHorizontally) {
+                                  Text(
+                                      text = "EASY",
+                                      fontSize = 12.sp,
+                                      color = colorResource(R.color.black),
+                                      modifier = Modifier.testTag("Easy"))
+                                  Text(
+                                      text = "${exercisesAchieved[0]}",
+                                      fontSize = 20.sp,
+                                      color = colorResource(R.color.black),
+                                      modifier = Modifier.testTag("ExercisesEasyCount"))
+                                }
+                          }
+                      Box(
+                          modifier =
+                              Modifier.size(50.dp)
+                                  .border(2.dp, colorResource(R.color.blue))
+                                  .clip(RoundedCornerShape(12.dp))
+                                  .background(colorResource(R.color.white))
+                                  .testTag("ExercisesHardCountBox"),
+                          contentAlignment = Alignment.Center) {
                             Column(
                                 modifier = Modifier.fillMaxSize(),
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                Text(
-                                    text = "HARD",
-                                    fontSize = 12.sp,
-                                    color = colorResource(R.color.black),
-                                    modifier = Modifier.testTag("Hard")
-                                )
-                                Text(
-                                    text = "${exercisesAchieved[1]}",
-                                    fontSize = 20.sp,
-                                    color = colorResource(R.color.black),
-                                    modifier = Modifier.testTag("ExercisesHardCount")
-                                )
-                            }
-                        }
+                                horizontalAlignment = Alignment.CenterHorizontally) {
+                                  Text(
+                                      text = "HARD",
+                                      fontSize = 12.sp,
+                                      color = colorResource(R.color.black),
+                                      modifier = Modifier.testTag("Hard"))
+                                  Text(
+                                      text = "${exercisesAchieved[1]}",
+                                      fontSize = 20.sp,
+                                      color = colorResource(R.color.black),
+                                      modifier = Modifier.testTag("ExercisesHardCount"))
+                                }
+                          }
                     }
 
-                    Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(12.dp))
 
-                    // Number of quests achieved
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp)
-                            .testTag("QuestsRow"),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Number of quests achieved",
-                            fontSize = 16.sp,
-                            color = colorResource(R.color.black),
-                            modifier = Modifier.testTag("QuestsText")
-                        )
-                        Box(
-                            modifier = Modifier
-                                .size(50.dp)
-                                .border(2.dp, colorResource(R.color.blue))
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(colorResource(R.color.white))
-                                .testTag("DailyQuestCountBox"),
-                            contentAlignment = Alignment.Center
-                        ) {
+                // Number of quests achieved
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth().padding(vertical = 8.dp).testTag("QuestsRow"),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically) {
+                      Text(
+                          text = "Number of quests achieved",
+                          fontSize = 16.sp,
+                          color = colorResource(R.color.black),
+                          modifier = Modifier.testTag("QuestsText"))
+                      Box(
+                          modifier =
+                              Modifier.size(50.dp)
+                                  .border(2.dp, colorResource(R.color.blue))
+                                  .clip(RoundedCornerShape(12.dp))
+                                  .background(colorResource(R.color.white))
+                                  .testTag("DailyQuestCountBox"),
+                          contentAlignment = Alignment.Center) {
                             Column(
                                 modifier = Modifier.fillMaxSize(),
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                Text(
-                                    text = "DAILY",
-                                    fontSize = 12.sp,
-                                    color = colorResource(R.color.black),
-                                    modifier = Modifier.testTag("Daily")
-                                )
-                                Text(
-                                    text = "${questsAchieved[0]}",
-                                    fontSize = 20.sp,
-                                    color = colorResource(R.color.black),
-                                    modifier = Modifier.testTag("DailyQuestCount")
-                                )
-                            }
-                        }
-                        Box(
-                            modifier = Modifier
-                                .size(50.dp)
-                                .border(2.dp, colorResource(R.color.blue))
-                                .clip(RoundedCornerShape(12.dp))
-                                .background(colorResource(R.color.white))
-                                .testTag("WeeklyQuestsCountBox"),
-                            contentAlignment = Alignment.Center
-                        ) {
+                                horizontalAlignment = Alignment.CenterHorizontally) {
+                                  Text(
+                                      text = "DAILY",
+                                      fontSize = 12.sp,
+                                      color = colorResource(R.color.black),
+                                      modifier = Modifier.testTag("Daily"))
+                                  Text(
+                                      text = "${questsAchieved[0]}",
+                                      fontSize = 20.sp,
+                                      color = colorResource(R.color.black),
+                                      modifier = Modifier.testTag("DailyQuestCount"))
+                                }
+                          }
+                      Box(
+                          modifier =
+                              Modifier.size(50.dp)
+                                  .border(2.dp, colorResource(R.color.blue))
+                                  .clip(RoundedCornerShape(12.dp))
+                                  .background(colorResource(R.color.white))
+                                  .testTag("WeeklyQuestsCountBox"),
+                          contentAlignment = Alignment.Center) {
                             Column(
                                 modifier = Modifier.fillMaxSize(),
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                Text(
-                                    text = "WEEKLY",
-                                    fontSize = 12.sp,
-                                    color = colorResource(R.color.black),
-                                    modifier = Modifier.testTag("Weekly")
-                                )
-                                Text(
-                                    text = "${questsAchieved[1]}",
-                                    fontSize = 20.sp,
-                                    color = colorResource(R.color.black),
-                                    modifier = Modifier.testTag("WeeklyQuestsCount")
-                                )
-                            }
-                        }
+                                horizontalAlignment = Alignment.CenterHorizontally) {
+                                  Text(
+                                      text = "WEEKLY",
+                                      fontSize = 12.sp,
+                                      color = colorResource(R.color.black),
+                                      modifier = Modifier.testTag("Weekly"))
+                                  Text(
+                                      text = "${questsAchieved[1]}",
+                                      fontSize = 20.sp,
+                                      color = colorResource(R.color.black),
+                                      modifier = Modifier.testTag("WeeklyQuestsCount"))
+                                }
+                          }
                     }
 
-                    Spacer(modifier = Modifier.height(60.dp))
+                Spacer(modifier = Modifier.height(60.dp))
 
-                    // Graphs and statistics
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
+                // Graphs and statistics
+                Box(
+                    modifier =
+                        Modifier.fillMaxWidth()
                             .height(240.dp)
                             .clip(RoundedCornerShape(12.dp))
-                            .background(colorResource(R.color.dark_gray))
-                            .padding(16.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = "Graphs and stats",
-                            fontSize = 16.sp,
-                            color = colorResource(R.color.black),
-                            fontWeight = FontWeight.Normal
-                        )
+                            .background(colorResource(R.color.black))
+                            .padding(16.dp)
+                            .testTag("GraphsAndStats"),
+                    contentAlignment = Alignment.Center) {
+                      Text(
+                          text = "Graphs and stats",
+                          fontSize = 16.sp,
+                          color = colorResource(R.color.white),
+                          fontWeight = FontWeight.Normal)
                     }
-                }
-            }
+              }
         }
-    )
+      })
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
@@ -1,13 +1,256 @@
 package com.github.se.signify.ui.screens.profile
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.signify.R
+import com.github.se.signify.ui.BackButton
 import com.github.se.signify.ui.navigation.NavigationActions
 
 @Composable
-fun MyStatsScreen(navigationActions: NavigationActions) {
-  Column(modifier = Modifier.testTag("StatsScreen")) { Text(text = "My stats Screen") }
+fun MyStatsScreen(
+  navigationActions: NavigationActions,
+  numberOfDays: Int,
+  lettersLearned: List<Char>,
+  exercisesAchieved: List<Int>,
+  questsAchieved: List<Int>
+) {
+  Scaffold(
+    topBar = {
+      // Top blue bar
+      Box(
+        modifier = Modifier.fillMaxWidth()
+          .height(4.dp)
+          .background(MaterialTheme.colorScheme.primary)
+          .testTag("TopBlueBar")
+      )
+    },
+    content = { padding ->
+      Box(modifier = Modifier.fillMaxSize().padding(padding).testTag("MyStatsScreen")) {
+        // Back button aligned to the top-left corner
+        BackButton { navigationActions.goBack() }
+        Column(
+          modifier = Modifier.fillMaxSize()
+            .padding(
+              top = 80.dp,
+              start = 16.dp,
+              end = 16.dp) // Padding to avoid overlap with the back button
+            .testTag("MyStatsContent"),
+          horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+          // Number of days
+          Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+          ) {
+            Icon(
+              painter = painterResource(id = R.drawable.flame),
+              contentDescription = "Days Icon",
+              tint = colorResource(R.color.red),
+              modifier = Modifier.size(32.dp).testTag("flameIcon")
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(text = "$numberOfDays days", fontWeight = FontWeight.Bold)
+          }
+          Spacer(modifier = Modifier.height(32.dp))
+          // Letters learned
+          Text(
+            text = "All letters learned",
+            fontWeight = FontWeight.Bold,
+            fontSize = 16.sp,
+            color = colorResource(R.color.dark_gray)
+          )
+          Box(
+            modifier = Modifier.fillMaxWidth()
+              .border(2.dp, colorResource(R.color.dark_gray), RoundedCornerShape(12.dp))
+              .clip(RoundedCornerShape(8.dp))
+              .padding(12.dp)
+              .testTag("lettersBox")
+          ) {
+            HorizontalLetterList(lettersLearned)
+          }
+          Spacer(modifier = Modifier.height(64.dp))
+          // Number of exercises achieved
+          Row(
+            modifier = Modifier.fillMaxWidth()
+              .padding(vertical = 8.dp)
+              .testTag("ExercisesRow"),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+          ) {
+            Text(
+              text = "Number of exercises achieved",
+              fontSize = 16.sp,
+              color = colorResource(R.color.black),
+              modifier = Modifier.testTag("ExercisesText")
+            )
+            Box(
+              modifier = Modifier.size(50.dp)
+                .border(2.dp, colorResource(R.color.blue))
+                .clip(RoundedCornerShape(12.dp))
+                .background(colorResource(R.color.white))
+                .testTag("ExercisesEasyCountBox"),
+              contentAlignment = Alignment.Center
+            ) {
+              Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally
+              ) {
+                Text(
+                  text = "EASY",
+                  fontSize = 12.sp,
+                  color = colorResource(R.color.black),
+                  modifier = Modifier.testTag("Easy")
+                )
+                Text(
+                  text = "${exercisesAchieved[0]}",
+                  fontSize = 20.sp,
+                  color = colorResource(R.color.black),
+                  modifier = Modifier.testTag("ExercisesEasyCount")
+                )
+              }
+            }
+            Box(
+              modifier = Modifier.size(50.dp)
+                .border(2.dp, colorResource(R.color.blue))
+                .clip(RoundedCornerShape(12.dp))
+                .background(colorResource(R.color.white))
+                .testTag("ExercisesHardCountBox"),
+              contentAlignment = Alignment.Center
+            ) {
+              Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally
+              ) {
+                Text(
+                  text = "HARD",
+                  fontSize = 12.sp,
+                  color = colorResource(R.color.black),
+                  modifier = Modifier.testTag("Hard")
+                )
+                Text(
+                  text = "${exercisesAchieved[1]}",
+                  fontSize = 20.sp,
+                  color = colorResource(R.color.black),
+                  modifier = Modifier.testTag("ExercisesHardCount")
+                )
+              }
+            }
+          }
+          Spacer(modifier = Modifier.height(12.dp))
+          // Number of quests achieved
+          Row(
+            modifier = Modifier.fillMaxWidth()
+              .padding(vertical = 8.dp)
+              .testTag("QuestsRow"),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+          ) {
+            Text(
+              text = "Number of quests achieved",
+              fontSize = 16.sp,
+              color = colorResource(R.color.black),
+              modifier = Modifier.testTag("QuestsText")
+            )
+            Box(
+              modifier = Modifier.size(50.dp)
+                .border(2.dp, colorResource(R.color.blue))
+                .clip(RoundedCornerShape(12.dp))
+                .background(colorResource(R.color.white))
+                .testTag("DailyQuestCountBox"),
+              contentAlignment = Alignment.Center
+            ) {
+              Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally
+              ) {
+                Text(
+                  text = "DAILY",
+                  fontSize = 12.sp,
+                  color = colorResource(R.color.black),
+                  modifier = Modifier.testTag("Daily")
+                )
+                Text(
+                  text = "${questsAchieved[0]}",
+                  fontSize = 20.sp,
+                  color = colorResource(R.color.black),
+                  modifier = Modifier.testTag("DailyQuestCount")
+                )
+              }
+            }
+            Box(
+              modifier = Modifier.size(50.dp)
+                .border(2.dp, colorResource(R.color.blue))
+                .clip(RoundedCornerShape(12.dp))
+                .background(colorResource(R.color.white))
+                .testTag("WeeklyQuestsCountBox"),
+              contentAlignment = Alignment.Center
+            ) {
+              Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally
+              ) {
+                Text(
+                  text = "WEEKLY",
+                  fontSize = 12.sp,
+                  color = colorResource(R.color.black),
+                  modifier = Modifier.testTag("Weekly")
+                )
+                Text(
+                  text = "${questsAchieved[1]}",
+                  fontSize = 20.sp,
+                  color = colorResource(R.color.black),
+                  modifier = Modifier.testTag("WeeklyQuestsCount")
+                )
+              }
+            }
+          }
+          Spacer(modifier = Modifier.height(60.dp))
+          // Graphs and statistics
+          Box(
+            modifier = Modifier.fillMaxWidth()
+              .height(240.dp)
+              .clip(RoundedCornerShape(12.dp))
+              .background(colorResource(R.color.dark_gray))
+              .padding(16.dp),
+            contentAlignment = Alignment.Center
+          ) {
+            Text(
+              text = "Graphs and stats",
+              fontSize = 16.sp,
+              color = colorResource(R.color.black),
+              fontWeight = FontWeight.Normal
+            )
+          }
+
+        }
+      }
+    }
+  )
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
@@ -239,7 +239,7 @@ fun HorizontalLetterList(lettersLearned: List<Char>) {
           color =
               if (isLearned) colorResource(R.color.blue)
               else colorResource(R.color.dark_gray).copy(alpha = .5f),
-          modifier = Modifier.padding(horizontal = 8.dp))
+          modifier = Modifier.padding(horizontal = 8.dp).testTag(letter.toString()))
     }
   }
 }


### PR DESCRIPTION
### Pull Request Description

**Summary**

This pull request introduces a new UI screen and its android test, designed to provide users with a comprehensive overview of their statistics. The UI has been developed to look as the figma design. It is link to the issues #144 and #153.

**Changes Made**
- Implemented the UI of the file named `MyStatsScreen.kt` that is coherent with the figma design.
- Created the android test file named `MyStatsScreenTest.kt`.

**Testing**:
- Implemented the Following tests:
  - **Display test**: Ensures that all the information is displayed correctly.
  - **Scroll test**: Verifies that the box with the letter learned can be scrolled horizontally.
  - **Back Navigation Test**: Confirms that clicking the back button triggers the expected navigation.
- All tests pass successfully, confirming that the screen operates as intended.
- However, I only got 77% test coverage and I have some difficulty to find more test to do for now.

![jacocoTestReportMyStatsScreen](https://github.com/user-attachments/assets/514a4e30-c7ba-4597-897a-c9fe2880a989)
