### PR TITLE
261 mock the challenge repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ You can view the Figma project here: [Signify Figma Project](https://www.figma.c
 
 For the first milestone we provide also the following file with the figma wireframe and mockup: [Signify Figma M1](https://www.figma.com/design/hJsdCTG31DOo51A86W5NNC/Signify-App-M1?t=BKSwDNaqzPhiVu4y-1)
 
+For the second milestone we provide also the following file with the figma wireframe and mockup: [Signify Figma M2](https://www.figma.com/design/sqe0iMKLsNpGi72ohKHbhI/Signify-App-M2?node-id=0-1&node-type=canvas&t=kf898URWQxbvH1FA-0)
+
 ## Contributing
 
 All steps of the development of new features and bug fixes are organized through the [scrum board](https://github.com/orgs/Signify-epfl/projects/2) on Github.  

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreenTest.kt
@@ -3,11 +3,12 @@ package com.github.se.signify.ui.screens.challenge
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import com.github.se.signify.model.challenge.ChallengeMode
-import com.github.se.signify.model.challenge.ChallengeRepository
+import com.github.se.signify.model.challenge.MockChallengeRepository
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.ui.navigation.NavigationActions
 import com.github.se.signify.ui.screens.profile.currentUserId
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -15,21 +16,21 @@ import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class CreateAChallengeScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
+
   private lateinit var navigationActions: NavigationActions
   private lateinit var userRepository: UserRepository
-  private lateinit var challengeRepository: ChallengeRepository
+  private lateinit var challengeRepository: MockChallengeRepository
   private val friends = mutableStateListOf("Alice", "Bob", "Charlie")
 
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
     userRepository = mock(UserRepository::class.java)
-    challengeRepository = mock(ChallengeRepository::class.java)
+    challengeRepository = MockChallengeRepository()
 
     // Mock getFriendsList to return friends list
     doAnswer { invocation ->
@@ -86,10 +87,7 @@ class CreateAChallengeScreenTest {
     composeTestRule.onNodeWithTag("ChallengeButton_$friend").performClick()
     composeTestRule.onNodeWithTag("DialogTitle").assertIsDisplayed()
   }
-  /*
-  EXPLANATION: The testUser initialized by the mock doesn't have an email,
-  so its userId and UserName are set to "unknown" when accessing it from the repository
-   */
+
   @Test
   fun testSelectChallengeModeAndSendChallenge() {
     val friend = friends[0]
@@ -100,12 +98,10 @@ class CreateAChallengeScreenTest {
     composeTestRule.onNodeWithTag("SprintModeButton").performClick()
     composeTestRule.onNodeWithTag("SendChallengeButton").assertIsEnabled()
     composeTestRule.onNodeWithTag("SendChallengeButton").performClick()
-    // Verify that sendChallengeRequest and addOngoingChallenge were called
-    verify(challengeRepository)
-        .sendChallengeRequest(
-            eq(currentUserId), eq(friend), eq(ChallengeMode.SPRINT), any(), any(), any())
-    verify(userRepository).addOngoingChallenge(eq(currentUserId), any(), any(), any())
-    verify(userRepository).addOngoingChallenge(eq(friend), any(), any(), any())
+
+    // Verify that the challengeRepository and userRepository were called
+    assertTrue(challengeRepository.sendChallengeCalled)
+    assertNotNull(challengeRepository.lastSentChallenge) // ensure it was set
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreenTest.kt
@@ -99,9 +99,9 @@ class CreateAChallengeScreenTest {
     composeTestRule.onNodeWithTag("SendChallengeButton").assertIsEnabled()
     composeTestRule.onNodeWithTag("SendChallengeButton").performClick()
 
-    // Verify that the challengeRepository and userRepository were called
-    assertTrue(challengeRepository.sendChallengeCalled)
-    assertNotNull(challengeRepository.lastSentChallenge) // ensure it was set
+    // Verify that the challengeRepository was called
+    assertTrue(challengeRepository.wasSendChallengeCalled())
+    assertNotNull(challengeRepository.lastSentChallengeId())
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreenTest.kt
@@ -112,8 +112,8 @@ class NewChallengeScreenTest {
     composeTestRule.onNodeWithTag("DeleteButton$challengeIdToDelete").performClick()
 
     // Verify that the MockChallengeRepository is updated
-    assertTrue(challengeRepository.deleteChallengeCalled)
-    assertEquals(challengeIdToDelete, challengeRepository.lastDeletedChallenge)
+    assertTrue(challengeRepository.wasDeleteChallengeCalled())
+    assertEquals(challengeIdToDelete, challengeRepository.lastDeletedChallengeId())
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreenTest.kt
@@ -4,11 +4,12 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.se.signify.model.challenge.Challenge
-import com.github.se.signify.model.challenge.ChallengeRepository
-import com.github.se.signify.model.user.User
+import com.github.se.signify.model.challenge.MockChallengeRepository
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.ui.navigation.NavigationActions
 import com.github.se.signify.ui.screens.profile.currentUserId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -21,9 +22,11 @@ import org.mockito.kotlin.whenever
 
 class NewChallengeScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
+
   private lateinit var navigationActions: NavigationActions
   private lateinit var userRepository: UserRepository
-  private lateinit var challengeRepository: ChallengeRepository
+  private lateinit var challengeRepository: MockChallengeRepository
+
   private val ongoingChallenges =
       mutableStateListOf(
           Challenge(
@@ -38,16 +41,14 @@ class NewChallengeScreenTest {
               player2 = "Opponent2",
               mode = "Chrono",
               status = "active"))
-  private val opponentUser =
-      User(uid = "Opponent1", name = "Opponent User", ongoingChallenges = listOf("challenge1"))
 
   @Before
   fun setUp() {
     navigationActions = Mockito.mock(NavigationActions::class.java)
     userRepository = Mockito.mock(UserRepository::class.java)
-    challengeRepository = Mockito.mock(ChallengeRepository::class.java)
+    challengeRepository = MockChallengeRepository()
 
-    // Mocks
+    // Mock UserRepository
     doAnswer { invocation ->
           val onSuccess = invocation.arguments[1] as (List<Challenge>) -> Unit
           onSuccess(ongoingChallenges)
@@ -55,15 +56,9 @@ class NewChallengeScreenTest {
         .whenever(userRepository)
         .getOngoingChallenges(eq(currentUserId), any(), any())
 
-    doAnswer { invocation ->
-          ongoingChallenges.removeIf { it.challengeId == invocation.arguments[1] }
-          val onSuccess = invocation.arguments[2] as () -> Unit
-          onSuccess()
-        }
-        .whenever(userRepository)
-        .removeOngoingChallenge(any(), any(), any(), any())
+    challengeRepository.setChallenges(ongoingChallenges)
 
-    // Set up the Composable content and wait for idle state
+    // Set up the Composable content
     composeTestRule.setContent {
       NewChallengeScreen(
           navigationActions = navigationActions,
@@ -71,10 +66,9 @@ class NewChallengeScreenTest {
           challengeRepository = challengeRepository)
     }
 
-    composeTestRule.waitForIdle() // Ensure composable is idle before testing
+    composeTestRule.waitForIdle()
   }
 
-  // Step 2: Implement Basic UI Tests
   @Test
   fun testTopBlueBarIsDisplayed() {
     composeTestRule.onNodeWithTag("TopBar").assertIsDisplayed()
@@ -82,70 +76,48 @@ class NewChallengeScreenTest {
 
   @Test
   fun testBackButtonNavigatesBack() {
-    // Click the back button
     composeTestRule.onNodeWithTag("BackButton").performClick()
-    // Verify navigation action is called
     verify(navigationActions).goBack()
   }
 
   @Test
   fun testMyFriendsButtonIsDisplayedAndNavigates() {
-    // Check if "My Friends" button is displayed
     composeTestRule.onNodeWithTag("MyFriendsButton").assertIsDisplayed()
-    // Perform click action on the "My Friends" button
     composeTestRule.onNodeWithTag("MyFriendsButton").performClick()
-    // Verify navigation action is called
     verify(navigationActions).navigateTo("Friends")
   }
 
   @Test
   fun testCreateChallengeButtonIsDisplayedAndNavigates() {
-    // Check if "Create a Challenge" button is displayed
     composeTestRule.onNodeWithTag("CreateChallengeButton").assertIsDisplayed()
-    // Perform click action on the "Create a Challenge" button
     composeTestRule.onNodeWithTag("CreateChallengeButton").performClick()
-    // Verify navigation action is called
     verify(navigationActions).navigateTo("CreateChallenge")
   }
-  // Step 3: Test Ongoing Challenges Display
+
   @Test
   fun testOngoingChallengesDisplayed() {
-    // Verify the "My Ongoing Challenges" title is displayed
     composeTestRule.onNodeWithTag("OngoingChallengesTitle").assertIsDisplayed()
-    // Scroll to each challenge card and verify it is displayed
     ongoingChallenges.forEachIndexed { index, challenge ->
       composeTestRule.onNodeWithTag("OngoingChallengeCard$index").assertIsDisplayed()
       composeTestRule.onNodeWithText("Opponent: ${challenge.player2}").assertIsDisplayed()
       composeTestRule.onNodeWithText("Mode: ${challenge.mode}").assertIsDisplayed()
     }
   }
-  // Step 4: Test Deleting an Ongoing Challenge
+
   @Test
   fun testDeleteOngoingChallenge() {
     val challengeIdToDelete = ongoingChallenges[0].challengeId
-    // Perform delete action on the challenge
+
     composeTestRule.onNodeWithTag("DeleteButton$challengeIdToDelete").assertExists()
     composeTestRule.onNodeWithTag("DeleteButton$challengeIdToDelete").performClick()
-    // Verify removeOngoingChallenge and deleteChallenge were called
-    /*
-    EXPLANATION: The testUser initialized by the mock doesn't have an email,
-    so its userId and UserName are set to "unknown" when accessing it from the repository
-     */
-    /*verify(userRepository)
-    .removeOngoingChallenge(any(), eq(challengeIdToDelete), any(), any())*/
-    verify(userRepository)
-        .removeOngoingChallenge(eq(opponentUser.uid), eq(challengeIdToDelete), any(), any())
-    verify(challengeRepository).deleteChallenge(eq(challengeIdToDelete), any(), any())
-    // Verify that ongoingChallenges list is updated after deletion
-    composeTestRule.waitForIdle()
-    assert(ongoingChallenges.size == 1) {
-      "Ongoing challenges list should have one item after deletion"
-    }
+
+    // Verify that the MockChallengeRepository is updated
+    assertTrue(challengeRepository.deleteChallengeCalled)
+    assertEquals(challengeIdToDelete, challengeRepository.lastDeletedChallenge)
   }
 
   @Test
   fun testNewChallengeScreenViewModelInitialization() {
-    // Verify that getFriendsList and getOngoingChallenges are called when the screen is displayed
     verify(userRepository).getFriendsList(eq(currentUserId), any(), any())
     verify(userRepository).getOngoingChallenges(eq(currentUserId), any(), any())
   }

--- a/app/src/main/java/com/github/se/signify/model/challenge/MockChallengeRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/MockChallengeRepository.kt
@@ -1,0 +1,75 @@
+package com.github.se.signify.model.challenge
+
+class MockChallengeRepository : ChallengeRepository {
+
+  // Data storage for challenges
+  private val challenges = mutableMapOf<String, Challenge>()
+
+  // Control variables for simulating behavior
+  var shouldSucceed: Boolean = true // Determines whether the operation succeeds
+  var exceptionToThrow: Exception =
+      Exception("Simulated failure") // Customizable exception for failure scenarios
+
+  // Flags for verifying calls
+  var sendChallengeCalled: Boolean = false
+  var deleteChallengeCalled: Boolean = false
+
+  // Last actions for verification
+  var lastSentChallenge: String? = null
+  var lastDeletedChallenge: String? = null
+
+  override fun sendChallengeRequest(
+      player1Id: String,
+      player2Id: String,
+      mode: ChallengeMode,
+      challengeId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    sendChallengeCalled = true
+    lastSentChallenge = challengeId
+
+    if (shouldSucceed) {
+      val newChallenge =
+          Challenge(
+              challengeId = challengeId,
+              player1 = player1Id,
+              player2 = player2Id,
+              mode = mode.name,
+              status = "pending")
+      challenges[challengeId] = newChallenge
+      onSuccess()
+    } else {
+      onFailure(exceptionToThrow)
+    }
+  }
+
+  override fun deleteChallenge(
+      challengeId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    deleteChallengeCalled = true
+    lastDeletedChallenge = challengeId
+
+    if (shouldSucceed) {
+      if (challenges.remove(challengeId) != null) {
+        onSuccess()
+      } else {
+        onFailure(Exception("Challenge with ID $challengeId not found"))
+      }
+    } else {
+      onFailure(exceptionToThrow)
+    }
+  }
+
+  // Helper method to fetch challenges (optional, useful for tests)
+  fun getChallenge(challengeId: String): Challenge? {
+    return challenges[challengeId]
+  }
+
+  // Helper method to fetch all challenges (optional)
+  fun getAllChallenges(): List<Challenge> {
+    return challenges.values.toList()
+  }
+}

--- a/app/src/main/java/com/github/se/signify/model/challenge/MockChallengeRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/MockChallengeRepository.kt
@@ -1,20 +1,14 @@
 package com.github.se.signify.model.challenge
 
 class MockChallengeRepository : ChallengeRepository {
-
-  // Data storage for challenges
   private val challenges = mutableMapOf<String, Challenge>()
 
-  // Control variables for simulating behavior
   var shouldSucceed: Boolean = true // Determines whether the operation succeeds
-  var exceptionToThrow: Exception =
-      Exception("Simulated failure") // Customizable exception for failure scenarios
+  var exceptionToThrow: Exception = Exception("Simulated failure") // Exception for failures
 
-  // Flags for verifying calls
   var sendChallengeCalled: Boolean = false
   var deleteChallengeCalled: Boolean = false
 
-  // Last actions for verification
   var lastSentChallenge: String? = null
   var lastDeletedChallenge: String? = null
 
@@ -63,13 +57,16 @@ class MockChallengeRepository : ChallengeRepository {
     }
   }
 
-  // Helper method to fetch challenges (optional, useful for tests)
   fun getChallenge(challengeId: String): Challenge? {
     return challenges[challengeId]
   }
 
-  // Helper method to fetch all challenges (optional)
   fun getAllChallenges(): List<Challenge> {
     return challenges.values.toList()
+  }
+
+  fun setChallenges(newChallenges: List<Challenge>) {
+    challenges.clear()
+    challenges.putAll(newChallenges.associateBy { it.challengeId })
   }
 }

--- a/app/src/test/java/com/github/se/signify/model/challenge/ChallengeViewModelTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/challenge/ChallengeViewModelTest.kt
@@ -23,29 +23,24 @@ class ChallengeViewModelTest {
 
   @Test
   fun `sendChallengeRequest triggers onSuccess and logs message`() {
-    mockRepository.shouldSucceed = true // Simulate a successful repository operation
-
     challengeViewModel.sendChallengeRequest(player1Id, player2Id, mode, challengeId)
 
-    assertTrue(mockRepository.sendChallengeCalled) // Verify repository interaction
-    assertEquals(challengeId, mockRepository.lastSentChallenge) // Verify challenge details
+    assertTrue(mockRepository.wasSendChallengeCalled())
+    assertEquals(challengeId, mockRepository.lastSentChallengeId())
   }
 
   @Test
   fun `sendChallengeRequest triggers onFailure and logs error`() {
-    mockRepository.shouldSucceed = false // Simulate a failed repository operation
-    mockRepository.exceptionToThrow = Exception("Simulated failure")
+    mockRepository.shouldSucceed = false
 
     challengeViewModel.sendChallengeRequest(player1Id, player2Id, mode, challengeId)
 
-    assertTrue(mockRepository.sendChallengeCalled) // Verify repository interaction
-    assertEquals(challengeId, mockRepository.lastSentChallenge) // Verify challenge details
+    assertTrue(mockRepository.wasSendChallengeCalled())
+    assertEquals(challengeId, mockRepository.lastSentChallengeId())
   }
 
   @Test
   fun `deleteChallenge triggers onSuccess and logs message`() {
-    mockRepository.shouldSucceed = true // Simulate a successful repository operation
-
     mockRepository.sendChallengeRequest(
         player1Id = player1Id,
         player2Id = player2Id,
@@ -56,21 +51,17 @@ class ChallengeViewModelTest {
 
     challengeViewModel.deleteChallenge(challengeId)
 
-    assertTrue(mockRepository.deleteChallengeCalled) // Verify repository interaction
-    assertEquals(challengeId, mockRepository.lastDeletedChallenge) // Verify challenge details
+    assertTrue(mockRepository.wasDeleteChallengeCalled())
+    assertEquals(challengeId, mockRepository.lastDeletedChallengeId())
   }
 
   @Test
   fun `deleteChallenge triggers onFailure and logs error`() {
-    // Arrange
-    mockRepository.shouldSucceed = false // Simulate a failed repository operation
-    mockRepository.exceptionToThrow = Exception("Simulated delete failure")
-
+    mockRepository.shouldSucceed = false
     challengeViewModel.deleteChallenge(challengeId)
 
-    assertTrue(mockRepository.deleteChallengeCalled) // Verify repository interaction
-    assertEquals(challengeId, mockRepository.lastDeletedChallenge) // Verify challenge details
-    // Optionally, verify log output (requires mocking Log)
+    assertTrue(mockRepository.wasDeleteChallengeCalled())
+    assertEquals(challengeId, mockRepository.lastDeletedChallengeId())
   }
 
   @Test

--- a/app/src/test/java/com/github/se/signify/model/challenge/ChallengeViewModelTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/challenge/ChallengeViewModelTest.kt
@@ -1,15 +1,13 @@
 package com.github.se.signify.model.challenge
 
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 
 class ChallengeViewModelTest {
-
-  private lateinit var challengeRepository: ChallengeRepository
+  private lateinit var mockRepository: MockChallengeRepository
   private lateinit var challengeViewModel: ChallengeViewModel
 
   private val challengeId = "challengeId"
@@ -19,26 +17,67 @@ class ChallengeViewModelTest {
 
   @Before
   fun setUp() {
-    challengeRepository = mock(ChallengeRepository::class.java)
-    challengeViewModel = ChallengeViewModel(challengeRepository)
+    mockRepository = MockChallengeRepository()
+    challengeViewModel = ChallengeViewModel(mockRepository)
   }
 
   @Test
-  fun sendChallengeRequest_callsRepository() {
-    // Act
+  fun `sendChallengeRequest triggers onSuccess and logs message`() {
+    mockRepository.shouldSucceed = true // Simulate a successful repository operation
+
     challengeViewModel.sendChallengeRequest(player1Id, player2Id, mode, challengeId)
 
-    // Assert: Verify that the repository's sendChallengeRequest method was called
-    verify(challengeRepository)
-        .sendChallengeRequest(eq(player1Id), eq(player2Id), eq(mode), eq(challengeId), any(), any())
+    assertTrue(mockRepository.sendChallengeCalled) // Verify repository interaction
+    assertEquals(challengeId, mockRepository.lastSentChallenge) // Verify challenge details
   }
 
   @Test
-  fun deleteChallenge_callsRepository() {
-    // Act
+  fun `sendChallengeRequest triggers onFailure and logs error`() {
+    mockRepository.shouldSucceed = false // Simulate a failed repository operation
+    mockRepository.exceptionToThrow = Exception("Simulated failure")
+
+    challengeViewModel.sendChallengeRequest(player1Id, player2Id, mode, challengeId)
+
+    assertTrue(mockRepository.sendChallengeCalled) // Verify repository interaction
+    assertEquals(challengeId, mockRepository.lastSentChallenge) // Verify challenge details
+  }
+
+  @Test
+  fun `deleteChallenge triggers onSuccess and logs message`() {
+    mockRepository.shouldSucceed = true // Simulate a successful repository operation
+
+    mockRepository.sendChallengeRequest(
+        player1Id = player1Id,
+        player2Id = player2Id,
+        mode = mode,
+        challengeId = challengeId,
+        onSuccess = { /* Success */},
+        onFailure = { /* No-op */})
+
     challengeViewModel.deleteChallenge(challengeId)
 
-    // Assert: Verify that the repository's deleteChallenge method was called
-    verify(challengeRepository).deleteChallenge(eq(challengeId), any(), any())
+    assertTrue(mockRepository.deleteChallengeCalled) // Verify repository interaction
+    assertEquals(challengeId, mockRepository.lastDeletedChallenge) // Verify challenge details
+  }
+
+  @Test
+  fun `deleteChallenge triggers onFailure and logs error`() {
+    // Arrange
+    mockRepository.shouldSucceed = false // Simulate a failed repository operation
+    mockRepository.exceptionToThrow = Exception("Simulated delete failure")
+
+    challengeViewModel.deleteChallenge(challengeId)
+
+    assertTrue(mockRepository.deleteChallengeCalled) // Verify repository interaction
+    assertEquals(challengeId, mockRepository.lastDeletedChallenge) // Verify challenge details
+    // Optionally, verify log output (requires mocking Log)
+  }
+
+  @Test
+  fun `factory creates ChallengeViewModel with repository`() {
+    val mockRepository = MockChallengeRepository()
+    val factory = ChallengeViewModel.factory(mockRepository)
+    val viewModel = factory.create(ChallengeViewModel::class.java)
+    assertNotNull(viewModel)
   }
 }

--- a/app/src/test/java/com/github/se/signify/model/challenge/MockChallengeRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/challenge/MockChallengeRepositoryTest.kt
@@ -1,0 +1,121 @@
+package com.github.se.signify.model.challenge
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+
+class MockChallengeRepositoryTest {
+
+  private lateinit var mockRepository: MockChallengeRepository
+  private val player1Id = "player1"
+  private val player2Id = "player2"
+  private val challengeId = "challenge123"
+  private val mode = ChallengeMode.SPRINT
+
+  @Before
+  fun setUp() {
+    mockRepository = MockChallengeRepository()
+  }
+
+  @Test
+  fun `sendChallengeRequest succeeds when shouldSucceed is true`() {
+    mockRepository.shouldSucceed = true
+    mockRepository.sendChallengeRequest(
+        player1Id,
+        player2Id,
+        mode,
+        challengeId,
+        onSuccess = {},
+        onFailure = { fail("onFailure should not be called") })
+    assertNotNull(mockRepository.getChallenge(challengeId))
+  }
+
+  @Test
+  fun `sendChallengeRequest fails when shouldSucceed is false`() {
+    mockRepository.shouldSucceed = false
+    mockRepository.sendChallengeRequest(
+        player1Id,
+        player2Id,
+        mode,
+        challengeId,
+        onSuccess = { fail("onSuccess should not be called") },
+        onFailure = { /* Success */})
+  }
+
+  @Test
+  fun `deleteChallenge succeeds when challenge exists`() {
+    mockRepository.shouldSucceed = true
+    mockRepository.sendChallengeRequest(player1Id, player2Id, mode, challengeId, {}, {})
+    mockRepository.deleteChallenge(
+        challengeId, onSuccess = {}, onFailure = { fail("onFailure should not be called") })
+    assertNull(mockRepository.getChallenge(challengeId))
+  }
+
+  @Test
+  fun `deleteChallenge fails when challenge does not exist`() {
+    mockRepository.shouldSucceed = true
+    mockRepository.deleteChallenge(
+        challengeId, onSuccess = { fail("onSuccess should not be called") }, onFailure = {})
+  }
+
+  @Test
+  fun `deleteChallenge fails when shouldSucceed is false`() {
+    mockRepository.shouldSucceed = false
+    mockRepository.deleteChallenge(
+        challengeId, onSuccess = { fail("onSuccess should not be called") }, onFailure = {})
+  }
+
+  @Test
+  fun `getAllChallenges returns all stored challenges`() {
+    mockRepository.shouldSucceed = true
+    mockRepository.sendChallengeRequest(player1Id, player2Id, mode, challengeId, {}, {})
+    assertEquals(1, mockRepository.getAllChallenges().size)
+  }
+
+  @Test
+  fun `sendChallengeRequest sets sendChallengeCalled to true`() {
+    mockRepository.sendChallengeRequest(
+        player1Id = "player1",
+        player2Id = "player2",
+        mode = ChallengeMode.SPRINT,
+        challengeId = "challenge123",
+        onSuccess = {},
+        onFailure = {})
+    assertTrue(mockRepository.sendChallengeCalled)
+  }
+
+  @Test
+  fun `deleteChallenge sets deleteChallengeCalled to true`() {
+    mockRepository.deleteChallenge(challengeId = "challenge123", onSuccess = {}, onFailure = {})
+    assertTrue(mockRepository.deleteChallengeCalled)
+  }
+
+  @Test
+  fun `sendChallengeRequest updates lastSentChallenge`() {
+    mockRepository.sendChallengeRequest(
+        player1Id = "player1",
+        player2Id = "player2",
+        mode = ChallengeMode.SPRINT,
+        challengeId = "challenge123",
+        onSuccess = {},
+        onFailure = {})
+    assertEquals("challenge123", mockRepository.lastSentChallenge)
+  }
+
+  @Test
+  fun `deleteChallenge updates lastDeletedChallenge`() {
+    mockRepository.sendChallengeRequest(
+        player1Id = "player1",
+        player2Id = "player2",
+        mode = ChallengeMode.SPRINT,
+        challengeId = "challenge123",
+        onSuccess = {},
+        onFailure = {})
+    mockRepository.deleteChallenge(challengeId = "challenge123", onSuccess = {}, onFailure = {})
+    assertEquals("challenge123", mockRepository.lastDeletedChallenge)
+  }
+}

--- a/app/src/test/java/com/github/se/signify/model/challenge/MockChallengeRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/challenge/MockChallengeRepositoryTest.kt
@@ -37,13 +37,14 @@ class MockChallengeRepositoryTest {
   @Test
   fun `sendChallengeRequest fails when shouldSucceed is false`() {
     mockRepository.shouldSucceed = false
+    mockRepository.exceptionToThrow = Exception("Simulated failure")
     mockRepository.sendChallengeRequest(
         player1Id,
         player2Id,
         mode,
         challengeId,
         onSuccess = { fail("onSuccess should not be called") },
-        onFailure = { /* Success */})
+        onFailure = { exception -> assertEquals("Simulated failure", exception.message) })
   }
 
   @Test
@@ -65,8 +66,11 @@ class MockChallengeRepositoryTest {
   @Test
   fun `deleteChallenge fails when shouldSucceed is false`() {
     mockRepository.shouldSucceed = false
+    mockRepository.exceptionToThrow = Exception("Simulated failure")
     mockRepository.deleteChallenge(
-        challengeId, onSuccess = { fail("onSuccess should not be called") }, onFailure = {})
+        challengeId,
+        onSuccess = { fail("onSuccess should not be called") },
+        onFailure = { exception -> assertEquals("Simulated failure", exception.message) })
   }
 
   @Test
@@ -117,5 +121,21 @@ class MockChallengeRepositoryTest {
         onFailure = {})
     mockRepository.deleteChallenge(challengeId = "challenge123", onSuccess = {}, onFailure = {})
     assertEquals("challenge123", mockRepository.lastDeletedChallenge)
+  }
+
+  @Test
+  fun testSetChallenges() {
+    val newChallenges =
+        listOf(
+            Challenge("challenge1", "player1", "player2", "Sprint", "pending"),
+            Challenge("challenge2", "player3", "player4", "Chrono", "active"))
+
+    mockRepository.setChallenges(newChallenges)
+
+    val challenges = mockRepository.getAllChallenges()
+    assertEquals(2, challenges.size)
+    assertNotNull(challenges[0])
+    assertNotNull(challenges[1])
+    assertEquals("player1", challenges[0].player1)
   }
 }


### PR DESCRIPTION
###  **Title**:  Introduce MockChallengeRepository and Refactor Tests

---

### **Description**
This PR introduces a new `MockChallengeRepository` to streamline testing of components that rely on `ChallengeRepository`. Additionally, it refactors the tests for `ChallengeViewModel`,`CreateChallengeScreen` and `NewChallengeScreen` to use this mock. The aim is to simplify testing by centralizing ChallengeRepository logic in a reusable mock.

---

### **Changes Made**
1. **Created `MockChallengeRepository`**:
   - Simulates the behavior of `ChallengeRepository` with in-memory storage for challenges.
   - Supports toggling success and failure scenarios using `shouldSucceed` and `exceptionToThrow`.
   - Includes helper methods like `setChallenges` and `getChallenges` for test setup and verification.
2. **Created `MockChallengeRepositoryTest`**:
   - Testing of the various functions of the mock.
3. **Refactored Tests**:
   - Updated tests for `ChallengeViewModel`, `CreateChallengeScreen` and `NewChallengeScreen`:
     - Modified to now use MockChallengeRepository.
     - Simplified test logic by leveraging `MockChallengeRepository`'s helper methods.
     - Improved coverage on some files like ChallengeViewModel by also covering callbacks.

---
