### PR TITLE
refactor: navigation and add missing tests

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/BottomBarNavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/BottomBarNavigationTest.kt
@@ -1,7 +1,5 @@
 package com.github.se.signify.ui.screens
 
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -30,10 +28,9 @@ class BottomNavigationBarTest {
       BottomNavigationMenu(
           onTabSelect = { navigationActions.navigateTo(it.route) },
           tabList = LIST_TOP_LEVEL_DESTINATION,
-          selectedItem = LIST_TOP_LEVEL_DESTINATION.first().route,
-          modifier = Modifier.testTag("BottomNavigationBar"))
+          selectedItem = LIST_TOP_LEVEL_DESTINATION.first().route)
     }
 
-    composeTestRule.onNodeWithTag("BottomNavigationBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/MainActivityTest.kt
@@ -13,7 +13,6 @@ import com.github.se.signify.model.di.AppDependencyProvider
 import com.github.se.signify.model.stats.StatsRepository
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.ui.navigation.NavigationActions
-import com.github.se.signify.ui.navigation.Route
 import com.github.se.signify.ui.navigation.Screen
 import com.github.se.signify.ui.screens.profile.FriendsListScreen
 import com.github.se.signify.ui.screens.profile.ProfileScreen
@@ -51,13 +50,13 @@ class MainActivityTest {
 
     composeTestRule.onNodeWithTag("WelcomeScreen").assertIsDisplayed()
 
-    composeTestRule.runOnIdle { navigationActions.navigateTo(Route.PROFILE) }
+    composeTestRule.runOnIdle { navigationActions.navigateTo(Screen.PROFILE) }
     composeTestRule.onNodeWithTag("ProfileScreen").assertIsDisplayed()
 
     composeTestRule.runOnIdle { navigationState.value?.navigateTo(Screen.AUTH) }
     composeTestRule.onNodeWithTag("LoginScreen").assertIsDisplayed()
 
-    composeTestRule.runOnIdle { navigationActions.navigateTo(Route.FRIENDS) }
+    composeTestRule.runOnIdle { navigationActions.navigateTo(Screen.FRIENDS) }
     composeTestRule.onNodeWithTag("FriendsListScreen").assertIsDisplayed()
     composeTestRule.onNodeWithContentDescription("Search").performClick()
 
@@ -70,16 +69,16 @@ class MainActivityTest {
     composeTestRule.runOnIdle { navigationState.value?.navigateTo(Screen.EXERCISE_HARD) }
     composeTestRule.onNodeWithTag("ExerciseScreenHard").assertIsDisplayed()
 
-    composeTestRule.runOnIdle { navigationActions.navigateTo(Route.SETTINGS) }
+    composeTestRule.runOnIdle { navigationActions.navigateTo(Screen.SETTINGS) }
     composeTestRule.onNodeWithTag("SettingsScreen").assertIsDisplayed()
 
-    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.HOME) }
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Screen.HOME) }
     composeTestRule.onNodeWithTag("HomeScreen").assertIsDisplayed()
 
-    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.STATS) }
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Screen.STATS) }
     composeTestRule.onNodeWithTag("MyStatsScreen").assertIsDisplayed()
 
-    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Route.CHALLENGE_HISTORY) }
+    composeTestRule.runOnIdle { navigationState.value?.navigateTo(Screen.CHALLENGE_HISTORY) }
     composeTestRule.onNodeWithTag("ChallengeHistoryScreen").assertIsDisplayed()
 
     composeTestRule.runOnIdle { navigationState.value?.navigateTo(Screen.CHALLENGE) }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/UtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/UtilsTest.kt
@@ -37,8 +37,6 @@ import com.github.se.signify.ui.UtilTextButton
 import com.github.se.signify.ui.getIconResId
 import com.github.se.signify.ui.getImageResId
 import com.github.se.signify.ui.getTipResId
-import com.github.se.signify.ui.navigation.BottomNavigationMenu
-import com.github.se.signify.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.signify.ui.navigation.NavigationActions
 import junit.framework.TestCase.assertEquals
 import org.junit.Rule
