### PR TITLE
Update the challenge creation screen to use common elements from Utils.kt

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreenTest.kt
@@ -3,6 +3,7 @@ package com.github.se.signify.ui.screens.challenge
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.github.se.signify.model.challenge.ChallengeMode
 import com.github.se.signify.model.challenge.ChallengeRepository
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.ui.navigation.NavigationActions
@@ -101,7 +102,7 @@ class CreateAChallengeScreenTest {
     composeTestRule.onNodeWithTag("SendChallengeButton").performClick()
     // Verify that sendChallengeRequest and addOngoingChallenge were called
     verify(challengeRepository)
-        .sendChallengeRequest(eq(currentUserId), eq(friend), eq("sprint"), any(), any(), any())
+        .sendChallengeRequest(eq(currentUserId), eq(friend), eq(ChallengeMode.SPRINT), any(), any(), any())
     verify(userRepository).addOngoingChallenge(eq(currentUserId), any(), any(), any())
     verify(userRepository).addOngoingChallenge(eq(friend), any(), any(), any())
   }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreenTest.kt
@@ -102,7 +102,8 @@ class CreateAChallengeScreenTest {
     composeTestRule.onNodeWithTag("SendChallengeButton").performClick()
     // Verify that sendChallengeRequest and addOngoingChallenge were called
     verify(challengeRepository)
-        .sendChallengeRequest(eq(currentUserId), eq(friend), eq(ChallengeMode.SPRINT), any(), any(), any())
+        .sendChallengeRequest(
+            eq(currentUserId), eq(friend), eq(ChallengeMode.SPRINT), any(), any(), any())
     verify(userRepository).addOngoingChallenge(eq(currentUserId), any(), any(), any())
     verify(userRepository).addOngoingChallenge(eq(friend), any(), any(), any())
   }

