### PR TITLE
New feature : update profile picture 

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/SettingsScreenTest.kt
@@ -1,10 +1,20 @@
 package com.github.se.signify.ui.screens.profile
 
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.platform.app.InstrumentationRegistry
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.model.user.UserViewModel
 import com.github.se.signify.ui.navigation.NavigationActions
+import java.io.File
+import java.io.FileNotFoundException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -12,6 +22,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 
@@ -22,14 +33,29 @@ class SettingsScreenTest {
   private lateinit var navigationActions: NavigationActions
   private lateinit var userRepository: UserRepository
   private lateinit var userViewModel: UserViewModel
+  private lateinit var context: Context
+  private lateinit var contentResolver: ContentResolver
+
+  private val testUserID = "currentUserId"
 
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
     userRepository = mock(UserRepository::class.java)
     userViewModel = UserViewModel(userRepository)
+    val picturePath = "file:///path/to/profile/picture.jpg"
 
-    composeTestRule.setContent { SettingsScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent {
+      SettingsScreen(navigationActions, userViewModel)
+      UserProfilePicture(picturePath)
+    }
+
+    // Mock context and contentResolver
+    context = mock(Context::class.java)
+    contentResolver = mock(ContentResolver::class.java)
+
+    // Stub the contentResolver in the mocked context
+    `when`(context.contentResolver).thenReturn(contentResolver)
   }
 
   @Test
@@ -43,6 +69,9 @@ class SettingsScreenTest {
 
     // Check if the edit profile picture icon is displayed
     composeTestRule.onNodeWithContentDescription("Edit Profile Picture").assertIsDisplayed()
+
+    // Check if the delete profile picture icon is displayed
+    composeTestRule.onNodeWithContentDescription("Delete Profile Picture").assertIsDisplayed()
 
     // Check if the "Other settings" section is displayed
     composeTestRule.onNodeWithText("Other settings:\nLanguage,\n theme, ...").assertIsDisplayed()
@@ -79,10 +108,16 @@ class SettingsScreenTest {
   }
 
   @Test
-  fun testSaveButtonUpdatesUserName() {
+  fun testSaveButtonUpdatesUserNameAndProfilePicture() {
     // Simulate entering a new name
     val newName = "New Username"
     composeTestRule.onNodeWithText(userViewModel.userName.value).performTextInput(newName)
+
+    // Simulate selecting a new profile picture
+    val newProfilePicturePath = "file:///path/to/new/profile/picture.jpg"
+    composeTestRule.runOnIdle {
+      userViewModel.updateProfilePictureUrl(testUserID, newProfilePicturePath)
+    }
 
     // Click the Save button
     composeTestRule.onNodeWithText("Save").performClick()
@@ -90,6 +125,12 @@ class SettingsScreenTest {
     // Verify that the updateUserName function in the ViewModel is called with the correct name
     verify(userRepository)
         .updateUserName(Mockito.anyString(), eq(newName), anyOrNull(), anyOrNull())
+
+    // Verify that the updateProfilePictureUrl function in the ViewModel is called with the correct
+    // path
+    verify(userRepository)
+        .updateProfilePictureUrl(
+            Mockito.anyString(), eq(newProfilePicturePath), anyOrNull(), anyOrNull())
   }
 
   @Test
@@ -111,19 +152,101 @@ class SettingsScreenTest {
     val newName = "Temporary Name"
     composeTestRule.onNodeWithText(userViewModel.userName.value).performTextInput(newName)
 
+    // Simulate selecting a new profile picture
+    val newProfilePicturePath = "file:///path/to/new/profile/picture.jpg"
+    composeTestRule.runOnIdle {
+      userViewModel.updateProfilePictureUrl(testUserID, newProfilePicturePath)
+    }
+
     // Click the Cancel button
     composeTestRule.onNodeWithText("Cancel").performClick()
 
     // Verify that the TextField is cleared
     composeTestRule.onNodeWithText("Temporary Name").assertDoesNotExist()
+
+    // Check that the original profile picture URL is restored
+    composeTestRule.runOnIdle {
+      val restoredProfilePictureUrl = userViewModel.profilePictureUrl.value
+      assert(restoredProfilePictureUrl != newProfilePicturePath) {
+        "Profile picture URL was not reset"
+      }
+    }
   }
 
   @Test
   fun testEditProfilePictureIconClick() {
     // Click the Edit Profile Picture icon
     composeTestRule.onNodeWithContentDescription("Edit Profile Picture").performClick()
+  }
 
-    // Add assertions or verifications based on what should happen after the icon is clicked
-    // when it will be implemented
+  @Test
+  fun testUserProfilePictureDisplaysImageWhenUriIsNotNull() {
+
+    // Verify that the AsyncImage is displayed with the mock profile picture
+    composeTestRule.onNodeWithTag("profilePictureTag").assertExists()
+  }
+
+  @Test
+  fun testUserProfilePictureDisplaysPlaceholderWhenUriIsNull() {
+
+    // Verify that the default placeholder is displayed
+    composeTestRule.onNodeWithTag("default_profile_picture").assertExists()
+  }
+
+  @Test
+  fun testUriToFileReturnsFileWhenUriIsValid() {
+    // Arrange
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val testData = "This is a test".toByteArray()
+
+    // Create a temporary file and write test data into it
+    val tempFile = File(context.cacheDir, "testFile.txt").apply { writeBytes(testData) }
+
+    // Create a URI directly from the file path
+    val fileUri = Uri.fromFile(tempFile)
+
+    // Act
+    val resultFile = uriToFile(context, fileUri)
+
+    // Assert
+    assertNotNull("File should not be null", resultFile)
+    assertEquals(
+        "File content should match test data", String(resultFile!!.readBytes()), String(testData))
+  }
+
+  @Test
+  fun testUriToFileReturnsNullWhenUriIsInvalid() {
+    // Arrange
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    // Use a non-existent URI
+    val invalidUri = Uri.parse("content://invalid/uri")
+
+    // Act
+    val resultFile = uriToFile(context, invalidUri)
+
+    // Assert
+    assertNull("File should be null when URI is invalid", resultFile)
+  }
+
+  @Test
+  fun testUriToFileHandlesException() {
+    // Arrange
+    val mockUri = Uri.parse("content://mockuri")
+    val contentResolver = InstrumentationRegistry.getInstrumentation().targetContext.contentResolver
+
+    // Simulate exception by providing a non-existent URI
+    try {
+      contentResolver.openInputStream(mockUri)
+      fail("Expected an exception to be thrown")
+    } catch (e: FileNotFoundException) {
+      // Expected behavior
+    }
+
+    // Act
+    val resultFile = uriToFile(InstrumentationRegistry.getInstrumentation().targetContext, mockUri)
+
+    // Assert
+    assertNull("File should be null when an exception occurs", resultFile)
   }
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
@@ -1,7 +1,12 @@
 package com.github.se.signify.ui.screens.profile
 
+import android.content.Context
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,13 +14,18 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -34,26 +44,50 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
 import com.github.se.signify.R
 import com.github.se.signify.model.user.UserViewModel
 import com.github.se.signify.ui.BackButton
 import com.github.se.signify.ui.navigation.NavigationActions
+import java.io.File
+import java.io.FileOutputStream
 
 @Composable
 fun SettingsScreen(
     navigationActions: NavigationActions,
     userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory)
 ) {
+  val context = LocalContext.current
+
+  LaunchedEffect(Unit) {
+    userViewModel.getUserName(currentUserId)
+    userViewModel.getProfilePictureUrl(currentUserId)
+  }
+
+  val userName = userViewModel.userName.collectAsState()
+  val profilePictureUrl = userViewModel.profilePictureUrl.collectAsState()
 
   var newName by remember { mutableStateOf("") }
-  LaunchedEffect(Unit) { userViewModel.getUserName(currentUserId) }
-  val userName = userViewModel.userName.collectAsState()
+  var selectedImageUrl by remember { mutableStateOf(profilePictureUrl.value) }
+  LaunchedEffect(profilePictureUrl.value) { selectedImageUrl = profilePictureUrl.value }
+
+  val galleryLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        if (uri != null) {
+          val file = uriToFile(context, uri)
+          if (file != null) {
+            selectedImageUrl = file.absolutePath
+          }
+        }
+      }
 
   Column(
       modifier =
@@ -79,12 +113,30 @@ fun SettingsScreen(
                   horizontalArrangement = Arrangement.Center,
                   verticalAlignment = Alignment.CenterVertically,
               ) {
-                Icon(
-                    imageVector = Icons.Outlined.Edit,
-                    contentDescription = "Edit Profile Picture",
-                    tint = colorResource(R.color.black))
+                Column {
+                  Icon(
+                      modifier = Modifier.clickable { galleryLauncher.launch("image/*") },
+                      imageVector = Icons.Outlined.Edit,
+                      contentDescription = "Edit Profile Picture",
+                      tint = colorResource(R.color.black),
+                  )
+
+                  Spacer(modifier = Modifier.height(16.dp))
+
+                  Icon(
+                      modifier =
+                          Modifier.clickable {
+                            userViewModel.updateProfilePictureUrl(currentUserId, null)
+                            selectedImageUrl = null
+                          },
+                      imageVector = Icons.Outlined.Delete,
+                      contentDescription = "Delete Profile Picture",
+                      tint = colorResource(R.color.black),
+                  )
+                }
+
                 Spacer(modifier = Modifier.width(8.dp))
-                ProfilePicture(null)
+                UserProfilePicture(selectedImageUrl)
               }
             }
 
@@ -144,13 +196,20 @@ fun SettingsScreen(
         // Cancel and Save Buttons
         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
           ActionButtons(
-              { newName = "" }, colorResource(R.color.dark_gray), "Cancel", Modifier.weight(1f))
+              {
+                newName = ""
+                selectedImageUrl = profilePictureUrl.value
+              },
+              colorResource(R.color.dark_gray),
+              "Cancel",
+              Modifier.weight(1f))
 
           ActionButtons(
               {
                 if (newName.isNotBlank()) {
                   userViewModel.updateUserName(currentUserId, newName)
                 }
+                userViewModel.updateProfilePictureUrl(currentUserId, selectedImageUrl)
               },
               colorResource(R.color.blue),
               "Save",
@@ -167,4 +226,41 @@ fun ActionButtons(onClickAction: () -> Unit, color: Color, text: String, modifie
       modifier = modifier) {
         Text(text = text, color = colorResource(R.color.white), fontWeight = FontWeight.Bold)
       }
+}
+
+@Composable
+fun UserProfilePicture(profilePictureUri: String?) {
+  if (profilePictureUri != null) {
+    AsyncImage(
+        model = Uri.parse(profilePictureUri),
+        contentDescription = "Profile Picture",
+        modifier =
+            Modifier.size(120.dp)
+                .clip(CircleShape)
+                .background(colorResource(R.color.dark_gray))
+                .testTag("profilePictureTag"),
+        contentScale = ContentScale.Crop) // Crop the image to fit within the bounds
+  } else {
+    // Default placeholder for no image
+    Icon(
+        imageVector = Icons.Default.Person,
+        contentDescription = "Default Profile Picture",
+        modifier = Modifier.size(120.dp).testTag("default_profile_picture"))
+  }
+}
+
+fun uriToFile(context: Context, uri: Uri): File? {
+  val contentResolver = context.contentResolver
+  val file = File(context.cacheDir, "temp_image_${System.currentTimeMillis()}.jpg")
+
+  try {
+    val inputStream = contentResolver.openInputStream(uri) ?: return null
+    val outputStream = FileOutputStream(file)
+
+    inputStream.use { input -> outputStream.use { output -> input.copyTo(output) } }
+    return file
+  } catch (e: Exception) {
+    e.printStackTrace()
+  }
+  return null
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
@@ -124,11 +124,7 @@ fun SettingsScreen(
                   Spacer(modifier = Modifier.height(16.dp))
 
                   Icon(
-                      modifier =
-                          Modifier.clickable {
-                            userViewModel.updateProfilePictureUrl(currentUserId, null)
-                            selectedImageUrl = null
-                          },
+                      modifier = Modifier.clickable { selectedImageUrl = null },
                       imageVector = Icons.Outlined.Delete,
                       contentDescription = "Delete Profile Picture",
                       tint = colorResource(R.color.black),


### PR DESCRIPTION
This pull request introduces the functionality to manage profile pictures in the SettingsScreen. Users can now:
- Choose a profile picture from their gallery.
- Delete the profile picture, reverting to a default placeholder.
__________

**New Components :** 

_Composable: UserProfilePicture_
- Displays the user's profile picture if available or a default placeholder when no image is set.
- Supports interaction for editing or deleting the profile picture.

_Function: uriToFile_
- Converts a Uri (e.g., from the gallery) into a File stored in the app's cache directory.
- Handles exceptions and ensures invalid URIs return null.


**Tests Added**

To ensure the reliability and accuracy of the new features, I implemented tests for all the new code, specially the function uriToFile. 
Finally we have a  91% test coverage with a wide range of unit and UI tests for the new and existing functionalities.

________
**Next Steps**

The next phase involves:
Integrating profile picture management into other screens, such as: ProfileScreen and FriendsListScreen.

________

<img width="1192" alt="Capture d’écran 2024-11-07 à 21 07 06" src="https://github.com/user-attachments/assets/aee23c21-a0ff-414d-aeaf-1c807a4416ab">

