### PR TITLE
fix: for Including Large Model Files in CI-Built APK

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,15 +22,22 @@ jobs:
     defaults:
       run:
         working-directory: ./${{ env.base_folder }}
-
     steps:
+      # Install Git LFS in CI
+      - name: Install Git LFS
+        run: git lfs install
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          lfs: true  # Enables LFS file download
           submodules: recursive
           fetch-depth: 0
-
-
+      # Check if the File is in the build with correct size
+      - name: Verify LFS Download
+        run: |
+          ls -lh app/src/main/assets/RFC_model_ir9_opset19.onnx
+          du -sh app/src/main/assets/RFC_model_ir9_opset19.onnx
 
       - name: Enable KVM group perms
         run: |
@@ -97,7 +104,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --info
+
       # New Steps: Building the Signed APK
+
       - name: Decode the base64-encoded keystore
         run: echo "${{ secrets.SIGNING_KEY }}" | base64 --decode > ./keystore.jks
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -97,8 +97,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --info
-
       # New Steps: Building the Signed APK
+      - name: Verify APK Contents
+        run: |
+          unzip -l app/build/outputs/apk/release/app-release.apk | grep -E "RFC_model_ir9_opset19.onnx|hand_landmarker.task"
+      - name: List Assets Directory Contents
+        run: ls -la app/src/main/assets
 
       - name: Decode the base64-encoded keystore
         run: echo "${{ secrets.SIGNING_KEY }}" | base64 --decode > ./keystore.jks

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -98,12 +98,6 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --info
       # New Steps: Building the Signed APK
-      - name: Verify APK Contents
-        run: |
-          unzip -l app/build/outputs/apk/release/app-release.apk | grep -E "RFC_model_ir9_opset19.onnx|hand_landmarker.task"
-      - name: List Assets Directory Contents
-        run: ls -la app/src/main/assets
-
       - name: Decode the base64-encoded keystore
         run: echo "${{ secrets.SIGNING_KEY }}" | base64 --decode > ./keystore.jks
 
@@ -124,3 +118,8 @@ jobs:
         with:
           name: release apk
           path: app/build/outputs/apk/release/app-release.apk
+      - name: Verify APK Contents
+        run: |
+          unzip -l app/build/outputs/apk/release/app-release.apk | grep -E "RFC_model_ir9_opset19.onnx|hand_landmarker.task"
+      - name: List Assets Directory Contents
+        run: ls -la app/src/main/assets


### PR DESCRIPTION
## Problem
- The app requires two large model files, RFC_model_ir9_opset19.onnx (116 MB) and hand_landmarker.task (7.8 MB), for hand detection functionality. When building the APK locally, the model files were correctly included, and the app worked as expected. However, when building the APK in the CI environment, the models were either missing or corrupted, causing the app's hand detection feature to fail.

## Solution
To resolve this issue, I:

- Configured Git LFS for Large Files: Added RFC_model_ir9_opset19.onnx and hand_landmarker.task to Git LFS due to their large sizes, ensuring they could be properly managed and stored in the repository without exceeding Git's standard file size limits.

- Updated CI Pipeline to Handle Git LFS Files:

- Installed Git LFS in the CI environment to ensure that large files are fetched properly.
Enabled LFS support in the checkout action by setting lfs: true, ensuring that the actual model files were downloaded rather than just pointers.
- Verified File Presence in CI Build: Added a verification step in the CI workflow to check that the model files were present and correctly downloaded before the APK build process.
- Confirmed that the file sizes matched expectations (116 MB for RFC_model_ir9_opset19.onnx and 7.8 MB for hand_landmarker.task), ensuring they were fully included in the APK.

After implementing these changes, the CI-built APK now includes the required model files, allowing the hand detection functionality to work correctly.