### PR TITLE
feat: add the scrolling logic of a pager in the LetterDictionary in HomeScreen and updating/wrinting tests accordingly

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/HomeScreenTest.kt
@@ -227,8 +227,7 @@ class HomeScreenTest {
     composeTestRule.setContent { HomeScreen(navigationActions) }
 
     ('A'..'Z').forEachIndexed { _, letter ->
-      // Click on "LetterDictionaryForward" to navigate to the desired letter
-      // Click on the specific letter box
+      // Click on the specific letter box by scrolling to it
       composeTestRule.onNodeWithTag("LetterBox_$letter").performScrollTo().performClick()
 
       // Assert that the text and corresponding sign tip are displayed

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/HomeScreenTest.kt
@@ -76,7 +76,7 @@ class HomeScreenTest {
 
     composeTestRule.onNodeWithTag("QuestsButton").performClick()
 
-    verify(navigationActions).navigateTo("Quest")
+    verify(navigationActions).navigateTo(Screen.QUEST)
   }
 
   @Test
@@ -202,15 +202,34 @@ class HomeScreenTest {
   }
 
   @Test
-  fun dictionaryIsDisplayed() {
+  fun dictionaryIsDisplayedUsingButtons() {
     composeTestRule.setContent { HomeScreen(navigationActions) }
 
     ('A'..'Z').forEachIndexed { index, letter ->
       // Click on "LetterDictionaryForward" to navigate to the desired letter
-      repeat(index) { composeTestRule.onNodeWithTag("LetterDictionaryForward").performClick() }
-
+      if (index > 0) {
+        composeTestRule.onNodeWithTag("LetterDictionaryForward").performClick()
+      }
       // Click on the specific letter box
       composeTestRule.onNodeWithTag("LetterBox_$letter").performClick()
+
+      // Assert that the text and corresponding sign tip are displayed
+      composeTestRule.onNodeWithTag("LetterTextDict_$letter").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("SignTipBox_$letter").assertIsDisplayed()
+
+      // Scroll to top button is clicked
+      composeTestRule.onNodeWithTag("ScrollToTopButton").performClick()
+    }
+  }
+
+  @Test
+  fun dictionaryIsDisplayedUsingPagersScrolling() {
+    composeTestRule.setContent { HomeScreen(navigationActions) }
+
+    ('A'..'Z').forEachIndexed { _, letter ->
+      // Click on "LetterDictionaryForward" to navigate to the desired letter
+      // Click on the specific letter box
+      composeTestRule.onNodeWithTag("LetterBox_$letter").performScrollTo().performClick()
 
       // Assert that the text and corresponding sign tip are displayed
       composeTestRule.onNodeWithTag("LetterTextDict_$letter").assertIsDisplayed()

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
@@ -40,9 +40,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip


### PR DESCRIPTION
- This PR enhances the LetterDictionary component within the HomeScreen by adding support for horizontal scrolling via swipe gestures in the pager, alongside the existing button-based navigation. The implementation ensures seamless navigation between letters in both directions (left and right) using the pager.

The following updates have been made:
## General updates : 
- There was a problem with navigating to the questScreen after the PR of #253 that was not catched up, I changed that accordingly.
## Feature Updates:

- Added swipe-based scrolling logic for the LetterDictionary pager.
Users can now swipe through letters in addition to using the LetterDictionaryForward and LetterDictionaryBack buttons.
Note: Scrolling directly from A to Z (or Z to A) via swipe gestures is not implemented. Button navigation still allows wrapping around.
## Test Updates:

Extended existing tests to validate the new swipe-based navigation behavior:
dictionaryIsDisplayedUsingButtons: Ensures that navigation using the forward and back buttons (`LetterDictionaryForward`) continues to function correctly.
New Test (`dictionaryIsDisplayedUsingPagersScrolling`):
- Validates the swipe-based scrolling functionality for the LetterDictionary pager.
- Verifies that the correct content (letter-specific box, text, and sign tip box) is displayed after swiping.

Both tests now include additional steps to simulate clicking the "Scroll to Top" button (ScrollToTopButton).
