### PR TITLE
Replace the home screen's camera preview box with a button

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/HomeScreenTest.kt
@@ -34,8 +34,7 @@ class HomeScreenTest {
 
     // Assert that all elements are displayed in ChallengeScreen
     composeTestRule.onNodeWithTag("QuestsButton").performScrollTo().assertIsDisplayed()
-    composeTestRule.onNodeWithTag("CameraFeedbackToggle").performScrollTo().assertIsDisplayed()
-    composeTestRule.onNodeWithTag("CameraFeedback").performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("CameraFeedbackButton").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("LetterDictionary").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("LetterDictionaryBack").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("LetterDictionaryForward").performScrollTo().assertIsDisplayed()
@@ -51,8 +50,7 @@ class HomeScreenTest {
 
     composeTestRule.onNodeWithTag("HelpButton").assertHasClickAction()
     composeTestRule.onNodeWithTag("QuestsButton").assertHasClickAction()
-    composeTestRule.onNodeWithTag("CameraFeedbackToggle").assertHasClickAction()
-    composeTestRule.onNodeWithTag("CameraFeedback").assertHasClickAction()
+    composeTestRule.onNodeWithTag("CameraFeedbackButton").assertHasClickAction()
     composeTestRule.onNodeWithTag("LetterDictionaryBack").assertHasClickAction()
     composeTestRule.onNodeWithTag("LetterDictionaryForward").assertHasClickAction()
   }
@@ -67,10 +65,10 @@ class HomeScreenTest {
   }
 
   @Test
-  fun cameraFeedbackWindowNavigatesToMainAimScreen() {
+  fun cameraFeedbackButtonNavigatesToPracticeScreen() {
     composeTestRule.setContent { HomeScreen(navigationActions = navigationActions) }
 
-    composeTestRule.onNodeWithTag("CameraFeedback").performClick()
+    composeTestRule.onNodeWithTag("CameraFeedbackButton").performClick()
 
     verify(navigationActions).navigateTo(Screen.PRACTICE)
   }

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
@@ -2,7 +2,6 @@ package com.github.se.signify.ui.screens.home
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,7 +17,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -111,16 +110,7 @@ fun HomeScreen(navigationActions: NavigationActions) {
 
               Spacer(modifier = Modifier.height(16.dp))
 
-              ReusableTextButton(
-                  onClickAction = { /* Do nothing for now */},
-                  testTag = "CameraFeedbackToggle",
-                  text = "Toggle Camera",
-                  backgroundColor = colorResource(R.color.blue),
-              )
-
-              Spacer(modifier = Modifier.height(16.dp))
-
-              CameraFeedback(onClick = { navigationActions.navigateTo(Screen.PRACTICE) })
+              CameraFeedbackButton(onClick = { navigationActions.navigateTo(Screen.PRACTICE) })
 
               Spacer(modifier = Modifier.height(16.dp))
 
@@ -133,22 +123,14 @@ fun HomeScreen(navigationActions: NavigationActions) {
       })
 }
 
-// This should be hooked to the camera feedback screen later on.
 @Composable
-fun CameraFeedback(onClick: () -> Unit = {}) {
-  Box(
-      modifier =
-          Modifier.aspectRatio(4f / 3f)
-              .border(2.dp, colorResource(R.color.blue), RoundedCornerShape(8.dp))
-              .background(colorResource(R.color.black), RoundedCornerShape(8.dp))
-              .clickable { onClick() }
-              .testTag("CameraFeedback")) {
-        Text(
-            text = "Camera\nFeedback",
-            modifier = Modifier.align(Alignment.Center),
-            color = colorResource(R.color.white),
-            fontSize = 32.dp.value.sp)
-      }
+fun CameraFeedbackButton(onClick: () -> Unit = {}) {
+  ReusableTextButton(
+      onClickAction = onClick,
+      testTag = "CameraFeedbackButton",
+      text = "Try it out",
+      backgroundColor = colorResource(R.color.blue),
+  )
 }
 
 @Composable
@@ -214,11 +196,10 @@ fun LetterDictionary() {
 
 @Composable
 fun ExerciseList(exercises: List<Exercise>, onExerciseClick: (exercise: Exercise) -> Unit) {
-  LazyVerticalGrid(
-      columns = GridCells.Fixed(2),
+  LazyHorizontalGrid(
+      rows = GridCells.Adaptive(128.dp),
       modifier =
-          Modifier.fillMaxSize()
-              .wrapContentHeight()
+          Modifier.fillMaxWidth()
               .border(2.dp, colorResource(R.color.black), RoundedCornerShape(8.dp))
               .clip(RoundedCornerShape(8.dp))
               .background(colorResource(R.color.dark_gray))


### PR DESCRIPTION
## Changes
As proposed by @SaFouNaldo , I have replaced the empty camera preview with a simple button labeled "Try it out!". Tests had to be updated in accordance to this change.
Additionally, the exercise list was changed to be a 1 element tall horizontally scrollable grid.

## Future plans
This PR leaves the screen with a lot of new blank space, which we'll need to fill somehow.
I am not convinced with these changes, and suggest we explore new layouts for the home screen and its exercises.

Still, it shouldn't hurt to merge this for now.