### PR TITLE
Revert removal of sonar plugin from version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ json = "20240303"
 kotlin = "1.9.0"
 gms = "4.4.2"
 ktfmt = "0.17.0"
+sonar = "4.4.1.3373"
 
 # UI Compose
 mockitoAndroid = "5.13.0"
@@ -131,3 +132,5 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 gms = { id = "com.google.gms.google-services", version.ref = "gms" }
+# Do not remove this line, as it is used by SonarCloud in the CI on Github.
+sonar = { id = "org.sonarqube", version.ref = "sonar" }


### PR DESCRIPTION
SonarCloud's test coverage in the CI has been showing constant 0% coverage for all PRs since my refactor to `gradle/libs.version.toml` in [this PR](https://github.com/Signify-epfl/signify-app/pull/160/files#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87df).
@ziyadbagh thinks this might be due to removing sonar from the version catalog `gradle/libs.version.toml`. I have reverted this change to test whether this was indeed the issue.

I suggest we merge this PR to test whether this fixes the CI, and roll it back if it doesn't.
If this does not fix the issue, since I don't think I have admin access on SonarCloud, I will probably need assistance from @SaFouNaldo .