### PR TITLE
Lock the app to portrait mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,9 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.Signify">
+            android:theme="@style/Theme.Signify"
+            android:screenOrientation="portrait"
+            tools:ignore="LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
### Description
I updated the `AndroidManifest.xml` to lock `MainActivity` to portrait orientation.

#### Changes:
- Set `android:screenOrientation="portrait"` for `MainActivity` to restrict it to portrait mode.
- Added `tools:ignore="LockedOrientationActivity"` to suppress Lint warnings about locking the screen orientation. This suppression helps keep the IDE free from unnecessary warnings while maintaining the desired orientation behavior.