### PR TITLE
Setup dependency injection for mocks

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/MainActivityTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.rule.GrantPermissionRule
 import com.github.se.signify.SignifyAppPreview
+import com.github.se.signify.model.di.AppDependencyProvider
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.model.user.UserViewModel
 import com.github.se.signify.ui.navigation.NavigationActions
@@ -37,11 +38,11 @@ class MainActivityTest {
     val context = mock(Context::class.java)
 
     composeTestRule.setContent {
-      FriendsListScreen(navigationActions, userViewModel)
-      SettingsScreen(navigationActions, userViewModel)
-      ProfileScreen(navigationActions, userViewModel)
+      FriendsListScreen(navigationActions, userRepository, userViewModel)
+      SettingsScreen(navigationActions, userRepository, userViewModel)
+      ProfileScreen(navigationActions, userRepository, userViewModel)
       // Set the content with the mocked context
-      SignifyAppPreview(context, navigationState)
+      SignifyAppPreview(context, AppDependencyProvider, navigationState)
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/MainActivityTest.kt
@@ -11,7 +11,6 @@ import androidx.test.rule.GrantPermissionRule
 import com.github.se.signify.SignifyAppPreview
 import com.github.se.signify.model.di.AppDependencyProvider
 import com.github.se.signify.model.user.UserRepository
-import com.github.se.signify.model.user.UserViewModel
 import com.github.se.signify.ui.navigation.NavigationActions
 import com.github.se.signify.ui.navigation.Route
 import com.github.se.signify.ui.navigation.Screen
@@ -34,13 +33,12 @@ class MainActivityTest {
   @Before
   fun setUp() {
     val userRepository = mock(UserRepository::class.java)
-    val userViewModel = UserViewModel(userRepository)
     val context = mock(Context::class.java)
 
     composeTestRule.setContent {
-      FriendsListScreen(navigationActions, userRepository, userViewModel)
-      SettingsScreen(navigationActions, userRepository, userViewModel)
-      ProfileScreen(navigationActions, userRepository, userViewModel)
+      FriendsListScreen(navigationActions, userRepository)
+      SettingsScreen(navigationActions, userRepository)
+      ProfileScreen(navigationActions, userRepository)
       // Set the content with the mocked context
       SignifyAppPreview(context, AppDependencyProvider, navigationState)
     }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/UtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/UtilsTest.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
 import androidx.test.rule.GrantPermissionRule
 import com.github.se.signify.R
-import com.github.se.signify.model.hand.HandLandMarkImplementation
+import com.github.se.signify.model.di.AppDependencyProvider
 import com.github.se.signify.model.hand.HandLandMarkViewModel
 import com.github.se.signify.ui.AccountInformation
 import com.github.se.signify.ui.AnnexScreenScaffold
@@ -426,8 +426,7 @@ class UtilsTest {
   @Test
   fun cameraPreview_isDisplayed() {
     val context = mock(Context::class.java)
-    val handLandMarkImplementation =
-        HandLandMarkImplementation("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
+    val handLandMarkImplementation = AppDependencyProvider.handLandMarkRepository()
     val handLandMarkViewModel = HandLandMarkViewModel(handLandMarkImplementation, context)
 
     composeTestRule.setContent { CameraPlaceholder(handLandMarkViewModel) }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/ASLRecognitionTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/ASLRecognitionTest.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.LifecycleRegistry
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
-import com.github.se.signify.model.hand.HandLandMarkImplementation
+import com.github.se.signify.model.di.AppDependencyProvider
 import com.github.se.signify.model.hand.HandLandMarkViewModel
 import com.github.se.signify.ui.navigation.NavigationActions
 import com.github.se.signify.ui.navigation.Screen
@@ -48,8 +48,7 @@ class ASLRecognitionTest : LifecycleOwner {
     val context = mock(Context::class.java)
 
     navigationActions = mock(NavigationActions::class.java)
-    val handLandMarkImplementation =
-        HandLandMarkImplementation("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
+    val handLandMarkImplementation = AppDependencyProvider.handLandMarkRepository()
     handLandMarkViewModel = HandLandMarkViewModel(handLandMarkImplementation, context)
 
     `when`(navigationActions.currentRoute()).thenReturn(Screen.PRACTICE)

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/ExerciseScreenEasyTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/ExerciseScreenEasyTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
-import com.github.se.signify.model.hand.HandLandMarkImplementation
+import com.github.se.signify.model.di.AppDependencyProvider
 import com.github.se.signify.model.hand.HandLandMarkViewModel
 import com.github.se.signify.ui.navigation.NavigationActions
 import org.junit.Before
@@ -36,8 +36,7 @@ class ExerciseScreenEasyTest {
   @Before
   fun setup() {
     val context = mock(Context::class.java)
-    val handLandMarkImplementation =
-        HandLandMarkImplementation("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
+    val handLandMarkImplementation = AppDependencyProvider.handLandMarkRepository()
     handLandMarkViewModel = HandLandMarkViewModel(handLandMarkImplementation, context)
     mockNavigationActions = mock(NavigationActions::class.java)
   }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/ExerciseScreenHardTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/ExerciseScreenHardTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.se.signify.model.hand.HandLandMarkImplementation
+import com.github.se.signify.model.di.AppDependencyProvider
 import com.github.se.signify.model.hand.HandLandMarkViewModel
 import com.github.se.signify.ui.navigation.NavigationActions
 import org.junit.Before
@@ -26,8 +26,7 @@ class ExerciseScreenHardTest {
   @Before
   fun setup() {
     val context = mock(Context::class.java)
-    val handLandMarkImplementation =
-        HandLandMarkImplementation("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
+    val handLandMarkImplementation = AppDependencyProvider.handLandMarkRepository()
     handLandMarkViewModel = HandLandMarkViewModel(handLandMarkImplementation, context)
     mockNavigationActions = mock(NavigationActions::class.java)
     composeTestRule.setContent {

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/HandLandMarkImplementationInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/HandLandMarkImplementationInstrumentedTest.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.util.Log
 import androidx.camera.core.ImageProxy
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.signify.model.hand.HandLandMarkConfig
 import com.github.se.signify.model.hand.HandLandMarkImplementation
 import junit.framework.TestCase.assertEquals
 import org.junit.Before
@@ -18,13 +19,14 @@ class HandLandMarkImplementationInstrumentedTest {
 
   private lateinit var handLandMarkImplementation: HandLandMarkImplementation
   private lateinit var context: Context
-  private val pathToTask = "main/assets/hand_landmarker.task"
-  private val pathToModel = "main/assets/RFC_model_ir9_opset19.onnx"
+  private val config =
+      HandLandMarkConfig(
+          "main/assets/hand_landmarker.task", "main/assets/RFC_model_ir9_opset19.onnx")
 
   @Before
   fun setUp() {
     context = mock(Context::class.java)
-    handLandMarkImplementation = HandLandMarkImplementation(pathToTask, pathToModel)
+    handLandMarkImplementation = HandLandMarkImplementation(config)
   }
 
   @Test
@@ -35,10 +37,8 @@ class HandLandMarkImplementationInstrumentedTest {
 
   @Test
   fun test_init_failure() {
-    val invalidPathToTask = "invalid_task"
-    val invalidPathToModel = "invalid_model"
-    val invalidHandLandMarkImplementation =
-        HandLandMarkImplementation(invalidPathToTask, invalidPathToModel)
+    val invalidConfig = HandLandMarkConfig("invalid_task", "invalid_model")
+    val invalidHandLandMarkImplementation = HandLandMarkImplementation(invalidConfig)
     invalidHandLandMarkImplementation.init(context, { assert(false) }, { assert(true) })
   }
 

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/QuestScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/QuestScreenTest.kt
@@ -2,9 +2,7 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.se.signify.model.quest.Quest
 import com.github.se.signify.model.quest.QuestRepository
-import com.github.se.signify.model.quest.QuestViewModel
 import com.github.se.signify.model.user.UserRepository
-import com.github.se.signify.model.user.UserViewModel
 import com.github.se.signify.ui.navigation.NavigationActions
 import com.github.se.signify.ui.navigation.Route
 import com.github.se.signify.ui.screens.home.QuestBox
@@ -22,8 +20,6 @@ class QuestScreenTest {
   private lateinit var questRepository: QuestRepository
   private lateinit var userRepository: UserRepository
   private lateinit var navigationActions: NavigationActions
-  private lateinit var questViewModel: QuestViewModel
-  private lateinit var userViewModel: UserViewModel
 
   private val sampleQuest =
       Quest(index = "1", title = "Sample Quest", description = "This is a sample quest description")
@@ -35,8 +31,6 @@ class QuestScreenTest {
     questRepository = mock(QuestRepository::class.java)
     userRepository = mock(UserRepository::class.java)
     navigationActions = mock(NavigationActions::class.java)
-    questViewModel = QuestViewModel(questRepository)
-    userViewModel = UserViewModel(userRepository)
 
     `when`(navigationActions.currentRoute()).thenReturn(Route.QUEST)
   }
@@ -48,8 +42,7 @@ class QuestScreenTest {
           navigationActions = navigationActions,
           userRepository = userRepository,
           questRepository = questRepository,
-          questViewModel = questViewModel,
-          userViewModel = userViewModel)
+      )
     }
 
     composeTestRule.onNodeWithTag("QuestScreen").assertIsDisplayed()
@@ -78,8 +71,7 @@ class QuestScreenTest {
           navigationActions = navigationActions,
           questRepository = questRepository,
           userRepository = userRepository,
-          questViewModel = questViewModel,
-          userViewModel = userViewModel)
+      )
     }
 
     // Check that the back button is displayed
@@ -143,8 +135,7 @@ class QuestScreenTest {
           navigationActions = navigationActions,
           questRepository = questRepository,
           userRepository = userRepository,
-          questViewModel = questViewModel,
-          userViewModel = userViewModel)
+      )
     }
 
     // Click the back button

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/QuestScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/QuestScreenTest.kt
@@ -46,6 +46,8 @@ class QuestScreenTest {
     composeTestRule.setContent {
       QuestScreen(
           navigationActions = navigationActions,
+          userRepository = userRepository,
+          questRepository = questRepository,
           questViewModel = questViewModel,
           userViewModel = userViewModel)
     }
@@ -74,6 +76,8 @@ class QuestScreenTest {
     composeTestRule.setContent {
       QuestScreen(
           navigationActions = navigationActions,
+          questRepository = questRepository,
+          userRepository = userRepository,
           questViewModel = questViewModel,
           userViewModel = userViewModel)
     }
@@ -137,6 +141,8 @@ class QuestScreenTest {
     composeTestRule.setContent {
       QuestScreen(
           navigationActions = navigationActions,
+          questRepository = questRepository,
+          userRepository = userRepository,
           questViewModel = questViewModel,
           userViewModel = userViewModel)
     }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
@@ -35,7 +35,6 @@ class FriendsListScreenTest {
 
     navigationActions = mock(NavigationActions::class.java)
     userRepository = mock(UserRepository::class.java)
-    userViewModel = UserViewModel(userRepository)
 
     // Mock getFriendsList method to return currentFriends
     doAnswer { invocation ->
@@ -55,7 +54,9 @@ class FriendsListScreenTest {
         .`when`(userRepository)
         .getRequestsFriendsList(Mockito.anyString(), anyOrNull(), anyOrNull())
 
-    composeTestRule.setContent { FriendsListScreen(navigationActions, userRepository) }
+      userViewModel = UserViewModel(userRepository)
+
+    composeTestRule.setContent { FriendsListScreen(navigationActions, userRepository, userViewModel) }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
@@ -56,7 +56,9 @@ class FriendsListScreenTest {
 
     userViewModel = UserViewModel(userRepository)
 
-    composeTestRule.setContent { FriendsListScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent {
+      FriendsListScreen(navigationActions, userRepository, userViewModel)
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
@@ -35,6 +35,7 @@ class FriendsListScreenTest {
 
     navigationActions = mock(NavigationActions::class.java)
     userRepository = mock(UserRepository::class.java)
+    userViewModel = UserViewModel(userRepository)
 
     // Mock getFriendsList method to return currentFriends
     doAnswer { invocation ->

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
@@ -54,11 +54,7 @@ class FriendsListScreenTest {
         .`when`(userRepository)
         .getRequestsFriendsList(Mockito.anyString(), anyOrNull(), anyOrNull())
 
-    userViewModel = UserViewModel(userRepository)
-
-    composeTestRule.setContent {
-      FriendsListScreen(navigationActions, userRepository, userViewModel)
-    }
+    composeTestRule.setContent { FriendsListScreen(navigationActions, userRepository) }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/FriendsListScreenTest.kt
@@ -54,9 +54,11 @@ class FriendsListScreenTest {
         .`when`(userRepository)
         .getRequestsFriendsList(Mockito.anyString(), anyOrNull(), anyOrNull())
 
-      userViewModel = UserViewModel(userRepository)
+    userViewModel = UserViewModel(userRepository)
 
-    composeTestRule.setContent { FriendsListScreen(navigationActions, userRepository, userViewModel) }
+    composeTestRule.setContent {
+      FriendsListScreen(navigationActions, userRepository, userViewModel)
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.model.user.UserViewModel
@@ -51,12 +52,12 @@ class ProfileScreenTest {
   @Test
   fun buttonsAreCorrectlyDisplayed() {
 
-    composeTestRule.onNodeWithTag("SettingsButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("InfoButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("MyFriendsButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("MyFriendsButton").assertTextEquals("My Friends")
-    composeTestRule.onNodeWithTag("MyStatsButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("MyStatsButton").assertTextEquals("My Stats")
+    composeTestRule.onNodeWithTag("SettingsButton").performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("InfoButton").performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("MyFriendsButton").performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("MyFriendsButton").performScrollTo().assertTextEquals("My Friends")
+    composeTestRule.onNodeWithTag("MyStatsButton").performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("MyStatsButton").performScrollTo().assertTextEquals("My Stats")
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
@@ -43,7 +43,7 @@ class ProfileScreenTest {
     `when`(navigationActions.currentRoute()).thenReturn(Screen.PROFILE)
     // Initialize the state of isHelpBoxVisible to true
     composeTestRule.setContent {
-      ProfileScreen(navigationActions, userRepository, userViewModel)
+      ProfileScreen(navigationActions, userRepository)
       ProfilePicture(picturePath)
     }
   }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
@@ -43,7 +43,7 @@ class ProfileScreenTest {
     `when`(navigationActions.currentRoute()).thenReturn(Screen.PROFILE)
     // Initialize the state of isHelpBoxVisible to true
     composeTestRule.setContent {
-      ProfileScreen(navigationActions, userViewModel)
+      ProfileScreen(navigationActions, userRepository, userViewModel)
       ProfilePicture(picturePath)
     }
   }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
@@ -55,7 +55,10 @@ class ProfileScreenTest {
     composeTestRule.onNodeWithTag("SettingsButton").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("InfoButton").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("MyFriendsButton").performScrollTo().assertIsDisplayed()
-    composeTestRule.onNodeWithTag("MyFriendsButton").performScrollTo().assertTextEquals("My Friends")
+    composeTestRule
+        .onNodeWithTag("MyFriendsButton")
+        .performScrollTo()
+        .assertTextEquals("My Friends")
     composeTestRule.onNodeWithTag("MyStatsButton").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("MyStatsButton").performScrollTo().assertTextEquals("My Stats")
   }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/SettingsScreenTest.kt
@@ -47,7 +47,7 @@ class SettingsScreenTest {
     val picturePath = "file:///path/to/profile/picture.jpg"
 
     composeTestRule.setContent {
-      SettingsScreen(navigationActions, userViewModel)
+      SettingsScreen(navigationActions, userRepository, userViewModel)
       ProfilePicture(picturePath)
     }
 

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/SettingsScreenTest.kt
@@ -43,11 +43,10 @@ class SettingsScreenTest {
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
     userRepository = mock(UserRepository::class.java)
-    userViewModel = UserViewModel(userRepository)
     val picturePath = "file:///path/to/profile/picture.jpg"
 
     composeTestRule.setContent {
-      SettingsScreen(navigationActions, userRepository, userViewModel)
+      SettingsScreen(navigationActions, userRepository)
       ProfilePicture(picturePath)
     }
 

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/SettingsScreenTest.kt
@@ -43,6 +43,7 @@ class SettingsScreenTest {
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
     userRepository = mock(UserRepository::class.java)
+    userViewModel = UserViewModel(userRepository)
     val picturePath = "file:///path/to/profile/picture.jpg"
 
     composeTestRule.setContent {

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -14,8 +14,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
-import com.github.se.signify.model.hand.HandLandMarkConfig
-import com.github.se.signify.model.hand.HandLandMarkImplementation
+import com.github.se.signify.model.di.AppDependencyProvider
+import com.github.se.signify.model.di.DependencyProvider
 import com.github.se.signify.model.hand.HandLandMarkViewModel
 import com.github.se.signify.ui.navigation.NavigationActions
 import com.github.se.signify.ui.navigation.Route
@@ -45,7 +45,7 @@ class MainActivity : ComponentActivity() {
         Surface(modifier = Modifier.fillMaxSize()) {
           val context = LocalContext.current
           val navigationState = MutableStateFlow<NavigationActions?>(null)
-          SignifyAppPreview(context, navigationState)
+          SignifyAppPreview(context, AppDependencyProvider, navigationState)
         }
       }
     }
@@ -54,11 +54,14 @@ class MainActivity : ComponentActivity() {
 
 @SuppressLint("StateFlowValueCalledInComposition")
 @Composable
-fun SignifyAppPreview(context: Context, navigationState: MutableStateFlow<NavigationActions?>) {
+fun SignifyAppPreview(
+    context: Context,
+    dependencyProvider: DependencyProvider,
+    navigationState: MutableStateFlow<NavigationActions?>
+) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
-  val handLandMarkImplementation =
-      HandLandMarkImplementation(HandLandMarkConfig("hand_landmarker.task", "RFC_model_ir9_opset19.onnx"))
+  val handLandMarkImplementation = dependencyProvider.handLandMarkRepository()
   val handLandMarkViewModel = HandLandMarkViewModel(handLandMarkImplementation, context)
   NavHost(navController = navController, startDestination = Route.WELCOME) {
     navigation(
@@ -82,14 +85,29 @@ fun SignifyAppPreview(context: Context, navigationState: MutableStateFlow<Naviga
       composable(Screen.CHALLENGE) { ChallengeScreen(navigationActions) }
     }
 
-    composable(Route.NEW_CHALLENGE) { NewChallengeScreen(navigationActions) }
-    composable(Route.CREATE_CHALLENGE) { CreateAChallengeScreen(navigationActions) }
+    composable(Route.NEW_CHALLENGE) {
+      NewChallengeScreen(
+          navigationActions,
+          dependencyProvider.userRepository(),
+          dependencyProvider.challengeRepository())
+    }
+    composable(Route.CREATE_CHALLENGE) {
+      CreateAChallengeScreen(
+          navigationActions,
+          dependencyProvider.userRepository(),
+          dependencyProvider.challengeRepository())
+    }
     composable(Route.CHALLENGE_HISTORY) { ChallengeHistoryScreen(navigationActions, 1, 1) }
     navigation(
         startDestination = Screen.QUEST,
         route = Route.QUEST,
     ) {
-      composable(Screen.QUEST) { QuestScreen(navigationActions) }
+      composable(Screen.QUEST) {
+        QuestScreen(
+            navigationActions,
+            dependencyProvider.questRepository(),
+            dependencyProvider.userRepository())
+      }
     }
 
     navigation(
@@ -103,9 +121,13 @@ fun SignifyAppPreview(context: Context, navigationState: MutableStateFlow<Naviga
         startDestination = Screen.PROFILE,
         route = Route.PROFILE,
     ) {
-      composable(Screen.PROFILE) { ProfileScreen(navigationActions = navigationActions) }
+      composable(Screen.PROFILE) {
+        ProfileScreen(navigationActions = navigationActions, dependencyProvider.userRepository())
+      }
 
-      composable(Route.FRIENDS) { FriendsListScreen(navigationActions) }
+      composable(Route.FRIENDS) {
+        FriendsListScreen(navigationActions, dependencyProvider.userRepository())
+      }
 
       composable(Route.STATS) {
         MyStatsScreen(
@@ -119,7 +141,9 @@ fun SignifyAppPreview(context: Context, navigationState: MutableStateFlow<Naviga
             questsAchieved = listOf(3, 0))
       }
 
-      composable(Route.SETTINGS) { SettingsScreen(navigationActions) }
+      composable(Route.SETTINGS) {
+        SettingsScreen(navigationActions, dependencyProvider.userRepository())
+      }
     }
     composable(Screen.PRACTICE) { ASLRecognition(handLandMarkViewModel, navigationActions) }
     composable(Screen.EXERCISE_EASY) {

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
+import com.github.se.signify.model.hand.HandLandMarkConfig
 import com.github.se.signify.model.hand.HandLandMarkImplementation
 import com.github.se.signify.model.hand.HandLandMarkViewModel
 import com.github.se.signify.ui.navigation.NavigationActions
@@ -57,7 +58,7 @@ fun SignifyAppPreview(context: Context, navigationState: MutableStateFlow<Naviga
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
   val handLandMarkImplementation =
-      HandLandMarkImplementation("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
+      HandLandMarkImplementation(HandLandMarkConfig("hand_landmarker.task", "RFC_model_ir9_opset19.onnx"))
   val handLandMarkViewModel = HandLandMarkViewModel(handLandMarkImplementation, context)
   NavHost(navController = navController, startDestination = Route.WELCOME) {
     navigation(

--- a/app/src/main/java/com/github/se/signify/model/challenge/ChallengeViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/ChallengeViewModel.kt
@@ -3,7 +3,6 @@ package com.github.se.signify.model.challenge
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -35,15 +34,14 @@ open class ChallengeViewModel(private val repository: ChallengeRepository) : Vie
         onFailure = { e -> Log.e(logTag, "Failed to delete challenge: ${e.message}") })
   }
 
-  // create factory
   companion object {
-    val Factory: ViewModelProvider.Factory =
-        object : ViewModelProvider.Factory {
-          @Suppress("UNCHECKED_CAST")
-          override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return ChallengeViewModel(ChallengeRepositoryFireStore(FirebaseFirestore.getInstance()))
-                as T
-          }
+    fun factory(repository: ChallengeRepository): ViewModelProvider.Factory {
+      return object : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+          return ChallengeViewModel(repository) as T
         }
+      }
+    }
   }
 }

--- a/app/src/main/java/com/github/se/signify/model/di/AppDependencyProvider.kt
+++ b/app/src/main/java/com/github/se/signify/model/di/AppDependencyProvider.kt
@@ -3,6 +3,7 @@ package com.github.se.signify.model.di
 import android.content.Context
 import com.github.se.signify.model.challenge.ChallengeRepository
 import com.github.se.signify.model.challenge.ChallengeRepositoryFireStore
+import com.github.se.signify.model.hand.HandLandMarkConfig
 import com.github.se.signify.model.hand.HandLandMarkImplementation
 import com.github.se.signify.model.hand.HandLandMarkRepository
 import com.github.se.signify.model.quest.QuestRepository
@@ -13,13 +14,15 @@ import com.google.firebase.Firebase
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestore
 
+private val appHandLandMarkConfig = HandLandMarkConfig("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
+
 class AppDependencyProvider : DependencyProvider {
     override fun provideChallengeRepository(context: Context): ChallengeRepository {
         return ChallengeRepositoryFireStore(FirebaseFirestore.getInstance())
     }
 
     override fun provideHandLandMarkRepository(context: Context): HandLandMarkRepository {
-        return HandLandMarkImplementation("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
+        return HandLandMarkImplementation(appHandLandMarkConfig)
     }
 
     override fun provideQuestRepository(context: Context): QuestRepository {

--- a/app/src/main/java/com/github/se/signify/model/di/AppDependencyProvider.kt
+++ b/app/src/main/java/com/github/se/signify/model/di/AppDependencyProvider.kt
@@ -17,19 +17,19 @@ import com.google.firebase.firestore.firestore
 private val appHandLandMarkConfig = HandLandMarkConfig("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
 
 class AppDependencyProvider : DependencyProvider {
-    override fun challengeRepository(context: Context): ChallengeRepository {
+    override fun challengeRepository(): ChallengeRepository {
         return ChallengeRepositoryFireStore(FirebaseFirestore.getInstance())
     }
 
-    override fun handLandMarkRepository(context: Context): HandLandMarkRepository {
+    override fun handLandMarkRepository(): HandLandMarkRepository {
         return HandLandMarkImplementation(appHandLandMarkConfig)
     }
 
-    override fun questRepository(context: Context): QuestRepository {
+    override fun questRepository(): QuestRepository {
         return QuestRepositoryFireStore(Firebase.firestore)
     }
 
-    override fun userRepository(context: Context): UserRepository {
+    override fun userRepository(): UserRepository {
         return UserRepositoryFireStore(Firebase.firestore)
     }
 }

--- a/app/src/main/java/com/github/se/signify/model/di/AppDependencyProvider.kt
+++ b/app/src/main/java/com/github/se/signify/model/di/AppDependencyProvider.kt
@@ -13,22 +13,23 @@ import com.google.firebase.Firebase
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestore
 
-private val appHandLandMarkConfig = HandLandMarkConfig("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
+private val appHandLandMarkConfig =
+    HandLandMarkConfig("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
 
 object AppDependencyProvider : DependencyProvider {
-    override fun challengeRepository(): ChallengeRepository {
-        return ChallengeRepositoryFireStore(FirebaseFirestore.getInstance())
-    }
+  override fun challengeRepository(): ChallengeRepository {
+    return ChallengeRepositoryFireStore(FirebaseFirestore.getInstance())
+  }
 
-    override fun handLandMarkRepository(): HandLandMarkRepository {
-        return HandLandMarkImplementation(appHandLandMarkConfig)
-    }
+  override fun handLandMarkRepository(): HandLandMarkRepository {
+    return HandLandMarkImplementation(appHandLandMarkConfig)
+  }
 
-    override fun questRepository(): QuestRepository {
-        return QuestRepositoryFireStore(Firebase.firestore)
-    }
+  override fun questRepository(): QuestRepository {
+    return QuestRepositoryFireStore(Firebase.firestore)
+  }
 
-    override fun userRepository(): UserRepository {
-        return UserRepositoryFireStore(Firebase.firestore)
-    }
+  override fun userRepository(): UserRepository {
+    return UserRepositoryFireStore(Firebase.firestore)
+  }
 }

--- a/app/src/main/java/com/github/se/signify/model/di/AppDependencyProvider.kt
+++ b/app/src/main/java/com/github/se/signify/model/di/AppDependencyProvider.kt
@@ -1,6 +1,5 @@
 package com.github.se.signify.model.di
 
-import android.content.Context
 import com.github.se.signify.model.challenge.ChallengeRepository
 import com.github.se.signify.model.challenge.ChallengeRepositoryFireStore
 import com.github.se.signify.model.hand.HandLandMarkConfig
@@ -16,7 +15,7 @@ import com.google.firebase.firestore.firestore
 
 private val appHandLandMarkConfig = HandLandMarkConfig("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
 
-class AppDependencyProvider : DependencyProvider {
+object AppDependencyProvider : DependencyProvider {
     override fun challengeRepository(): ChallengeRepository {
         return ChallengeRepositoryFireStore(FirebaseFirestore.getInstance())
     }

--- a/app/src/main/java/com/github/se/signify/model/di/AppDependencyProvider.kt
+++ b/app/src/main/java/com/github/se/signify/model/di/AppDependencyProvider.kt
@@ -17,19 +17,19 @@ import com.google.firebase.firestore.firestore
 private val appHandLandMarkConfig = HandLandMarkConfig("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
 
 class AppDependencyProvider : DependencyProvider {
-    override fun provideChallengeRepository(context: Context): ChallengeRepository {
+    override fun challengeRepository(context: Context): ChallengeRepository {
         return ChallengeRepositoryFireStore(FirebaseFirestore.getInstance())
     }
 
-    override fun provideHandLandMarkRepository(context: Context): HandLandMarkRepository {
+    override fun handLandMarkRepository(context: Context): HandLandMarkRepository {
         return HandLandMarkImplementation(appHandLandMarkConfig)
     }
 
-    override fun provideQuestRepository(context: Context): QuestRepository {
+    override fun questRepository(context: Context): QuestRepository {
         return QuestRepositoryFireStore(Firebase.firestore)
     }
 
-    override fun provideUserRepository(context: Context): UserRepository {
+    override fun userRepository(context: Context): UserRepository {
         return UserRepositoryFireStore(Firebase.firestore)
     }
 }

--- a/app/src/main/java/com/github/se/signify/model/di/AppDependencyProvider.kt
+++ b/app/src/main/java/com/github/se/signify/model/di/AppDependencyProvider.kt
@@ -1,0 +1,32 @@
+package com.github.se.signify.model.di
+
+import android.content.Context
+import com.github.se.signify.model.challenge.ChallengeRepository
+import com.github.se.signify.model.challenge.ChallengeRepositoryFireStore
+import com.github.se.signify.model.hand.HandLandMarkImplementation
+import com.github.se.signify.model.hand.HandLandMarkRepository
+import com.github.se.signify.model.quest.QuestRepository
+import com.github.se.signify.model.quest.QuestRepositoryFireStore
+import com.github.se.signify.model.user.UserRepository
+import com.github.se.signify.model.user.UserRepositoryFireStore
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.firestore
+
+class AppDependencyProvider : DependencyProvider {
+    override fun provideChallengeRepository(context: Context): ChallengeRepository {
+        return ChallengeRepositoryFireStore(FirebaseFirestore.getInstance())
+    }
+
+    override fun provideHandLandMarkRepository(context: Context): HandLandMarkRepository {
+        return HandLandMarkImplementation("hand_landmarker.task", "RFC_model_ir9_opset19.onnx")
+    }
+
+    override fun provideQuestRepository(context: Context): QuestRepository {
+        return QuestRepositoryFireStore(Firebase.firestore)
+    }
+
+    override fun provideUserRepository(context: Context): UserRepository {
+        return UserRepositoryFireStore(Firebase.firestore)
+    }
+}

--- a/app/src/main/java/com/github/se/signify/model/di/DependencyProvider.kt
+++ b/app/src/main/java/com/github/se/signify/model/di/DependencyProvider.kt
@@ -7,8 +7,8 @@ import com.github.se.signify.model.quest.QuestRepository
 import com.github.se.signify.model.user.UserRepository
 
 interface DependencyProvider {
-    fun challengeRepository(context: Context): ChallengeRepository
-    fun handLandMarkRepository(context: Context): HandLandMarkRepository
-    fun questRepository(context: Context): QuestRepository
-    fun userRepository(context: Context): UserRepository
+    fun challengeRepository(): ChallengeRepository
+    fun handLandMarkRepository(): HandLandMarkRepository
+    fun questRepository(): QuestRepository
+    fun userRepository(): UserRepository
 }

--- a/app/src/main/java/com/github/se/signify/model/di/DependencyProvider.kt
+++ b/app/src/main/java/com/github/se/signify/model/di/DependencyProvider.kt
@@ -1,14 +1,16 @@
 package com.github.se.signify.model.di
 
-import android.content.Context
 import com.github.se.signify.model.challenge.ChallengeRepository
 import com.github.se.signify.model.hand.HandLandMarkRepository
 import com.github.se.signify.model.quest.QuestRepository
 import com.github.se.signify.model.user.UserRepository
 
 interface DependencyProvider {
-    fun challengeRepository(): ChallengeRepository
-    fun handLandMarkRepository(): HandLandMarkRepository
-    fun questRepository(): QuestRepository
-    fun userRepository(): UserRepository
+  fun challengeRepository(): ChallengeRepository
+
+  fun handLandMarkRepository(): HandLandMarkRepository
+
+  fun questRepository(): QuestRepository
+
+  fun userRepository(): UserRepository
 }

--- a/app/src/main/java/com/github/se/signify/model/di/DependencyProvider.kt
+++ b/app/src/main/java/com/github/se/signify/model/di/DependencyProvider.kt
@@ -1,0 +1,14 @@
+package com.github.se.signify.model.di
+
+import android.content.Context
+import com.github.se.signify.model.challenge.ChallengeRepository
+import com.github.se.signify.model.hand.HandLandMarkRepository
+import com.github.se.signify.model.quest.QuestRepository
+import com.github.se.signify.model.user.UserRepository
+
+interface DependencyProvider {
+    fun provideChallengeRepository(context: Context): ChallengeRepository
+    fun provideHandLandMarkRepository(context: Context): HandLandMarkRepository
+    fun provideQuestRepository(context: Context): QuestRepository
+    fun provideUserRepository(context: Context): UserRepository
+}

--- a/app/src/main/java/com/github/se/signify/model/di/DependencyProvider.kt
+++ b/app/src/main/java/com/github/se/signify/model/di/DependencyProvider.kt
@@ -7,8 +7,8 @@ import com.github.se.signify.model.quest.QuestRepository
 import com.github.se.signify.model.user.UserRepository
 
 interface DependencyProvider {
-    fun provideChallengeRepository(context: Context): ChallengeRepository
-    fun provideHandLandMarkRepository(context: Context): HandLandMarkRepository
-    fun provideQuestRepository(context: Context): QuestRepository
-    fun provideUserRepository(context: Context): UserRepository
+    fun challengeRepository(context: Context): ChallengeRepository
+    fun handLandMarkRepository(context: Context): HandLandMarkRepository
+    fun questRepository(context: Context): QuestRepository
+    fun userRepository(context: Context): UserRepository
 }

--- a/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkImplementation.kt
+++ b/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkImplementation.kt
@@ -18,16 +18,17 @@ import java.nio.FloatBuffer
 import java.util.Collections
 import java.util.concurrent.Executors
 
+data class HandLandMarkConfig(val taskFile: String, val modelFile: String)
+
 /**
  * Implementation of the HandLandMarkRepository interface using MediaPipe's HandLandmarker and ONNX
  * runtime for hand landmark detection and gesture recognition. This class handles the
  * initialization of the hand landmark detection model and the gesture classification using an ONNX
  * model for American Sign Language (ASL) recognition.
  *
- * @property pathToTask The file path to the MediaPipe hand detection model.
- * @property pathToModel The file path to the ONNX model used for gesture classification.
+ * @param config Configuration object containing the file paths to the hand detection model and the ONNX model.
  */
-class HandLandMarkImplementation(private val pathToTask: String, private val pathToModel: String) :
+class HandLandMarkImplementation(private val config: HandLandMarkConfig) :
     HandLandMarkRepository {
 
   // HandLandmarker instance for detecting hand landmarks
@@ -58,7 +59,7 @@ class HandLandMarkImplementation(private val pathToTask: String, private val pat
    */
   override fun init(context: Context, onSuccess: () -> Unit, onFailure: (e: Exception) -> Unit) {
     try {
-      val baseOptions = BaseOptions.builder().setModelAssetPath(pathToTask).build()
+      val baseOptions = BaseOptions.builder().setModelAssetPath(config.taskFile).build()
 
       val options =
           HandLandmarkerOptions.builder()
@@ -77,8 +78,8 @@ class HandLandMarkImplementation(private val pathToTask: String, private val pat
 
       // Load the ONNX model from assets to a temporary file
       rfcModel =
-          context.assets.open(pathToModel).use { inputStream ->
-            val tempFile = File(context.cacheDir, pathToModel)
+          context.assets.open(config.modelFile).use { inputStream ->
+            val tempFile = File(context.cacheDir, config.modelFile)
             inputStream.copyTo(tempFile.outputStream())
             tempFile.absolutePath
           }

--- a/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkImplementation.kt
+++ b/app/src/main/java/com/github/se/signify/model/hand/HandLandMarkImplementation.kt
@@ -26,10 +26,10 @@ data class HandLandMarkConfig(val taskFile: String, val modelFile: String)
  * initialization of the hand landmark detection model and the gesture classification using an ONNX
  * model for American Sign Language (ASL) recognition.
  *
- * @param config Configuration object containing the file paths to the hand detection model and the ONNX model.
+ * @param config Configuration object containing the file paths to the hand detection model and the
+ *   ONNX model.
  */
-class HandLandMarkImplementation(private val config: HandLandMarkConfig) :
-    HandLandMarkRepository {
+class HandLandMarkImplementation(private val config: HandLandMarkConfig) : HandLandMarkRepository {
 
   // HandLandmarker instance for detecting hand landmarks
   private var handLandmarker: HandLandmarker? = null

--- a/app/src/main/java/com/github/se/signify/model/quest/QuestViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/quest/QuestViewModel.kt
@@ -2,8 +2,6 @@ package com.github.se.signify.model.quest
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.google.firebase.Firebase
-import com.google.firebase.firestore.firestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,13 +17,14 @@ open class QuestViewModel(private val repository: QuestRepository) : ViewModel()
   }
 
   companion object {
-    val Factory: ViewModelProvider.Factory =
-        object : ViewModelProvider.Factory {
-          @Suppress("UNCHECKED_CAST")
-          override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return QuestViewModel(QuestRepositoryFireStore(Firebase.firestore)) as T
-          }
+    fun factory(repository: QuestRepository): ViewModelProvider.Factory {
+      return object : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+          return QuestViewModel(repository) as T
         }
+      }
+    }
   }
 
   fun getDailyQuest() {

--- a/app/src/main/java/com/github/se/signify/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/UserViewModel.kt
@@ -4,8 +4,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.github.se.signify.model.challenge.Challenge
-import com.google.firebase.Firebase
-import com.google.firebase.firestore.firestore
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -44,13 +42,14 @@ open class UserViewModel(private val repository: UserRepository) : ViewModel() {
 
   // create factory
   companion object {
-    val Factory: ViewModelProvider.Factory =
-        object : ViewModelProvider.Factory {
-          @Suppress("UNCHECKED_CAST")
-          override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return UserViewModel(UserRepositoryFireStore(Firebase.firestore)) as T
-          }
+    fun factory(repository: UserRepository): ViewModelProvider.Factory {
+      return object : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+          return UserViewModel(repository) as T
         }
+      }
+    }
   }
 
   fun getFriendsList(currentUserId: String) {

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
@@ -31,7 +31,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.se.signify.model.challenge.ChallengeRepository
 import com.github.se.signify.model.challenge.ChallengeViewModel
+import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.model.user.UserViewModel
 import com.github.se.signify.ui.BackButton
 import com.github.se.signify.ui.navigation.NavigationActions
@@ -40,8 +42,11 @@ import com.github.se.signify.ui.screens.profile.currentUserId
 @Composable
 fun CreateAChallengeScreen(
     navigationActions: NavigationActions,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory),
-    challengeViewModel: ChallengeViewModel = viewModel(factory = ChallengeViewModel.Factory)
+    userRepository: UserRepository,
+    challengeRepository: ChallengeRepository,
+    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository)),
+    challengeViewModel: ChallengeViewModel =
+        viewModel(factory = ChallengeViewModel.factory(challengeRepository))
 ) {
   // Fetch friends list when this screen is first displayed
   LaunchedEffect(Unit) { userViewModel.getFriendsList(currentUserId) }

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
@@ -44,10 +44,11 @@ fun CreateAChallengeScreen(
     navigationActions: NavigationActions,
     userRepository: UserRepository,
     challengeRepository: ChallengeRepository,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository)),
-    challengeViewModel: ChallengeViewModel =
-        viewModel(factory = ChallengeViewModel.factory(challengeRepository))
 ) {
+  val userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
+  val challengeViewModel: ChallengeViewModel =
+      viewModel(factory = ChallengeViewModel.factory(challengeRepository))
+
   // Fetch friends list when this screen is first displayed
   LaunchedEffect(Unit) { userViewModel.getFriendsList(currentUserId) }
 

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
@@ -33,7 +33,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.signify.model.challenge.Challenge
+import com.github.se.signify.model.challenge.ChallengeRepository
 import com.github.se.signify.model.challenge.ChallengeViewModel
+import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.model.user.UserViewModel
 import com.github.se.signify.ui.BackButton
 import com.github.se.signify.ui.UtilTextButton
@@ -44,8 +46,11 @@ import com.github.se.signify.ui.screens.profile.currentUserId
 @Composable
 fun NewChallengeScreen(
     navigationActions: NavigationActions,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory),
-    challengeViewModel: ChallengeViewModel = viewModel(factory = ChallengeViewModel.Factory)
+    userRepository: UserRepository,
+    challengeRepository: ChallengeRepository,
+    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository)),
+    challengeViewModel: ChallengeViewModel =
+        viewModel(factory = ChallengeViewModel.factory(challengeRepository))
 ) {
   // Fetch friends list and ongoing challenges when this screen is first displayed
   LaunchedEffect(Unit) {

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
@@ -48,10 +48,11 @@ fun NewChallengeScreen(
     navigationActions: NavigationActions,
     userRepository: UserRepository,
     challengeRepository: ChallengeRepository,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository)),
-    challengeViewModel: ChallengeViewModel =
-        viewModel(factory = ChallengeViewModel.factory(challengeRepository))
 ) {
+  val userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
+  val challengeViewModel: ChallengeViewModel =
+      viewModel(factory = ChallengeViewModel.factory(challengeRepository))
+
   // Fetch friends list and ongoing challenges when this screen is first displayed
   LaunchedEffect(Unit) {
     userViewModel.getFriendsList(currentUserId)

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/QuestScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/QuestScreen.kt
@@ -45,7 +45,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.signify.model.quest.Quest
+import com.github.se.signify.model.quest.QuestRepository
 import com.github.se.signify.model.quest.QuestViewModel
+import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.model.user.UserViewModel
 import com.github.se.signify.ui.getLetterIconResId
 import com.github.se.signify.ui.navigation.NavigationActions
@@ -54,8 +56,10 @@ import com.github.se.signify.ui.screens.profile.currentUserId
 @Composable
 fun QuestScreen(
     navigationActions: NavigationActions,
-    questViewModel: QuestViewModel = viewModel(factory = QuestViewModel.Factory),
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory)
+    questRepository: QuestRepository,
+    userRepository: UserRepository,
+    questViewModel: QuestViewModel = viewModel(factory = QuestViewModel.factory(questRepository)),
+    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
 ) {
   val quests = questViewModel.quest.collectAsState()
   LaunchedEffect(currentUserId) { userViewModel.checkAndUnlockNextQuest(currentUserId) }

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/QuestScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/QuestScreen.kt
@@ -58,9 +58,10 @@ fun QuestScreen(
     navigationActions: NavigationActions,
     questRepository: QuestRepository,
     userRepository: UserRepository,
-    questViewModel: QuestViewModel = viewModel(factory = QuestViewModel.factory(questRepository)),
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
 ) {
+  val questViewModel: QuestViewModel = viewModel(factory = QuestViewModel.factory(questRepository))
+  val userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
+
   val quests = questViewModel.quest.collectAsState()
   LaunchedEffect(currentUserId) { userViewModel.checkAndUnlockNextQuest(currentUserId) }
 

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
@@ -61,8 +61,8 @@ val currentUserId = FirebaseAuth.getInstance().currentUser?.email?.split("@")?.g
 fun FriendsListScreen(
     navigationActions: NavigationActions,
     userRepository: UserRepository,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
 ) {
+  val userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
   var errorMessage by remember { mutableStateOf("") }
 
   Column(

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
@@ -61,8 +61,8 @@ val currentUserId = FirebaseAuth.getInstance().currentUser?.email?.split("@")?.g
 fun FriendsListScreen(
     navigationActions: NavigationActions,
     userRepository: UserRepository,
+    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
 ) {
-  val userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
   var errorMessage by remember { mutableStateOf("") }
 
   Column(

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.model.user.UserViewModel
 import com.github.se.signify.ui.BackButton
 import com.github.se.signify.ui.navigation.NavigationActions
@@ -59,7 +60,8 @@ val currentUserId = FirebaseAuth.getInstance().currentUser?.email?.split("@")?.g
 @Composable
 fun FriendsListScreen(
     navigationActions: NavigationActions,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory)
+    userRepository: UserRepository,
+    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
 ) {
   var errorMessage by remember { mutableStateOf("") }
 
@@ -299,10 +301,7 @@ fun FriendCard(name: String, actions: @Composable RowScope.() -> Unit) {
 }
 
 @Composable
-fun FriendItem(
-    friendName: String,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory)
-) {
+fun FriendItem(friendName: String, userViewModel: UserViewModel) {
   FriendCard(friendName) {
 
     // Button "Remove"
@@ -317,10 +316,7 @@ fun FriendItem(
 }
 
 @Composable
-fun FriendRequestItem(
-    friendRequestName: String,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory)
-) {
+fun FriendRequestItem(friendRequestName: String, userViewModel: UserViewModel) {
 
   FriendCard(friendRequestName) {
     Row(

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
@@ -30,8 +30,9 @@ import com.google.firebase.auth.FirebaseAuth
 fun ProfileScreen(
     navigationActions: NavigationActions,
     userRepository: UserRepository,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
 ) {
+  val userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
+
   MainScreenScaffold(
       navigationActions = navigationActions,
       testTagColumn = "ProfileScreen",

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.signify.R
+import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.model.user.UserViewModel
 import com.github.se.signify.ui.AccountInformation
 import com.github.se.signify.ui.LearnedLetterList
@@ -28,7 +29,8 @@ import com.google.firebase.auth.FirebaseAuth
 @Composable
 fun ProfileScreen(
     navigationActions: NavigationActions,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory)
+    userRepository: UserRepository,
+    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
 ) {
   MainScreenScaffold(
       navigationActions = navigationActions,

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.model.user.UserViewModel
 import com.github.se.signify.ui.BackButton
 import com.github.se.signify.ui.ProfilePicture
@@ -58,7 +59,8 @@ import java.io.FileOutputStream
 @Composable
 fun SettingsScreen(
     navigationActions: NavigationActions,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory)
+    userRepository: UserRepository,
+    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository)),
 ) {
   val context = LocalContext.current
 

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
@@ -60,8 +60,9 @@ import java.io.FileOutputStream
 fun SettingsScreen(
     navigationActions: NavigationActions,
     userRepository: UserRepository,
-    userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository)),
 ) {
+  val userViewModel: UserViewModel = viewModel(factory = UserViewModel.factory(userRepository))
+
   val context = LocalContext.current
 
   LaunchedEffect(Unit) {

--- a/app/src/test/java/com/github/se/signify/model/di/MockDependencyProvider.kt
+++ b/app/src/test/java/com/github/se/signify/model/di/MockDependencyProvider.kt
@@ -7,7 +7,7 @@ import com.github.se.signify.model.quest.QuestRepository
 import com.github.se.signify.model.user.UserRepository
 import org.mockito.Mockito.mock
 
-class MockDependencyProvider : DependencyProvider {
+object MockDependencyProvider : DependencyProvider {
     override fun challengeRepository(): ChallengeRepository {
         return mock(ChallengeRepository::class.java)
     }

--- a/app/src/test/java/com/github/se/signify/model/di/MockDependencyProvider.kt
+++ b/app/src/test/java/com/github/se/signify/model/di/MockDependencyProvider.kt
@@ -8,19 +8,19 @@ import com.github.se.signify.model.user.UserRepository
 import org.mockito.Mockito.mock
 
 class MockDependencyProvider : DependencyProvider {
-    override fun provideChallengeRepository(context: Context): ChallengeRepository {
+    override fun challengeRepository(context: Context): ChallengeRepository {
         return mock(ChallengeRepository::class.java)
     }
 
-    override fun provideHandLandMarkRepository(context: Context): HandLandMarkRepository {
+    override fun handLandMarkRepository(context: Context): HandLandMarkRepository {
         return mock(HandLandMarkRepository::class.java)
     }
 
-    override fun provideQuestRepository(context: Context): QuestRepository {
+    override fun questRepository(context: Context): QuestRepository {
         return mock(QuestRepository::class.java)
     }
 
-    override fun provideUserRepository(context: Context): UserRepository {
+    override fun userRepository(context: Context): UserRepository {
         return mock(UserRepository::class.java)
     }
 }

--- a/app/src/test/java/com/github/se/signify/model/di/MockDependencyProvider.kt
+++ b/app/src/test/java/com/github/se/signify/model/di/MockDependencyProvider.kt
@@ -8,19 +8,19 @@ import com.github.se.signify.model.user.UserRepository
 import org.mockito.Mockito.mock
 
 class MockDependencyProvider : DependencyProvider {
-    override fun challengeRepository(context: Context): ChallengeRepository {
+    override fun challengeRepository(): ChallengeRepository {
         return mock(ChallengeRepository::class.java)
     }
 
-    override fun handLandMarkRepository(context: Context): HandLandMarkRepository {
+    override fun handLandMarkRepository(): HandLandMarkRepository {
         return mock(HandLandMarkRepository::class.java)
     }
 
-    override fun questRepository(context: Context): QuestRepository {
+    override fun questRepository(): QuestRepository {
         return mock(QuestRepository::class.java)
     }
 
-    override fun userRepository(context: Context): UserRepository {
+    override fun userRepository(): UserRepository {
         return mock(UserRepository::class.java)
     }
 }

--- a/app/src/test/java/com/github/se/signify/model/di/MockDependencyProvider.kt
+++ b/app/src/test/java/com/github/se/signify/model/di/MockDependencyProvider.kt
@@ -1,6 +1,5 @@
 package com.github.se.signify.model.di
 
-import android.content.Context
 import com.github.se.signify.model.challenge.ChallengeRepository
 import com.github.se.signify.model.hand.HandLandMarkRepository
 import com.github.se.signify.model.quest.QuestRepository
@@ -8,19 +7,19 @@ import com.github.se.signify.model.user.UserRepository
 import org.mockito.Mockito.mock
 
 object MockDependencyProvider : DependencyProvider {
-    override fun challengeRepository(): ChallengeRepository {
-        return mock(ChallengeRepository::class.java)
-    }
+  override fun challengeRepository(): ChallengeRepository {
+    return mock(ChallengeRepository::class.java)
+  }
 
-    override fun handLandMarkRepository(): HandLandMarkRepository {
-        return mock(HandLandMarkRepository::class.java)
-    }
+  override fun handLandMarkRepository(): HandLandMarkRepository {
+    return mock(HandLandMarkRepository::class.java)
+  }
 
-    override fun questRepository(): QuestRepository {
-        return mock(QuestRepository::class.java)
-    }
+  override fun questRepository(): QuestRepository {
+    return mock(QuestRepository::class.java)
+  }
 
-    override fun userRepository(): UserRepository {
-        return mock(UserRepository::class.java)
-    }
+  override fun userRepository(): UserRepository {
+    return mock(UserRepository::class.java)
+  }
 }

--- a/app/src/test/java/com/github/se/signify/model/di/MockDependencyProvider.kt
+++ b/app/src/test/java/com/github/se/signify/model/di/MockDependencyProvider.kt
@@ -1,0 +1,26 @@
+package com.github.se.signify.model.di
+
+import android.content.Context
+import com.github.se.signify.model.challenge.ChallengeRepository
+import com.github.se.signify.model.hand.HandLandMarkRepository
+import com.github.se.signify.model.quest.QuestRepository
+import com.github.se.signify.model.user.UserRepository
+import org.mockito.Mockito.mock
+
+class MockDependencyProvider : DependencyProvider {
+    override fun provideChallengeRepository(context: Context): ChallengeRepository {
+        return mock(ChallengeRepository::class.java)
+    }
+
+    override fun provideHandLandMarkRepository(context: Context): HandLandMarkRepository {
+        return mock(HandLandMarkRepository::class.java)
+    }
+
+    override fun provideQuestRepository(context: Context): QuestRepository {
+        return mock(QuestRepository::class.java)
+    }
+
+    override fun provideUserRepository(context: Context): UserRepository {
+        return mock(UserRepository::class.java)
+    }
+}


### PR DESCRIPTION
## Motivation

We need to write end-to-end tests before this week's milestone. To achieve this, we must mock all internet or account related backend logic. This is done using dependency injection, where a mock class replaces default implementations of backend logic in a screen's parameters.

Clearing up space for dependency injection will also enable more in depth integration tests. Helping improve coverage for those difficult connectivity related classes.

## Changes

This PR only aims to make space for future changes. It should not affect the app's functionality in any way.
I would still recommend reviewers to thouroughly check the app's logic, as I might have inadvertently broken something.

`MainActivity's` `SignifyAppPreview` now takes a `DependencyProvider` parameter. This dependency provider is a singleton object with methods that provide the app with it's backend logic classes.

By default, the app uses `AppDependencyProvider` which provides the expeted classes, such as `UserRepositoryFirestore`. In the future, end-to-end tests will use `MockDependencyProvider` which will replace backend logic with simpler and offline mock versions of these classes. These mock classes have not yet been implemented.

This change allows developers to freely define new dependency providers, that alter the backend logic of the app for testing or demo purposes.

## Future changes

The current implementation of the login screen uses Google authentication through Firebase directly. This login logic must be moved behind an `interface class` so that it can be mocked. Mocking the login screen is essential to writing end-to-end tests.

At the moment, `MockDependencyProvider` only injects dummy classes into the app. It should be augmented with actual mocks of backend logic to allow for realistic system tests or integration tests.

Finally, we obviously need to write end-to-end tests that use this mock dependency injection.