### PR TITLE
Add getProfilePictureUrl and updateProfilePictureUrl Functions with Corresponding Tests

### DIFF
--- a/app/src/main/java/com/github/se/signify/model/user/UserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/UserRepository.kt
@@ -27,6 +27,19 @@ interface UserRepository {
       onFailure: (Exception) -> Unit
   )
 
+  fun getProfilePictureUrl(
+      userId: String,
+      onSuccess: (String) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+
+  fun updateProfilePictureUrl(
+      userId: String,
+      newProfilePictureUrl: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+
   fun sendFriendRequest(
       currentUserId: String,
       targetUserId: String,

--- a/app/src/main/java/com/github/se/signify/model/user/UserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/UserRepository.kt
@@ -29,13 +29,13 @@ interface UserRepository {
 
   fun getProfilePictureUrl(
       userId: String,
-      onSuccess: (String) -> Unit,
+      onSuccess: (String?) -> Unit,
       onFailure: (Exception) -> Unit
   )
 
   fun updateProfilePictureUrl(
       userId: String,
-      newProfilePictureUrl: String,
+      newProfilePictureUrl: String?,
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   )

--- a/app/src/main/java/com/github/se/signify/model/user/UserRepositoryFireStore.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/UserRepositoryFireStore.kt
@@ -146,7 +146,7 @@ class UserRepositoryFireStore(private val db: FirebaseFirestore) : UserRepositor
 
   override fun getProfilePictureUrl(
       userId: String,
-      onSuccess: (String) -> Unit,
+      onSuccess: (String?) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
     val userRef = db.collection(collectionPath).document(userId)
@@ -160,16 +160,16 @@ class UserRepositoryFireStore(private val db: FirebaseFirestore) : UserRepositor
 
       if (documentSnapshot != null && documentSnapshot.exists()) {
         val profilePictureUrl = documentSnapshot[profilePicturePath] as? String
-        onSuccess(profilePictureUrl ?: "unknown")
+        onSuccess(profilePictureUrl)
       } else {
-        onSuccess("unknown")
+        onSuccess(null)
       }
     }
   }
 
   override fun updateProfilePictureUrl(
       userId: String,
-      newProfilePictureUrl: String,
+      newProfilePictureUrl: String?,
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {

--- a/app/src/main/java/com/github/se/signify/model/user/UserRepositoryFireStore.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/UserRepositoryFireStore.kt
@@ -10,6 +10,8 @@ class UserRepositoryFireStore(private val db: FirebaseFirestore) : UserRepositor
   private val collectionPath = "users"
   private val friendsListPath = "friends"
   private val friendRequestsListPath = "friendRequests"
+  private val usernamePath = "name"
+  private val profilePicturePath = "profileImageUrl"
 
   override fun init(onSuccess: () -> Unit) {
     Firebase.auth.addAuthStateListener {
@@ -112,7 +114,7 @@ class UserRepositoryFireStore(private val db: FirebaseFirestore) : UserRepositor
       }
 
       if (documentSnapshot != null && documentSnapshot.exists()) {
-        val userName = documentSnapshot["name"] as? String
+        val userName = documentSnapshot[usernamePath] as? String
         onSuccess(userName ?: "unknown")
       } else {
         onSuccess("unknown")
@@ -130,7 +132,52 @@ class UserRepositoryFireStore(private val db: FirebaseFirestore) : UserRepositor
     val userRef = db.collection(collectionPath).document(userId)
     try {
       userRef
-          .update("name", newName)
+          .update(usernamePath, newName)
+          .addOnSuccessListener {
+            onSuccess() // Invoke the onSuccess callback
+          }
+          .addOnFailureListener { e ->
+            onFailure(e) // Trigger onFailure callback
+          }
+    } catch (e: Exception) {
+      onFailure(e) // Trigger onFailure callback
+    }
+  }
+
+  override fun getProfilePictureUrl(
+      userId: String,
+      onSuccess: (String) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    val userRef = db.collection(collectionPath).document(userId)
+
+    // Use of addSnapshotListener for instant updates
+    userRef.addSnapshotListener { documentSnapshot, e ->
+      if (e != null) {
+        onFailure(e)
+        return@addSnapshotListener
+      }
+
+      if (documentSnapshot != null && documentSnapshot.exists()) {
+        val profilePictureUrl = documentSnapshot[profilePicturePath] as? String
+        onSuccess(profilePictureUrl ?: "unknown")
+      } else {
+        onSuccess("unknown")
+      }
+    }
+  }
+
+  override fun updateProfilePictureUrl(
+      userId: String,
+      newProfilePictureUrl: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+
+    val userRef = db.collection(collectionPath).document(userId)
+    try {
+      userRef
+          .update(profilePicturePath, newProfilePictureUrl)
           .addOnSuccessListener {
             onSuccess() // Invoke the onSuccess callback
           }

--- a/app/src/main/java/com/github/se/signify/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/UserViewModel.kt
@@ -19,8 +19,8 @@ open class UserViewModel(private val repository: UserRepository) : ViewModel() {
   private val _userName = MutableStateFlow("unknown")
   val userName: StateFlow<String> = _userName
 
-  private val _profilePictureUrl = MutableStateFlow("unknown")
-  val profilePictureUrl: StateFlow<String> = _profilePictureUrl
+  private val _profilePictureUrl = MutableStateFlow<String?>(null)
+  val profilePictureUrl: StateFlow<String?> = _profilePictureUrl
 
   private val _searchResult = MutableStateFlow<User?>(null)
   val searchResult: StateFlow<User?> = _searchResult
@@ -93,7 +93,7 @@ open class UserViewModel(private val repository: UserRepository) : ViewModel() {
         onFailure = { e -> Log.e(logTag, "Failed to get profile picture: ${e.message}}") })
   }
 
-  fun updateProfilePictureUrl(currentUserId: String, newProfilePictureUrl: String) {
+  fun updateProfilePictureUrl(currentUserId: String, newProfilePictureUrl: String?) {
     repository.updateProfilePictureUrl(
         currentUserId,
         newProfilePictureUrl,

--- a/app/src/main/java/com/github/se/signify/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/UserViewModel.kt
@@ -16,8 +16,11 @@ open class UserViewModel(private val repository: UserRepository) : ViewModel() {
   private val _friendsRequests = MutableStateFlow<List<String>>(emptyList())
   val friendsRequests: StateFlow<List<String>> = _friendsRequests
 
-  private val _userName = MutableStateFlow<String>("unknown")
+  private val _userName = MutableStateFlow("unknown")
   val userName: StateFlow<String> = _userName
+
+  private val _profilePictureUrl = MutableStateFlow("unknown")
+  val profilePictureUrl: StateFlow<String> = _profilePictureUrl
 
   private val _searchResult = MutableStateFlow<User?>(null)
   val searchResult: StateFlow<User?> = _searchResult
@@ -81,6 +84,21 @@ open class UserViewModel(private val repository: UserRepository) : ViewModel() {
         newName,
         onSuccess = { Log.d(logTag, "User name updated successfully.") },
         onFailure = { e -> Log.e(logTag, "Failed to update user name: ${e.message}") })
+  }
+
+  fun getProfilePictureUrl(currentUserId: String) {
+    repository.getProfilePictureUrl(
+        currentUserId,
+        onSuccess = { profilePictureUrl -> _profilePictureUrl.value = profilePictureUrl },
+        onFailure = { e -> Log.e(logTag, "Failed to get profile picture: ${e.message}}") })
+  }
+
+  fun updateProfilePictureUrl(currentUserId: String, newProfilePictureUrl: String) {
+    repository.updateProfilePictureUrl(
+        currentUserId,
+        newProfilePictureUrl,
+        onSuccess = { Log.d(logTag, "Profile picture updated successfully.") },
+        onFailure = { e -> Log.e(logTag, "Failed to update profile picture: ${e.message}") })
   }
 
   fun sendFriendRequest(currentUserId: String, targetUserId: String) {

--- a/app/src/test/java/com/github/se/signify/model/user/UserRepositoryFireStoreTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/user/UserRepositoryFireStoreTest.kt
@@ -127,6 +127,142 @@ class ToDosRepositoryFireStoreTest {
   }
 
   @Test
+  fun getProfilePictureUrl_callsDocuments() {
+    // Ensure that mockToDoQuerySnapshot is properly initialized and mocked
+    `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockToDoQuerySnapshot))
+
+    // Ensure the QuerySnapshot returns a list of mock DocumentSnapshots
+    `when`(mockToDoQuerySnapshot.documents).thenReturn(listOf())
+
+    // Call the method under test
+    userRepositoryFireStore.getProfilePictureUrl(
+        currentUserId,
+        onSuccess = {
+          // Do nothing; we just want to verify that the 'documents' field was accessed
+        },
+        onFailure = { fail("Failure callback should not be called") })
+
+    // Verify that the 'documents' field was accessed
+    verify(timeout(100)) { (mockToDoQuerySnapshot).documents }
+  }
+
+  @Test
+  fun updateUserName_shouldUpdateFireStoreDocument() {
+    // Mock the FireStore document reference and its update method
+    `when`(mockCurrentUserDocRef.update(eq("name"), eq("NewName")))
+        .thenReturn(Tasks.forResult(null)) // Simulate success
+
+    var successCallbackCalled = false
+    val onSuccess: () -> Unit = { successCallbackCalled = true }
+
+    // Act
+    userRepositoryFireStore.updateUserName(
+        currentUserId,
+        "NewName",
+        onSuccess,
+        onFailure = { fail("Failure callback should not be called") })
+
+    // Idle the main looper to process the tasks
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Assert
+    assertTrue(successCallbackCalled)
+
+    // Verify that FireStore's update method was called with the correct arguments
+    verify(mockCurrentUserDocRef).update(eq("name"), eq("NewName"))
+  }
+
+  @Test
+  fun updateUserName_shouldCallOnFailureWhenUpdateFails() {
+    // Arrange
+    val testException = Exception("Test Firestore failure") // Simulate Firestore failure
+
+    // Mock FireStore document reference to fail the update
+    `when`(mockCurrentUserDocRef.update(eq("name"), eq("NewName")))
+        .thenReturn(Tasks.forException(testException)) // Simulate failure
+
+    var failureCallbackCalled = false
+    val onFailure: (Exception) -> Unit = { exception ->
+      failureCallbackCalled = true
+      assertEquals(testException, exception) // Ensure the correct exception is passed
+    }
+
+    // Act
+    userRepositoryFireStore.updateUserName(
+        currentUserId,
+        "NewName",
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = onFailure)
+
+    // Idle the main looper to process the tasks
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Assert
+    assertTrue(failureCallbackCalled)
+
+    // Verify that FireStore's update method was called with the correct arguments
+    verify(mockCurrentUserDocRef).update(eq("name"), eq("NewName"))
+  }
+
+  @Test
+  fun updateProfilePictureUrl_shouldUpdateFireStoreDocument() {
+    // Mock the FireStore document reference and its update method
+    `when`(mockCurrentUserDocRef.update(eq("profileImageUrl"), eq("NewProfilePictureUrl")))
+        .thenReturn(Tasks.forResult(null)) // Simulate success
+
+    var successCallbackCalled = false
+    val onSuccess: () -> Unit = { successCallbackCalled = true }
+
+    // Act
+    userRepositoryFireStore.updateProfilePictureUrl(
+        currentUserId,
+        "NewProfilePictureUrl",
+        onSuccess,
+        onFailure = { fail("Failure callback should not be called") })
+
+    // Idle the main looper to process the tasks
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Assert
+    assertTrue(successCallbackCalled)
+
+    // Verify that FireStore's update method was called with the correct arguments
+    verify(mockCurrentUserDocRef).update(eq("profileImageUrl"), eq("NewProfilePictureUrl"))
+  }
+
+  @Test
+  fun updateProfilePictureUrl_shouldCallOnFailureWhenUpdateFails() {
+    // Arrange
+    val testException = Exception("Test Firestore failure") // Simulate Firestore failure
+
+    // Mock Firestore document reference to fail the update
+    `when`(mockCurrentUserDocRef.update(eq("profileImageUrl"), eq("NewProfilePictureUrl")))
+        .thenReturn(Tasks.forException(testException)) // Simulate failure
+
+    var failureCallbackCalled = false
+    val onFailure: (Exception) -> Unit = { exception ->
+      failureCallbackCalled = true
+      assertEquals(testException, exception) // Ensure the correct exception is passed
+    }
+
+    // Act
+    userRepositoryFireStore.updateProfilePictureUrl(
+        currentUserId,
+        "NewProfilePictureUrl",
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = onFailure)
+
+    // Idle the main looper to process the tasks
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Assert
+    assertTrue(failureCallbackCalled)
+
+    // Verify that Firestore's update method was called with the correct arguments
+    verify(mockCurrentUserDocRef).update(eq("profileImageUrl"), eq("NewProfilePictureUrl"))
+  }
+
+  @Test
   fun getUserById_shouldCallOnSuccessWhenUserExists() {
     // Arrange
     val mockUser =

--- a/app/src/test/java/com/github/se/signify/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/user/UserViewModelTest.kt
@@ -45,6 +45,26 @@ class UserViewModelTest {
   }
 
   @Test
+  fun updateUserNameRequestCallsRepository() {
+    val newName = "newNameTest"
+    userViewModel.updateUserName(currentUserId, newName)
+    verify(userRepository).updateUserName(eq(currentUserId), eq(newName), any(), any())
+  }
+
+  @Test
+  fun getProfilePictureUrlRequestCallsRepository() {
+    userViewModel.getProfilePictureUrl(currentUserId)
+    verify(userRepository).getProfilePictureUrl(eq(currentUserId), any(), any())
+  }
+
+  @Test
+  fun updateProfilePictureUrlRequestCallsRepository() {
+    val newUrl = "testUrl"
+    userViewModel.updateProfilePictureUrl(currentUserId, newUrl)
+    verify(userRepository).updateProfilePictureUrl(eq(currentUserId), eq(newUrl), any(), any())
+  }
+
+  @Test
   fun sendFriendRequestCallsRepository() {
     userViewModel.sendFriendRequest(currentUserId, friendUserId)
     verify(userRepository).sendFriendRequest(eq(currentUserId), eq(friendUserId), any(), any())


### PR DESCRIPTION
This pull request introduces two new functions, getProfilePictureUrl and updateProfilePictureUrl, to manage profile picture operations in the UserRepository and its implementation UserRepositoryFireStore. Additionally, corresponding tests have been added to ensure these functions work as expected.

**Changes:**

Code Enhancements:
- Added getProfilePictureUrl function to retrieve the user's profile picture URL.
- Added updateProfilePictureUrl function to update the user's profile picture URL.
- Updated the UserRepository interface to include these two new methods.
- Integrated the new methods into the UserViewModel for seamless interaction.

**Tests Added:**
- Created unit tests for getProfilePictureUrl and updateProfilePictureUrl : 
- Verified successful retrieval of profile picture URL.
- Verified successful update of profile picture URL.
- Verified failure scenarios with appropriate error handling.
- Created unit tests for updateUserName (previously merged methods) for increasing the line coverage. 


**Summary:**

These changes are essential to enable users to retrieve and update their profile pictures. This feature enhances the user experience by supporting profile customization and ensuring that profile data is dynamically updated in the application. The next step is to use these methods in the Settings screen to allow the user to change his profile picture.