@@ -244,17 +242,6 @@ class UtilsTest {
 
     // Assert that the top bar is displayed
     composeTestRule.onNodeWithTag("TopBar").assertIsDisplayed()
-  }
-
-  @Test
-  fun bottomBarIsDisplayed() {
-    composeTestRule.setContent {
-      BottomNavigationMenu(
-          onTabSelect = { navigationActions.navigateTo(it.route) },
-          tabList = LIST_TOP_LEVEL_DESTINATION,
-          selectedItem = LIST_TOP_LEVEL_DESTINATION.first().route)
-    }
-    composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/UtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/UtilsTest.kt
@@ -37,6 +37,8 @@ import com.github.se.signify.ui.UtilTextButton
 import com.github.se.signify.ui.getIconResId
 import com.github.se.signify.ui.getImageResId
 import com.github.se.signify.ui.getTipResId
+import com.github.se.signify.ui.navigation.BottomNavigationMenu
+import com.github.se.signify.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.signify.ui.navigation.NavigationActions
 import junit.framework.TestCase.assertEquals
 import org.junit.Rule
@@ -244,8 +246,16 @@ class UtilsTest {
     composeTestRule.onNodeWithTag("TopBar").assertIsDisplayed()
   }
 
-  // TODO: test the bottom bar after the refactor of the BottomNavigationMenu()
-  @Test fun bottomBarIsDisplayed() {}
+  @Test
+  fun bottomBarIsDisplayed() {
+    composeTestRule.setContent {
+      BottomNavigationMenu(
+          onTabSelect = { navigationActions.navigateTo(it.route) },
+          tabList = LIST_TOP_LEVEL_DESTINATION,
+          selectedItem = LIST_TOP_LEVEL_DESTINATION.first().route)
+    }
+    composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
+  }
 
   @Test
   fun screenColumnDisplaysCorrectInformation() {
@@ -276,7 +286,7 @@ class UtilsTest {
     }
 
     composeTestRule.onNodeWithTag("TopBar").assertIsDisplayed()
-    // TODO: test the bottom bar after the refactor of the BottomNavigationMenu()
+    composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("ScaffoldMainScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("InfoButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("Text").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/ChallengeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/ChallengeScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.github.se.signify.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -49,7 +50,7 @@ class ChallengeScreenTest {
 
     composeTestRule.onNodeWithTag("HistoryButton").performClick()
 
-    verify(navigationActions).navigateTo("ChallengeHistory")
+    verify(navigationActions).navigateTo(Screen.CHALLENGE_HISTORY)
   }
 
   @Test
@@ -57,7 +58,7 @@ class ChallengeScreenTest {
 
     composeTestRule.onNodeWithTag("ChallengeButton").performClick()
 
-    verify(navigationActions).navigateTo("NewChallenge")
+    verify(navigationActions).navigateTo(Screen.NEW_CHALLENGE)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreenTest.kt
@@ -8,6 +8,7 @@ import com.github.se.signify.model.challenge.ChallengeRepository
 import com.github.se.signify.model.user.User
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.Screen
 import com.github.se.signify.ui.screens.profile.currentUserId
 import org.junit.Before
 import org.junit.Rule
@@ -95,7 +96,7 @@ class NewChallengeScreenTest {
     // Perform click action on the "My Friends" button
     composeTestRule.onNodeWithTag("MyFriendsButton").performClick()
     // Verify navigation action is called
-    verify(navigationActions).navigateTo("Friends")
+    verify(navigationActions).navigateTo(Screen.FRIENDS)
   }
 
   @Test
@@ -105,7 +106,7 @@ class NewChallengeScreenTest {
     // Perform click action on the "Create a Challenge" button
     composeTestRule.onNodeWithTag("CreateChallengeButton").performClick()
     // Verify navigation action is called
-    verify(navigationActions).navigateTo("CreateChallenge")
+    verify(navigationActions).navigateTo(Screen.CREATE_CHALLENGE)
   }
   // Step 3: Test Ongoing Challenges Display
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/ASLRecognitionTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/ASLRecognitionTest.kt
@@ -65,7 +65,7 @@ class ASLRecognitionTest : LifecycleOwner {
     composeTestRule.onNodeWithTag("cameraPreview").assertIsDisplayed()
     composeTestRule.onNodeWithTag("gestureOverlayView").assertIsDisplayed()
     composeTestRule.onNodeWithTag("aslRecognitionTitle").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/HomeScreenTest.kt
@@ -38,6 +38,7 @@ class HomeScreenTest {
     composeTestRule.setContent { HomeScreen(navigationActions = navigationActions) }
 
     // Assert that all elements are displayed in ChallengeScreen
+    composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("QuestsButton").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("CameraFeedbackButton").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("LetterDictionary").performScrollTo().assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/QuestScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/QuestScreenTest.kt
@@ -1,13 +1,12 @@
+package com.github.se.signify.ui.screens.home
+
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.se.signify.model.quest.Quest
 import com.github.se.signify.model.quest.QuestRepository
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.ui.navigation.NavigationActions
-import com.github.se.signify.ui.navigation.Route
-import com.github.se.signify.ui.screens.home.QuestBox
-import com.github.se.signify.ui.screens.home.QuestDescriptionDialog
-import com.github.se.signify.ui.screens.home.QuestScreen
+import com.github.se.signify.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -32,7 +31,7 @@ class QuestScreenTest {
     userRepository = mock(UserRepository::class.java)
     navigationActions = mock(NavigationActions::class.java)
 
-    `when`(navigationActions.currentRoute()).thenReturn(Route.QUEST)
+    `when`(navigationActions.currentRoute()).thenReturn(Screen.QUEST)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/ProfileScreenTest.kt
@@ -56,6 +56,7 @@ class ProfileScreenTest {
   @Test
   fun buttonsAreCorrectlyDisplayed() {
 
+    composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("SettingsButton").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("InfoButton").performScrollTo().assertIsDisplayed()
     composeTestRule.onNodeWithTag("MyFriendsButton").performScrollTo().assertIsDisplayed()

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -87,32 +87,20 @@ fun SignifyAppPreview(
         route = Route.CHALLENGE,
     ) {
       composable(Screen.CHALLENGE) { ChallengeScreen(navigationActions) }
-    }
-
-    composable(Route.NEW_CHALLENGE) {
-      NewChallengeScreen(
-          navigationActions,
-          dependencyProvider.userRepository(),
-          dependencyProvider.challengeRepository())
-    }
-    composable(Route.CREATE_CHALLENGE) {
-      CreateAChallengeScreen(
-          navigationActions,
-          dependencyProvider.userRepository(),
-          dependencyProvider.challengeRepository())
-    }
-    composable(Route.CHALLENGE_HISTORY) {
-      ChallengeHistoryScreen(navigationActions, dependencyProvider.statsRepository())
-    }
-    navigation(
-        startDestination = Screen.QUEST,
-        route = Route.QUEST,
-    ) {
-      composable(Screen.QUEST) {
-        QuestScreen(
+      composable(Screen.NEW_CHALLENGE) {
+        NewChallengeScreen(
             navigationActions,
-            dependencyProvider.questRepository(),
-            dependencyProvider.userRepository())
+            dependencyProvider.userRepository(),
+            dependencyProvider.challengeRepository())
+      }
+      composable(Screen.CREATE_CHALLENGE) {
+        CreateAChallengeScreen(
+            navigationActions,
+            dependencyProvider.userRepository(),
+            dependencyProvider.challengeRepository())
+      }
+      composable(Screen.CHALLENGE_HISTORY) {
+        ChallengeHistoryScreen(navigationActions, dependencyProvider.statsRepository())
       }
     }
 
@@ -121,6 +109,24 @@ fun SignifyAppPreview(
         route = Route.HOME,
     ) {
       composable(Screen.HOME) { HomeScreen(navigationActions) }
+      composable(Screen.PRACTICE) { ASLRecognition(handLandMarkViewModel, navigationActions) }
+      composable(Screen.EXERCISE_EASY) {
+        ExerciseScreenEasy(navigationActions, handLandMarkViewModel)
+      }
+      composable(Screen.EXERCISE_MEDIUM) {
+        ExerciseScreenMedium(navigationActions, handLandMarkViewModel)
+      }
+
+      composable(Screen.EXERCISE_HARD) {
+        ExerciseScreenHard(navigationActions, handLandMarkViewModel)
+      }
+      composable(Screen.FEEDBACK) { FeedbackScreen(navigationActions) }
+      composable(Screen.QUEST) {
+        QuestScreen(
+            navigationActions,
+            dependencyProvider.questRepository(),
+            dependencyProvider.userRepository())
+      }
     }
 
     navigation(
@@ -133,33 +139,18 @@ fun SignifyAppPreview(
             dependencyProvider.userRepository(),
             dependencyProvider.statsRepository())
       }
-
-      composable(Route.FRIENDS) {
+      composable(Screen.FRIENDS) {
         FriendsListScreen(navigationActions, dependencyProvider.userRepository())
       }
-      composable(Route.FEEDBACK) { FeedbackScreen(navigationActions) }
-
-      composable(Route.STATS) {
+      composable(Screen.STATS) {
         MyStatsScreen(
             navigationActions,
             dependencyProvider.userRepository(),
             dependencyProvider.statsRepository())
       }
-
-      composable(Route.SETTINGS) {
+      composable(Screen.SETTINGS) {
         SettingsScreen(navigationActions, dependencyProvider.userRepository())
       }
-    }
-    composable(Screen.PRACTICE) { ASLRecognition(handLandMarkViewModel, navigationActions) }
-    composable(Screen.EXERCISE_EASY) {
-      ExerciseScreenEasy(navigationActions, handLandMarkViewModel)
-    }
-    composable(Screen.EXERCISE_MEDIUM) {
-      ExerciseScreenMedium(navigationActions, handLandMarkViewModel)
-    }
-
-    composable(Screen.EXERCISE_HARD) {
-      ExerciseScreenHard(navigationActions, handLandMarkViewModel)
     }
   }
   navigationState.value = navigationActions

--- a/app/src/main/java/com/github/se/signify/ui/Utils.kt
+++ b/app/src/main/java/com/github/se/signify/ui/Utils.kt
@@ -264,8 +264,7 @@ fun BottomBar(navigationActions: NavigationActions) {
   BottomNavigationMenu(
       onTabSelect = { route -> navigationActions.navigateTo(route) },
       tabList = LIST_TOP_LEVEL_DESTINATION,
-      selectedItem = navigationActions.currentRoute(),
-      modifier = Modifier.testTag("BottomNavigationMenu"))
+      selectedItem = navigationActions.currentRoute())
 }
 
 /**

--- a/app/src/main/java/com/github/se/signify/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/se/signify/ui/navigation/BottomNavigationMenu.kt
@@ -1,6 +1,5 @@
 package com.github.se.signify.ui.navigation
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -23,14 +22,12 @@ fun BottomNavigationMenu(
     onTabSelect: (TopLevelDestination) -> Unit,
     tabList: List<TopLevelDestination>,
     selectedItem: String = Route.HOME, // Provide a default value
-    @SuppressLint("ModifierParameter") modifier: Modifier = Modifier
 ) {
   Box(
       modifier =
-          modifier
-              .border(2.dp, MaterialTheme.colorScheme.outlineVariant) // Top blue line
+          Modifier.border(2.dp, MaterialTheme.colorScheme.outlineVariant) // Top blue line
               .padding(bottom = 2.dp)
-              .testTag("BottomNavigationBar")) {
+              .testTag("BottomNavigationMenu")) {
         NavigationBar(
             modifier = Modifier.fillMaxWidth().height(60.dp),
             containerColor = MaterialTheme.colorScheme.background // Set background to white

--- a/app/src/main/java/com/github/se/signify/ui/navigation/Route.kt
+++ b/app/src/main/java/com/github/se/signify/ui/navigation/Route.kt
@@ -1,17 +1,9 @@
 package com.github.se.signify.ui.navigation
 
 object Route {
+  const val WELCOME = "Welcome"
+  const val AUTH = "Auth"
   const val HOME = "Home"
   const val PROFILE = "Profile"
-  const val QUEST = "Quest"
   const val CHALLENGE = "Challenge"
-  const val NEW_CHALLENGE = "NewChallenge"
-  const val CREATE_CHALLENGE = "CreateChallenge"
-  const val CHALLENGE_HISTORY = "ChallengeHistory"
-  const val AUTH = "Auth"
-  const val WELCOME = "Welcome"
-  const val FRIENDS = "Friends"
-  const val SETTINGS = "Settings"
-  const val STATS = "Stats"
-  const val FEEDBACK = "Feedback"
 }

--- a/app/src/main/java/com/github/se/signify/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/navigation/Screen.kt
@@ -1,14 +1,24 @@
 package com.github.se.signify.ui.navigation
 
 object Screen {
+  const val WELCOME = "Welcome Screen"
+  const val AUTH = "Auth Screen"
+
   const val HOME = "Home Screen"
   const val PRACTICE = "Practice Screen"
-  const val EXERCISE_EASY = "Exercise Screen Easy"
-  const val EXERCISE_MEDIUM = "Exercise Screen Medium"
-  const val EXERCISE_HARD = "Exercise Screen Hard"
-  const val PROFILE = "Profile Screen"
+  const val EXERCISE_EASY = "Easy Exercise Screen"
+  const val EXERCISE_MEDIUM = "Medium Exercise Screen"
+  const val EXERCISE_HARD = "Hard Exercise Screen"
   const val QUEST = "Quest Screen"
+  const val FEEDBACK = "Feedback Screen"
+
+  const val PROFILE = "Profile Screen"
+  const val FRIENDS = "Friends Screen"
+  const val SETTINGS = "Settings Screen"
+  const val STATS = "Stats Screen"
+
   const val CHALLENGE = "Challenge Screen"
-  const val AUTH = "Auth Screen"
-  const val WELCOME = "Welcome Screen"
+  const val NEW_CHALLENGE = "NewChallenge Screen"
+  const val CREATE_CHALLENGE = "CreateChallenge Screen"
+  const val CHALLENGE_HISTORY = "ChallengeHistory Screen"
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeScreen.kt
@@ -12,7 +12,7 @@ import com.github.se.signify.R
 import com.github.se.signify.ui.MainScreenScaffold
 import com.github.se.signify.ui.SquareButton
 import com.github.se.signify.ui.navigation.NavigationActions
-import com.github.se.signify.ui.navigation.Route
+import com.github.se.signify.ui.navigation.Screen
 
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
@@ -28,7 +28,7 @@ fun ChallengeScreen(navigationActions: NavigationActions) {
         SquareButton(
             iconRes = R.drawable.battleicon,
             label = "Challenge",
-            onClick = { navigationActions.navigateTo(Route.NEW_CHALLENGE) },
+            onClick = { navigationActions.navigateTo(Screen.NEW_CHALLENGE) },
             size = 240,
             modifier = Modifier.testTag("ChallengeButton"))
         Spacer(modifier = Modifier.height(32.dp))
@@ -37,7 +37,7 @@ fun ChallengeScreen(navigationActions: NavigationActions) {
         SquareButton(
             iconRes = R.drawable.historyicon,
             label = "History",
-            onClick = { navigationActions.navigateTo(Route.CHALLENGE_HISTORY) },
+            onClick = { navigationActions.navigateTo(Screen.CHALLENGE_HISTORY) },
             size = 240,
             modifier = Modifier.testTag("HistoryButton"))
       }

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
@@ -38,6 +38,7 @@ import com.github.se.signify.model.user.UserViewModel
 import com.github.se.signify.ui.AnnexScreenScaffold
 import com.github.se.signify.ui.UtilTextButton
 import com.github.se.signify.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.Screen
 import com.github.se.signify.ui.screens.profile.currentUserId
 
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
@@ -62,7 +63,7 @@ fun NewChallengeScreen(
   AnnexScreenScaffold(navigationActions = navigationActions, testTagColumn = "NewChallengeScreen") {
     // My Friends button
     UtilTextButton(
-        onClickAction = { navigationActions.navigateTo("Friends") },
+        onClickAction = { navigationActions.navigateTo(Screen.FRIENDS) },
         testTag = "MyFriendsButton",
         text = "My Friends",
         backgroundColor = MaterialTheme.colorScheme.primary,
@@ -72,7 +73,7 @@ fun NewChallengeScreen(
 
     // Create a challenge button
     UtilTextButton(
-        onClickAction = { navigationActions.navigateTo("CreateChallenge") },
+        onClickAction = { navigationActions.navigateTo(Screen.CREATE_CHALLENGE) },
         testTag = "CreateChallengeButton",
         text = "Create a Challenge",
         backgroundColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/ASLRecognition.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/ASLRecognition.kt
@@ -117,8 +117,7 @@ fun ASLRecognition(
         BottomNavigationMenu(
             onTabSelect = { route -> navigationActions.navigateTo(route) },
             tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute(),
-            modifier = Modifier.testTag("bottomNavigationMenu"))
+            selectedItem = navigationActions.currentRoute())
       })
 }
 

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
@@ -62,7 +62,6 @@ import com.github.se.signify.ui.getImageResId
 import com.github.se.signify.ui.getLetterIconResId
 import com.github.se.signify.ui.getTipResId
 import com.github.se.signify.ui.navigation.NavigationActions
-import com.github.se.signify.ui.navigation.Route
 import com.github.se.signify.ui.navigation.Screen
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -115,7 +114,7 @@ fun HomeScreen(navigationActions: NavigationActions) {
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween) {
                       UtilButton(
-                          onClick = { navigationActions.navigateTo(Route.FEEDBACK) },
+                          onClick = { navigationActions.navigateTo(Screen.FEEDBACK) },
                           buttonTestTag = "FeedbackButton",
                           iconTestTag = "FeedbackIcon",
                           icon = Icons.Outlined.Email,

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
@@ -24,7 +24,7 @@ import com.github.se.signify.ui.MainScreenScaffold
 import com.github.se.signify.ui.SquareButton
 import com.github.se.signify.ui.UtilButton
 import com.github.se.signify.ui.navigation.NavigationActions
-import com.github.se.signify.ui.navigation.Route
+import com.github.se.signify.ui.navigation.Screen
 import com.google.firebase.auth.FirebaseAuth
 
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
@@ -56,7 +56,7 @@ fun ProfileScreen(
 
     // Settings button
     UtilButton(
-        onClick = { navigationActions.navigateTo(Route.SETTINGS) },
+        onClick = { navigationActions.navigateTo(Screen.SETTINGS) },
         buttonTestTag = "SettingsButton",
         iconTestTag = "SettingsIcon",
         icon = Icons.Outlined.Settings,
@@ -80,7 +80,7 @@ fun ProfileScreen(
     SquareButton(
         iconRes = R.drawable.friendsicon,
         label = "My Friends",
-        onClick = { navigationActions.navigateTo(Route.FRIENDS) },
+        onClick = { navigationActions.navigateTo(Screen.FRIENDS) },
         size = 200,
         modifier = Modifier.testTag("MyFriendsButton"))
     Spacer(modifier = Modifier.height(32.dp))
@@ -89,7 +89,7 @@ fun ProfileScreen(
     SquareButton(
         iconRes = R.drawable.statisticsicon,
         label = "My Stats",
-        onClick = { navigationActions.navigateTo(Route.STATS) },
+        onClick = { navigationActions.navigateTo(Screen.STATS) },
         size = 200,
         modifier = Modifier.testTag("MyStatsButton"))
   }


### PR DESCRIPTION
### PR Description

This PR is about refactoring the navigation system to standardize the use of `Route` and `Screen`:
- `Route` is now used exclusively for main screens:
  - Welcome, Authentication, Home, Profile, and Challenge screens.
- `Screen` is used for both main screens and annex screens (accessible from main screens).
- Ensure the navigation still works as before and the tests pass.
- Link to the issue #252 .

Additionally:
- Added missing tests for the bottom navigation menu across different screens and utilities to ensure consistent behavior.