--- a/app/src/main/java/com/github/se/signify/model/challenge/ChallengeRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/ChallengeRepository.kt
@@ -4,7 +4,7 @@ interface ChallengeRepository {
   fun sendChallengeRequest(
       player1Id: String,
       player2Id: String,
-      mode: String,
+      mode: ChallengeMode,
       challengeId: String,
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit

--- a/app/src/main/java/com/github/se/signify/model/challenge/ChallengeRepositoryFireStore.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/ChallengeRepositoryFireStore.kt
@@ -9,7 +9,7 @@ class ChallengeRepositoryFireStore(private val db: FirebaseFirestore) : Challeng
   override fun sendChallengeRequest(
       player1Id: String,
       player2Id: String,
-      mode: String,
+      mode: ChallengeMode,
       challengeId: String,
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
@@ -21,7 +21,7 @@ class ChallengeRepositoryFireStore(private val db: FirebaseFirestore) : Challeng
             "player2" to player2Id,
             "status" to "pending",
             "round" to 1,
-            "mode" to mode,
+            "mode" to mode.name,
             "player1Score" to 0,
             "player2Score" to 0,
             "currentGesture" to "",

--- a/app/src/main/java/com/github/se/signify/model/challenge/ChallengeViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/ChallengeViewModel.kt
@@ -6,6 +6,11 @@ import androidx.lifecycle.ViewModelProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
+enum class ChallengeMode(val modeName: String) {
+    SPRINT("Sprint"),
+    CHRONO("Chrono"),
+}
+
 open class ChallengeViewModel(private val repository: ChallengeRepository) : ViewModel() {
   private val _challenge = MutableStateFlow<Challenge?>(null)
   val challenge: StateFlow<Challenge?> = _challenge
@@ -15,7 +20,7 @@ open class ChallengeViewModel(private val repository: ChallengeRepository) : Vie
   fun sendChallengeRequest(
       player1Id: String,
       player2Id: String,
-      mode: String,
+      mode: ChallengeMode,
       challengeId: String
   ) {
     repository.sendChallengeRequest(

--- a/app/src/main/java/com/github/se/signify/model/challenge/ChallengeViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/ChallengeViewModel.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 enum class ChallengeMode(val modeName: String) {
-    SPRINT("Sprint"),
-    CHRONO("Chrono"),
+  SPRINT("Sprint"),
+  CHRONO("Chrono"),
 }
 
 open class ChallengeViewModel(private val repository: ChallengeRepository) : ViewModel() {

--- a/app/src/main/java/com/github/se/signify/ui/Utils.kt
+++ b/app/src/main/java/com/github/se/signify/ui/Utils.kt
@@ -159,13 +159,13 @@ fun UtilTextButton(
       modifier = Modifier.fillMaxWidth().height(40.dp).testTag(testTag),
       enabled = enabled,
   ) {
-        Text(
-            text,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface,
-            fontSize = 20.sp,
-            textAlign = TextAlign.Center)
-      }
+    Text(
+        text,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onSurface,
+        fontSize = 20.sp,
+        textAlign = TextAlign.Center)
+  }
 }
 
 /**

--- a/app/src/main/java/com/github/se/signify/ui/Utils.kt
+++ b/app/src/main/java/com/github/se/signify/ui/Utils.kt
@@ -140,6 +140,7 @@ fun UtilIconButton(onClickAction: () -> Unit, icon: ImageVector, iconDescription
  * @param testTag A string used for testing, which serves as the tag for the button.
  * @param text The text to be displayed inside the button.
  * @param backgroundColor The background color of the button.
+ * @param enabled A boolean value indicating whether the button is enabled.
  */
 @Composable
 fun UtilTextButton(
@@ -147,6 +148,7 @@ fun UtilTextButton(
     testTag: String,
     text: String,
     backgroundColor: Color,
+    enabled: Boolean = true,
 ) {
   OutlinedButton(
       onClick = onClickAction,
@@ -154,7 +156,9 @@ fun UtilTextButton(
           ButtonDefaults.outlinedButtonBorder.copy(
               width = 2.dp, brush = SolidColor(MaterialTheme.colorScheme.outline)),
       colors = ButtonDefaults.buttonColors(backgroundColor),
-      modifier = Modifier.fillMaxWidth().height(40.dp).testTag(testTag)) {
+      modifier = Modifier.fillMaxWidth().height(40.dp).testTag(testTag),
+      enabled = enabled,
+  ) {
         Text(
             text,
             fontWeight = FontWeight.Bold,

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
@@ -97,15 +97,6 @@ fun CreateAChallengeScreen(
                             backgroundColor = MaterialTheme.colorScheme.primary,
                         )
                     }
-                        Button(
-                            onClick = {
-                                selectedFriendId = friendId
-                                showDialog = true
-                            },
-                            modifier =
-                            Modifier.padding(8.dp).testTag("ChallengeButton_$friendId")) {
-                            Text("Challenge")
-                        }
                     }
                 }
             }

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
@@ -3,7 +3,6 @@ package com.github.se.signify.ui.screens.challenge
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -60,56 +58,56 @@ fun CreateAChallengeScreen(
   var selectedFriendId by remember { mutableStateOf<String?>(null) }
   var showDialog by remember { mutableStateOf(false) }
 
-    AnnexScreenScaffold(
-        navigationActions = navigationActions,
-        testTagColumn = "CreateAChallengeContent",
-    ) {
-        // Title
-        Text(
-            text = "Select a Friend to Challenge",
-            fontSize = 24.sp,
-            modifier = Modifier.testTag("ChallengeTitle"))
+  AnnexScreenScaffold(
+      navigationActions = navigationActions,
+      testTagColumn = "CreateAChallengeContent",
+  ) {
+    // Title
+    Text(
+        text = "Select a Friend to Challenge",
+        fontSize = 24.sp,
+        modifier = Modifier.testTag("ChallengeTitle"))
 
-        Spacer(modifier = Modifier.height(16.dp))
+    Spacer(modifier = Modifier.height(16.dp))
 
-        // Conditional display for friends list
-        if (friends.isEmpty()) {
-            Text(
-                text = "No friends available",
-                fontSize = 18.sp,
-                color = Color.Gray,
-                modifier = Modifier.testTag("NoFriendsText"))
-        } else {
-            // List of Friends
-            LazyColumn(
-                modifier = Modifier.fillMaxSize().weight(1f).testTag("FriendsList"),
-                verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                items(friends.size) { index ->
-                    val friendId = friends[index]
-                    FriendCard(friendId = friendId) {
-                        UtilTextButton(
-                            onClickAction = {
-                                selectedFriendId = friendId
-                                showDialog = true
-                            },
-                            testTag = "ChallengeButton_$friendId",
-                            text = "Challenge",
-                            backgroundColor = MaterialTheme.colorScheme.primary,
-                        )
-                    }
-                    }
-                }
+    // Conditional display for friends list
+    if (friends.isEmpty()) {
+      Text(
+          text = "No friends available",
+          fontSize = 18.sp,
+          color = Color.Gray,
+          modifier = Modifier.testTag("NoFriendsText"))
+    } else {
+      // List of Friends
+      LazyColumn(
+          modifier = Modifier.fillMaxSize().weight(1f).testTag("FriendsList"),
+          verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            items(friends.size) { index ->
+              val friendId = friends[index]
+              FriendCard(friendId = friendId) {
+                UtilTextButton(
+                    onClickAction = {
+                      selectedFriendId = friendId
+                      showDialog = true
+                    },
+                    testTag = "ChallengeButton_$friendId",
+                    text = "Challenge",
+                    backgroundColor = MaterialTheme.colorScheme.primary,
+                )
+              }
             }
-        }
+          }
+    }
+  }
 
-        // Show Challenge Dialog if showDialog is true
-        if (showDialog && selectedFriendId != null) {
-            ChallengeModeAlertDialog(
-                friendId = selectedFriendId!!,
-                onDismiss = { showDialog = false },
-                userViewModel = userViewModel,
-                challengeViewModel = challengeViewModel)
-        }
+  // Show Challenge Dialog if showDialog is true
+  if (showDialog && selectedFriendId != null) {
+    ChallengeModeAlertDialog(
+        friendId = selectedFriendId!!,
+        onDismiss = { showDialog = false },
+        userViewModel = userViewModel,
+        challengeViewModel = challengeViewModel)
+  }
 }
 
 @Composable
@@ -154,49 +152,49 @@ fun ChallengeModeAlertDialog(
   AlertDialog(
       onDismissRequest = onDismiss,
       confirmButton = {
-          UtilTextButton(
-              onClickAction = {
-                  if (selectedMode.value != null) {
-                      // Create the challenge in the challenges collection
-                      challengeViewModel.sendChallengeRequest(
-                          currentUserId, friendId, selectedMode.value!!, challengeId)
+        UtilTextButton(
+            onClickAction = {
+              if (selectedMode.value != null) {
+                // Create the challenge in the challenges collection
+                challengeViewModel.sendChallengeRequest(
+                    currentUserId, friendId, selectedMode.value!!, challengeId)
 
-                      // Add the challenge to the users' ongoing challenges
-                      userViewModel.addOngoingChallenge(currentUserId, challengeId)
-                      userViewModel.addOngoingChallenge(friendId, challengeId)
+                // Add the challenge to the users' ongoing challenges
+                userViewModel.addOngoingChallenge(currentUserId, challengeId)
+                userViewModel.addOngoingChallenge(friendId, challengeId)
 
-                      onDismiss() // Close the dialog after creating the challenge
-                  }
-              },
-              testTag = "SendChallengeButton",
-              text = "Send Challenge",
-              backgroundColor = MaterialTheme.colorScheme.primary,
-              enabled = selectedMode.value != null,
-          )
+                onDismiss() // Close the dialog after creating the challenge
+              }
+            },
+            testTag = "SendChallengeButton",
+            text = "Send Challenge",
+            backgroundColor = MaterialTheme.colorScheme.primary,
+            enabled = selectedMode.value != null,
+        )
       },
       dismissButton = {
-          UtilTextButton(
-              onClickAction = onDismiss,
-              testTag = "CancelButton",
-              text = "Cancel",
-              backgroundColor = MaterialTheme.colorScheme.surface,
-          )
+        UtilTextButton(
+            onClickAction = onDismiss,
+            testTag = "CancelButton",
+            text = "Cancel",
+            backgroundColor = MaterialTheme.colorScheme.surface,
+        )
       },
       title = { Text(text = "Pick a Mode", modifier = Modifier.testTag("DialogTitle")) },
       text = {
-          Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-          ) {
-              ChallengeMode.entries.forEach { mode ->
-                  Box (Modifier.weight(1f)){
-                      ModeButton(
-                          mode = mode,
-                          selectedMode = selectedMode,
-                      )
-                  }
-              }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+          ChallengeMode.entries.forEach { mode ->
+            Box(Modifier.weight(1f)) {
+              ModeButton(
+                  mode = mode,
+                  selectedMode = selectedMode,
+              )
+            }
           }
+        }
       })
 }
 
@@ -209,6 +207,8 @@ fun ModeButton(
       onClickAction = { selectedMode.value = mode },
       testTag = "${mode.modeName}ModeButton",
       text = mode.modeName,
-      backgroundColor = if (selectedMode.value == mode) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface,
-      )
+      backgroundColor =
+          if (selectedMode.value == mode) MaterialTheme.colorScheme.primary
+          else MaterialTheme.colorScheme.surface,
+  )
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults.buttonColors
 import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,7 +36,10 @@ import com.github.se.signify.model.challenge.ChallengeRepository
 import com.github.se.signify.model.challenge.ChallengeViewModel
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.model.user.UserViewModel
+import com.github.se.signify.ui.AnnexScreenScaffold
 import com.github.se.signify.ui.BackButton
+import com.github.se.signify.ui.UtilButton
+import com.github.se.signify.ui.UtilTextButton
 import com.github.se.signify.ui.navigation.NavigationActions
 import com.github.se.signify.ui.screens.profile.currentUserId
 
@@ -56,64 +60,56 @@ fun CreateAChallengeScreen(
   var selectedFriendId by remember { mutableStateOf<String?>(null) }
   var showDialog by remember { mutableStateOf(false) }
 
-  Scaffold(
-      topBar = { BackButton { navigationActions.goBack() } },
-      content = { padding ->
-        Column(
-            modifier =
-                Modifier.fillMaxSize()
-                    .padding(padding)
-                    .padding(16.dp)
-                    .testTag("CreateAChallengeContent"),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Top) {
-              // Title
-              Text(
-                  text = "Select a Friend to Challenge",
-                  fontSize = 24.sp,
-                  modifier = Modifier.testTag("ChallengeTitle"))
+    AnnexScreenScaffold(
+        navigationActions = navigationActions,
+        testTagColumn = "CreateAChallengeContent",
+    ) {
+        // Title
+        Text(
+            text = "Select a Friend to Challenge",
+            fontSize = 24.sp,
+            modifier = Modifier.testTag("ChallengeTitle"))
 
-              Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-              // Conditional display for friends list
-              if (friends.isEmpty()) {
-                Text(
-                    text = "No friends available",
-                    fontSize = 18.sp,
-                    color = Color.Gray,
-                    modifier = Modifier.testTag("NoFriendsText"))
-              } else {
-                // List of Friends
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize().testTag("FriendsList"),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                      items(friends.size) { index ->
-                        val friendId = friends[index]
-                        FriendCard(friendId = friendId) {
-                          Button(
-                              onClick = {
+        // Conditional display for friends list
+        if (friends.isEmpty()) {
+            Text(
+                text = "No friends available",
+                fontSize = 18.sp,
+                color = Color.Gray,
+                modifier = Modifier.testTag("NoFriendsText"))
+        } else {
+            // List of Friends
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().weight(1f).testTag("FriendsList"),
+                verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                items(friends.size) { index ->
+                    val friendId = friends[index]
+                    FriendCard(friendId = friendId) {
+                        Button(
+                            onClick = {
                                 selectedFriendId = friendId
                                 showDialog = true
-                              },
-                              modifier =
-                                  Modifier.padding(8.dp).testTag("ChallengeButton_$friendId")) {
-                                Text("Challenge")
-                              }
+                            },
+                            modifier =
+                            Modifier.padding(8.dp).testTag("ChallengeButton_$friendId")) {
+                            Text("Challenge")
                         }
-                      }
                     }
-              }
-
-              // Show Challenge Dialog if showDialog is true
-              if (showDialog && selectedFriendId != null) {
-                ChallengeModeAlertDialog(
-                    friendId = selectedFriendId!!,
-                    onDismiss = { showDialog = false },
-                    userViewModel = userViewModel,
-                    challengeViewModel = challengeViewModel)
-              }
+                }
             }
-      })
+        }
+
+        // Show Challenge Dialog if showDialog is true
+        if (showDialog && selectedFriendId != null) {
+            ChallengeModeAlertDialog(
+                friendId = selectedFriendId!!,
+                onDismiss = { showDialog = false },
+                userViewModel = userViewModel,
+                challengeViewModel = challengeViewModel)
+        }
+    }
 }
 
 @Composable
@@ -155,50 +151,51 @@ fun ChallengeModeAlertDialog(
   AlertDialog(
       onDismissRequest = onDismiss,
       confirmButton = {
-        Button(
-            onClick = {
-              if (selectedMode != null) {
-                // Create the challenge in the challenges collection
-                challengeViewModel.sendChallengeRequest(
-                    currentUserId, friendId, selectedMode!!, challengeId)
+          UtilTextButton(
+              onClickAction = {
+                  if (selectedMode != null) {
+                      // Create the challenge in the challenges collection
+                      challengeViewModel.sendChallengeRequest(
+                          currentUserId, friendId, selectedMode!!, challengeId)
 
-                // Add the challenge to the users' ongoing challenges
-                userViewModel.addOngoingChallenge(currentUserId, challengeId)
-                userViewModel.addOngoingChallenge(friendId, challengeId)
+                      // Add the challenge to the users' ongoing challenges
+                      userViewModel.addOngoingChallenge(currentUserId, challengeId)
+                      userViewModel.addOngoingChallenge(friendId, challengeId)
 
-                onDismiss() // Close the dialog after creating the challenge
-              }
-            },
-            enabled = selectedMode != null,
-            modifier = Modifier.testTag("SendChallengeButton")) {
-              Text("Send Challenge")
-            }
+                      onDismiss() // Close the dialog after creating the challenge
+                  }
+              },
+              testTag = "SendChallengeButton",
+              text = "Send Challenge",
+              backgroundColor = MaterialTheme.colorScheme.primary,
+              enabled = selectedMode != null,
+          )
       },
       dismissButton = {
-        Button(onClick = onDismiss, modifier = Modifier.testTag("CancelButton")) { Text("Cancel") }
+          UtilTextButton(
+              onClickAction = onDismiss,
+              testTag = "CancelButton",
+              text = "Cancel",
+              backgroundColor = MaterialTheme.colorScheme.surface,
+          )
       },
-      title = { Text(text = "Choose Challenge Mode", modifier = Modifier.testTag("DialogTitle")) },
+      title = { Text(text = "Pick a Mode", modifier = Modifier.testTag("DialogTitle")) },
       text = {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
           // Mode Selection Buttons
           Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-            Button(
-                onClick = { selectedMode = "sprint" },
-                colors =
-                    buttonColors(
-                        containerColor = if (selectedMode == "sprint") Color.Blue else Color.Gray),
-                modifier = Modifier.padding(8.dp).testTag("SprintModeButton")) {
-                  Text("Sprint")
-                }
-
-            Button(
-                onClick = { selectedMode = "chrono" },
-                colors =
-                    buttonColors(
-                        containerColor = if (selectedMode == "chrono") Color.Blue else Color.Gray),
-                modifier = Modifier.padding(8.dp).testTag("ChronoModeButton")) {
-                  Text("Chrono")
-                }
+              UtilTextButton(
+                    onClickAction = { selectedMode = "sprint" },
+                    testTag = "SprintModeButton",
+                    text = "Sprint",
+                    backgroundColor = if (selectedMode == "sprint") MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface,
+              )
+                UtilTextButton(
+                        onClickAction = { selectedMode = "chrono" },
+                        testTag = "ChronoModeButton",
+                        text = "Chrono",
+                        backgroundColor = if (selectedMode == "chrono") MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface,
+                )
           }
         }
       })

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
@@ -180,7 +180,9 @@ fun ChallengeModeAlertDialog(
             backgroundColor = MaterialTheme.colorScheme.surface,
         )
       },
-      title = { Text(text = "Pick a Mode", modifier = Modifier.testTag("DialogTitle")) },
+      title = {
+        Text(text = "Pick a Mode", modifier = Modifier.fillMaxWidth().testTag("DialogTitle"))
+      },
       text = {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -195,7 +197,9 @@ fun ChallengeModeAlertDialog(
             }
           }
         }
-      })
+      },
+      containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.5f),
+  )
 }
 
 @Composable

