### PR TITLE
Streaks implementation

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/UtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/UtilsTest.kt
@@ -410,7 +410,7 @@ class UtilsTest {
     composeTestRule.onNodeWithTag("ProfilePicture").assertExists()
     composeTestRule.onNodeWithTag("StreakCounter").assertIsDisplayed()
     composeTestRule.onNodeWithTag("FlameIcon").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("NumberOfDays").assertTextEquals("10 days")
+    composeTestRule.onNodeWithTag("NumberOfDays").assertTextEquals("10")
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/UtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/UtilsTest.kt
@@ -382,7 +382,7 @@ class UtilsTest {
 
   @Test
   fun streakCounterIsDisplayed() {
-    composeTestRule.setContent { StreakCounter(10, false) }
+    composeTestRule.setContent { StreakCounter(10) }
 
     composeTestRule.onNodeWithTag("StreakCounter").assertIsDisplayed()
     composeTestRule.onNodeWithTag("FlameIcon").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/HomeScreenTest.kt
@@ -44,7 +44,6 @@ class HomeScreenTest {
     composeTestRule.onNodeWithTag("LetterDictionaryBack").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("LetterDictionaryForward").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("ExerciseListPager").performScrollTo().assertIsDisplayed()
-    composeTestRule.onNodeWithTag("StreakCounter").performScrollTo().assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
@@ -24,7 +24,12 @@ class FriendsListScreenTest {
 
   private val currentFriends = mutableStateListOf("Alice", "Bob", "Charlie", "Sam")
   private val friendRequests = mutableStateListOf("Dave", "Eve", "Daniel", "Leo")
-  private val testUser = User(uid = "testUserId", name = "Test User") // Test user data
+  private val testUser =
+      User(
+          uid = "testUserId",
+          name = "Test User",
+          currentStreak = 0L,
+          highestStreak = 0L) // Test user data
 
   private lateinit var navigationActions: NavigationActions
   private lateinit var userRepository: UserRepository
@@ -192,7 +197,12 @@ class FriendsListScreenTest {
   @Test
   fun removeFriendAfterSearch() {
     // Arrange
-    val friendUser = User(uid = "Alice", name = "Friend User") // Simulated friend user data
+    val friendUser =
+        User(
+            uid = "Alice",
+            name = "Friend User",
+            currentStreak = 0L,
+            highestStreak = 0L) // Simulated friend user data
     userViewModel.setSearchResult(friendUser) // Simulate search result with existing friend
 
     // Act

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.se.signify.model.user.User
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.model.user.UserViewModel
+import com.github.se.signify.ui.ProfilePicture
 import com.github.se.signify.ui.navigation.NavigationActions
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -35,9 +36,9 @@ class FriendsListScreenTest {
   private lateinit var userRepository: UserRepository
   private lateinit var userViewModel: UserViewModel
 
+  @Suppress("UNCHECKED_CAST")
   @Before
   fun setUp() {
-
     navigationActions = mock(NavigationActions::class.java)
     userRepository = mock(UserRepository::class.java)
 
@@ -60,9 +61,11 @@ class FriendsListScreenTest {
         .getRequestsFriendsList(Mockito.anyString(), anyOrNull(), anyOrNull())
 
     userViewModel = UserViewModel(userRepository)
+    val picturePath = "file:///path/to/profile/picture.jpg"
 
     composeTestRule.setContent {
       FriendsListScreen(navigationActions, userRepository, userViewModel)
+      ProfilePicture(picturePath)
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/MyStatsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/MyStatsScreenTest.kt
@@ -55,7 +55,7 @@ class MyStatsScreenTest {
     composeTestRule.onNodeWithTag("StreakCounter").assertIsDisplayed()
     composeTestRule.onNodeWithTag("FlameIcon").assertIsDisplayed()
     composeTestRule.onNodeWithTag("NumberOfDays").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("NumberOfDays").assertTextEquals("$numberOfDays days")
+    composeTestRule.onNodeWithTag("NumberOfDays").assertTextEquals("$numberOfDays")
 
     // Verify letters learned section displays correctly
     composeTestRule.onNodeWithTag("AllLetterLearned").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/MyStatsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/MyStatsScreenTest.kt
@@ -19,7 +19,7 @@ class MyStatsScreenTest {
   private val userId = "userIdTest"
   private val userName = "userNameTest"
   private val profilePictureUrl = "file:///path/to/profile/picture.jpg"
-  private val numberOfDays = 10
+  private val numberOfDays = 10L
   private val lettersLearned = listOf('A', 'B', 'C', 'D', 'E', 'F')
   private val exercisesAchieved = listOf(10, 3)
   private val questsAchieved = listOf(4, 0)

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
@@ -31,7 +31,6 @@ class ProfileScreenTest {
   // User information test to be displayed
   private val userId =
       FirebaseAuth.getInstance().currentUser?.email?.split("@")?.get(0) ?: "unknown"
-  private val numberOfDays = 30
 
   @Before
   fun setUp() {
@@ -90,7 +89,6 @@ class ProfileScreenTest {
     composeTestRule.onNodeWithTag("StreakCounter").assertIsDisplayed()
     composeTestRule.onNodeWithTag("FlameIcon").assertIsDisplayed()
     composeTestRule.onNodeWithTag("NumberOfDays").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("NumberOfDays").assertTextEquals("$numberOfDays days")
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
@@ -40,7 +40,6 @@ class ProfileScreenTest {
     val picturePath = "file:///path/to/profile/picture.jpg"
 
     `when`(navigationActions.currentRoute()).thenReturn(Screen.PROFILE)
-    // Initialize the state of isHelpBoxVisible to true
     composeTestRule.setContent {
       ProfileScreen(navigationActions, userViewModel)
       ProfilePicture(picturePath)

--- a/app/src/main/java/com/github/se/signify/model/user/SaveUserToFireStore.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/SaveUserToFireStore.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
+import java.time.LocalDate
 
 fun saveUserToFireStore() {
   val auth = FirebaseAuth.getInstance()
@@ -27,8 +28,10 @@ fun saveUserToFireStore() {
             "friends" to emptyList<String>(), // Initialize the friends list
             "friendRequests" to emptyList<String>(), // Initialize the friend requests list
             "ongoingChallenges" to emptyList<String>(), // Initialize the ongoing challenges list
-            "pastChallenges" to emptyList<String>() // Initialize the past challenges list
-            )
+            "pastChallenges" to emptyList<String>(), // Initialize the past challenges list
+            "lastLoginDate" to LocalDate.now().toString(),
+            "currentStreak" to 1L,
+            "highestStreak" to 1L)
 
     // Check if the user already exists in FireStore
     val usersCollection = db.collection(collectionPath)

--- a/app/src/main/java/com/github/se/signify/model/user/User.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/User.kt
@@ -10,6 +10,6 @@ data class User(
     val ongoingChallenges: List<String> = emptyList(), // New field for ongoing challenges
     val pastChallenges: List<String> = emptyList(), // New field for past challenges
     val lastLoginDate: String = "",
-    val currentStreak: Long,
-    val highestStreak: Long
+    val currentStreak: Long = 1L,
+    val highestStreak: Long = 1L
 )

--- a/app/src/main/java/com/github/se/signify/model/user/User.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/User.kt
@@ -8,5 +8,8 @@ data class User(
     val friendRequests: List<String> = emptyList(),
     val friends: List<String> = emptyList(),
     val ongoingChallenges: List<String> = emptyList(), // New field for ongoing challenges
-    val pastChallenges: List<String> = emptyList() // New field for past challenges
+    val pastChallenges: List<String> = emptyList(), // New field for past challenges
+    val lastLoginDate: String = "",
+    val currentStreak: Long,
+    val highestStreak: Long
 )

--- a/app/src/main/java/com/github/se/signify/model/user/UserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/UserRepository.kt
@@ -102,4 +102,8 @@ interface UserRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   )
+
+  fun updateStreak(userId: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+
+  fun getStreak(userId: String, onSuccess: (Long) -> Unit, onFailure: (Exception) -> Unit)
 }

--- a/app/src/main/java/com/github/se/signify/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/UserViewModel.kt
@@ -36,6 +36,9 @@ open class UserViewModel(private val repository: UserRepository) : ViewModel() {
   private val _unlockedQuests = MutableStateFlow("1")
   val unlockedQuests: StateFlow<String> = _unlockedQuests
 
+  private val _streak = MutableStateFlow(0L)
+  val streak: StateFlow<Long> = _streak
+
   private val logTag = "UserViewModel"
 
   init {
@@ -185,7 +188,7 @@ open class UserViewModel(private val repository: UserRepository) : ViewModel() {
     val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
     val start = dateFormat.parse(startDate)
     val end = dateFormat.parse(endDate)
-    val diff = end.time - start.time
+    val diff = end!!.time - start!!.time
     return TimeUnit.MILLISECONDS.toDays(diff)
   }
 
@@ -222,5 +225,19 @@ open class UserViewModel(private val repository: UserRepository) : ViewModel() {
         onFailure = { e ->
           Log.e("UserViewModel", "Failed to get initial quest access date: ${e.message}")
         })
+  }
+
+  fun updateStreak(currentUserId: String) {
+    repository.updateStreak(
+        currentUserId,
+        onSuccess = { Log.d(logTag, "Streak update successful!") },
+        onFailure = { e -> Log.e(logTag, "Error updating streak: ${e.message}") })
+  }
+
+  fun getStreak(currentUserId: String) {
+    repository.getStreak(
+        currentUserId,
+        onSuccess = { s -> _streak.value = s },
+        onFailure = { e -> Log.e(logTag, "Failed to get user's streak: ${e.message}}") })
   }
 }

--- a/app/src/main/java/com/github/se/signify/ui/Utils.kt
+++ b/app/src/main/java/com/github/se/signify/ui/Utils.kt
@@ -540,11 +540,9 @@ fun LearnedLetterList(lettersLearned: List<Char>) {
  * A reusable composable function that creates the streak counter.
  *
  * @param days A long value for the number of days (streak).
- * @param daysText A boolean value => true will display the string " days" after the number.
  */
 @Composable
-fun StreakCounter(days: Long, daysText: Boolean) {
-  val text = if (!daysText) "" else if (days == 1L) " day" else " days"
+fun StreakCounter(days: Long) {
   Row(
       modifier = Modifier.testTag("StreakCounter"),
       verticalAlignment = Alignment.CenterVertically) {
@@ -555,7 +553,7 @@ fun StreakCounter(days: Long, daysText: Boolean) {
             modifier = Modifier.size(32.dp).testTag("FlameIcon"))
         Spacer(modifier = Modifier.width(4.dp))
         Text(
-            text = "$days$text",
+            text = "$days",
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.secondary,
             fontSize = 20.sp,
@@ -601,7 +599,7 @@ fun ProfilePicture(profilePictureUrl: String?) {
 fun AccountInformation(userId: String, userName: String, profilePictureUrl: String?, days: Long) {
   Row(
       modifier = Modifier.fillMaxWidth().testTag("UserInfo"),
-      horizontalArrangement = Arrangement.Center,
+      horizontalArrangement = Arrangement.SpaceBetween,
       verticalAlignment = Alignment.CenterVertically) {
         // User Info : user id and user name
         Column(
@@ -618,14 +616,12 @@ fun AccountInformation(userId: String, userName: String, profilePictureUrl: Stri
               color = MaterialTheme.colorScheme.onBackground,
               modifier = Modifier.testTag("UserName"))
         }
-        Spacer(modifier = Modifier.width(24.dp))
 
         // Profile Picture
         ProfilePicture(profilePictureUrl)
-        Spacer(modifier = Modifier.width(24.dp))
 
         // Number of days
-        StreakCounter(days, true)
+        StreakCounter(days)
       }
 }
 

--- a/app/src/main/java/com/github/se/signify/ui/Utils.kt
+++ b/app/src/main/java/com/github/se/signify/ui/Utils.kt
@@ -540,12 +540,12 @@ fun LearnedLetterList(lettersLearned: List<Char>) {
 /**
  * A reusable composable function that creates the streak counter.
  *
- * @param days An int value for the number of days (streak).
+ * @param days A long value for the number of days (streak).
  * @param daysText A boolean value => true will display the string " days" after the number.
  */
 @Composable
-fun StreakCounter(days: Int, daysText: Boolean) {
-  val text = if (daysText) " days" else ""
+fun StreakCounter(days: Long, daysText: Boolean) {
+  val text = if (!daysText) "" else if (days == 1L) " day" else " days"
   Row(
       modifier = Modifier.testTag("StreakCounter"),
       verticalAlignment = Alignment.CenterVertically) {
@@ -599,7 +599,7 @@ fun ProfilePicture(profilePictureUrl: String?) {
  * @param days An int value for the number of days (streak).
  */
 @Composable
-fun AccountInformation(userId: String, userName: String, profilePictureUrl: String?, days: Int) {
+fun AccountInformation(userId: String, userName: String, profilePictureUrl: String?, days: Long) {
   Row(
       modifier = Modifier.fillMaxWidth().testTag("UserInfo"),
       horizontalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
@@ -54,7 +54,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.signify.R
 import com.github.se.signify.ui.MainScreenScaffold
-import com.github.se.signify.ui.StreakCounter
 import com.github.se.signify.ui.UtilButton
 import com.github.se.signify.ui.UtilTextButton
 import com.github.se.signify.ui.getIconResId
@@ -113,7 +112,6 @@ fun HomeScreen(navigationActions: NavigationActions) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween) {
-                      StreakCounter(0, false)
                       UtilButton(
                           onClick = { navigationActions.navigateTo("Quest") },
                           buttonTestTag = "QuestsButton",

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
@@ -69,18 +69,24 @@ fun FriendsListScreen(
     LaunchedEffect(Unit) {
       userViewModel.getFriendsList(currentUserId)
       userViewModel.getRequestsFriendsList(currentUserId)
+      userViewModel.getUserName(currentUserId)
+      userViewModel.getProfilePictureUrl(currentUserId)
+      userViewModel.updateStreak(currentUserId)
+      userViewModel.getStreak(currentUserId)
     }
     val friends = userViewModel.friends.collectAsState()
     val friendsRequests = userViewModel.friendsRequests.collectAsState()
     val searchResult = userViewModel.searchResult.collectAsState()
+    val userName = userViewModel.userName.collectAsState()
+    val streak = userViewModel.streak.collectAsState()
+    val profilePicture = userViewModel.profilePictureUrl.collectAsState()
 
     // Top information
     AccountInformation(
         userId = currentUserId,
-        userName = userViewModel.getUserName(currentUserId).toString(),
-        profilePictureUrl = userViewModel.getProfilePictureUrl(currentUserId).toString(),
-        days = 10 // TODO change with days (when the user model will be updated)
-        )
+        userName = userName.value,
+        profilePictureUrl = profilePicture.value,
+        days = streak.value)
     Spacer(modifier = Modifier.height(32.dp))
 
     SearchBar { searchQuery ->

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
@@ -18,7 +18,7 @@ fun MyStatsScreen(
     userId: String,
     userName: String,
     profilePictureUrl: String?,
-    numberOfDays: Int,
+    numberOfDays: Long,
     lettersLearned: List<Char>,
     exercisesAchieved: List<Int>,
     questsAchieved: List<Int>

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
@@ -39,10 +39,13 @@ fun ProfileScreen(
     LaunchedEffect(Unit) {
       userViewModel.getUserName(currentUserId)
       userViewModel.getProfilePictureUrl(currentUserId)
+      userViewModel.updateStreak(currentUserId)
+      userViewModel.getStreak(currentUserId)
     }
 
     val userName = userViewModel.userName.collectAsState()
     val profilePictureUrl = userViewModel.profilePictureUrl.collectAsState()
+    val streak = userViewModel.streak.collectAsState()
 
     // Settings button
     UtilButton(
@@ -58,7 +61,7 @@ fun ProfileScreen(
         userId = FirebaseAuth.getInstance().currentUser?.email?.split("@")?.get(0) ?: "unknown",
         userName = userName.value,
         profilePictureUrl = profilePictureUrl.value,
-        days = 30)
+        days = streak.value)
     Spacer(modifier = Modifier.height(32.dp))
 
     // Letters learned

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
@@ -83,7 +83,6 @@ fun SettingsScreen(
         }
       }
 
-
   AnnexScreenScaffold(navigationActions = navigationActions, testTagColumn = "SettingsScreen") {
     // Editable Profile Picture
     Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
@@ -167,6 +166,7 @@ fun SettingsScreen(
     Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
       ActionButtons(
           {
+            Toast.makeText(context, "Changes canceled.", Toast.LENGTH_SHORT).show()
             newName = ""
             selectedImageUrl = profilePictureUrl.value
           },
@@ -180,6 +180,7 @@ fun SettingsScreen(
               userViewModel.updateUserName(currentUserId, newName)
             }
             userViewModel.updateProfilePictureUrl(currentUserId, selectedImageUrl)
+            Toast.makeText(context, "Changes saved.", Toast.LENGTH_SHORT).show()
           },
           MaterialTheme.colorScheme.primary,
           "Save",

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
@@ -2,6 +2,7 @@ package com.github.se.signify.ui.screens.profile
 
 import android.content.Context
 import android.net.Uri
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -194,6 +195,7 @@ fun SettingsScreen(
         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
           ActionButtons(
               {
+                Toast.makeText(context, "Changes canceled.", Toast.LENGTH_SHORT).show()
                 newName = ""
                 selectedImageUrl = profilePictureUrl.value
               },
@@ -207,6 +209,7 @@ fun SettingsScreen(
                   userViewModel.updateUserName(currentUserId, newName)
                 }
                 userViewModel.updateProfilePictureUrl(currentUserId, selectedImageUrl)
+                Toast.makeText(context, "Changes saved.", Toast.LENGTH_SHORT).show()
               },
               MaterialTheme.colorScheme.primary,
               "Save",

--- a/app/src/test/java/com/github/se/signify/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/user/UserViewModelTest.kt
@@ -100,4 +100,16 @@ class UserViewModelTest {
     userViewModel.addOngoingChallenge(currentUserId, challengeId)
     verify(userRepository).addOngoingChallenge(eq(currentUserId), eq(challengeId), any(), any())
   }
+
+  @Test
+  fun getStreak_callsRepository() {
+    userViewModel.getStreak(currentUserId)
+    verify(userRepository).getStreak(eq(currentUserId), any(), any())
+  }
+
+  @Test
+  fun updateStreak_callsRepository() {
+    userViewModel.updateStreak(currentUserId)
+    verify(userRepository).updateStreak(eq(currentUserId), any(), any())
+  }
 }


### PR DESCRIPTION
### Pull Request: Add Streak Feature to Track User Activity

_____
**Description:**

This PR introduces the **streak feature**, allowing users to track:
1. The number of consecutive days they have been connected to the application.
2. The highest streak score (not yet implemented in the UI but planned for future integration, possibly in the StatsScreen).

The following changes have been made:

- **Added functionality:**
  - `updateStreak` and `getStreak` functions in the `UserViewModel` to handle streak calculation and retrieval.

- **UI updates:**
  - Displayed the updated streak value in the `ProfileScreen`.
  - Adapted the text to handle singular cases (e.g., "1 day") in the `Utils` file.
  - Changed the streak type to `Long` for compatibility with Firestore's number representation.

- **Testing:**
  - Added unit tests for `updateStreak` and `getStreak` to ensure correct behavior.

_____
**Next Steps:**
- Display the streak on other screens, starting with the `SettingsScreen`.

_____
**Impact:**
- Enhances user engagement by tracking daily activity.
- Prepares the groundwork for additional features on the StatsScreen.

____
**Note:**

I added two lines in `SettingsScreen` to display toast messages when the user saves or cancels information. This change is unrelated to the primary purpose of this pull request, but since there are already several pull requests awaiting review, I preferred not to open a separate one for such a minor update.

___
<img width="325" alt="Capture d’écran 2024-11-14 à 02 46 49" src="https://github.com/user-attachments/assets/3ee03195-6c51-4431-9ed2-988fa895e3f8">