--- a/app/src/test/java/com/github/se/signify/model/challenge/ChallengeRepositoryFireStoreTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/challenge/ChallengeRepositoryFireStoreTest.kt
@@ -35,7 +35,7 @@ class ChallengeRepositoryFireStoreTest {
   private val challengeId = "challengeId"
   private val player1Id = "player1Id"
   private val player2Id = "player2Id"
-  private val mode = "sprint"
+  private val mode = ChallengeMode.SPRINT
 
   @Before
   fun setUp() {
@@ -63,7 +63,7 @@ class ChallengeRepositoryFireStoreTest {
             "player2" to player2Id,
             "status" to "pending",
             "round" to 1,
-            "mode" to mode,
+            "mode" to mode.name,
             "player1Score" to 0,
             "player2Score" to 0,
             "currentGesture" to "",

--- a/app/src/test/java/com/github/se/signify/model/challenge/ChallengeViewModelTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/challenge/ChallengeViewModelTest.kt
@@ -15,7 +15,7 @@ class ChallengeViewModelTest {
   private val challengeId = "challengeId"
   private val player1Id = "player1Id"
   private val player2Id = "player2Id"
-  private val mode = "sprint"
+  private val mode = ChallengeMode.SPRINT
 
   @Before
   fun setUp() {


### PR DESCRIPTION
## Changes

I've refactored the challenge creation screen as best I could.
- `CreateAChallenge.kt` has been refactored to use as many common elements from Utils.kt as possible.
- Hardcoded screen colors have been changed to use the correct theme colors.
- Challenge modes, previously encoded as `String`s are now an `enum`.
- Challenge mode selection logic is no longer hardcoded and can now accomodate new modes.

I've had to add an `enabled` parameter to a common button in `Utils.kt` to conserve the functionality of a button in the challenge creation screen. This added parameter has a default value that should stop it from affecting previous uses of the button.

Here are a few screenshots of the updated screen.
![image](https://github.com/user-attachments/assets/d9843113-d39d-4ae0-9f2c-60a967c2d5fb)
![image](https://github.com/user-attachments/assets/9edd43da-f3ed-4800-8b0d-6f43b686d633)
![image](https://github.com/user-attachments/assets/771d3a09-8c6e-4ece-8366-f9f3be5a3707)

## Future Additions

This screen still feels a little dull. There is definitely space for additions.
There is also a lot of room for improvements to the colors and look of its existing elements.

I think improvements and additions to Utils.kt and Theme.kt would help freshen this screen up, and others.