### PR TITLE
Refactor friends list screen

### DIFF
--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/FriendsListScreen.kt
@@ -1,5 +1,6 @@
 package com.github.se.signify.ui.screens.profile
 
+import android.annotation.SuppressLint
 import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,9 +22,11 @@ import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -33,6 +37,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -44,15 +49,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.se.signify.R
 import com.github.se.signify.model.auth.UserSession
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.model.user.UserViewModel
-import com.github.se.signify.ui.AccountInformation
 import com.github.se.signify.ui.AnnexScreenScaffold
 import com.github.se.signify.ui.ProfilePicture
 import com.github.se.signify.ui.navigation.NavigationActions
@@ -67,37 +73,23 @@ fun FriendsListScreen(
     userViewModel: UserViewModel =
         viewModel(factory = UserViewModel.factory(userSession, userRepository))
 ) {
+
+  val friendsString = stringResource(R.string.friends)
+  val friendsRequestsString = stringResource(R.string.friends_requests)
+
   var errorMessage by remember { mutableStateOf("") }
+  var selectedList by remember { mutableStateOf(friendsString) }
 
   AnnexScreenScaffold(navigationActions = navigationActions, testTagColumn = "FriendsListScreen") {
     LaunchedEffect(Unit) {
       userViewModel.getFriendsList()
       userViewModel.getRequestsFriendsList()
-      userViewModel.getUserName()
-      userViewModel.getProfilePictureUrl()
-      userViewModel.updateStreak()
-      userViewModel.getStreak()
     }
 
     val friends = userViewModel.friends.collectAsState()
     val friendsRequests = userViewModel.friendsRequests.collectAsState()
     val searchResult = userViewModel.searchResult.collectAsState()
     val errorState = userViewModel.errorState.collectAsState()
-
-    val userName = userViewModel.userName.collectAsState()
-    val streak = userViewModel.streak.collectAsState()
-    val profilePicture = userViewModel.profilePictureUrl.collectAsState()
-    var updatedProfilePicture by remember { mutableStateOf(profilePicture.value) }
-
-    LaunchedEffect(profilePicture.value) { updatedProfilePicture = profilePicture.value }
-
-    // Top information
-    AccountInformation(
-        userId = userSession.getUserId()!!,
-        userName = userName.value,
-        profilePictureUrl = updatedProfilePicture,
-        days = streak.value)
-    Spacer(modifier = Modifier.height(32.dp))
 
     SearchBar { searchQuery ->
       if (searchQuery.isNotEmpty()) {
@@ -113,13 +105,14 @@ fun FriendsListScreen(
       if (errorState.value != null) {
         errorMessage = errorState.value!!
       }
-
-      ErrorMessage(message)
-      // Dismiss the message
-      LaunchedEffect(message) {
-        delay(3000)
-        errorMessage = ""
-        userViewModel.clearErrorState()
+      if (errorMessage.isNotEmpty()) {
+        ErrorMessage(message)
+        // Dismiss the message
+        LaunchedEffect(message) {
+          delay(3000)
+          errorMessage = ""
+          userViewModel.clearErrorState()
+        }
       }
     }
 
@@ -161,21 +154,66 @@ fun FriendsListScreen(
       }
     }
 
-    // My Friends List
-    FriendListCard(
-        title = "My friends list", items = friends.value, emptyMessage = "You have no friends") {
-            friendName ->
-          FriendItem(friendName = friendName, userViewModel = userViewModel)
-        }
-    Spacer(modifier = Modifier.height(32.dp))
+    // Separation line
+    HorizontalDivider(
+        thickness = 1.dp,
+        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+        modifier = Modifier.padding(top = 24.dp, bottom = 4.dp))
 
-    // New Friends Demands
-    FriendListCard(
-        title = "New friends demands",
-        items = friendsRequests.value,
-        emptyMessage = "No new friend requests") { friendRequestName ->
-          FriendRequestItem(friendRequestName = friendRequestName, userViewModel = userViewModel)
+    // Buttons for toggling lists
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly) {
+          val numberFriends = if (friends.value.size > 1) friendsString else "Friend"
+
+          TextButton(
+              { selectedList = friendsString },
+              "${friends.value.size} $numberFriends",
+              ButtonDefaults.buttonColors(
+                  containerColor =
+                      if (selectedList == friendsString) MaterialTheme.colorScheme.primary
+                      else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)),
+              "${friendsString}Button")
+
+          val numberRequests =
+              if (friendsRequests.value.size > 1) friendsRequestsString else "Request"
+
+          TextButton(
+              { selectedList = friendsRequestsString },
+              "${friendsRequests.value.size} $numberRequests",
+              ButtonDefaults.buttonColors(
+                  containerColor =
+                      if (selectedList == friendsRequestsString) MaterialTheme.colorScheme.primary
+                      else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)),
+              "${friendsRequestsString}Button")
         }
+
+    // Separation line
+    HorizontalDivider(
+        thickness = 1.dp,
+        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+        modifier = Modifier.padding(top = 4.dp, bottom = 24.dp))
+
+    // Display the corresponding list based on the selected button
+    when (selectedList) {
+      // case Friends list
+      friendsString ->
+          FriendListCard(
+              title = "My $friendsString list",
+              items = friends.value,
+              emptyMessage = "You have no $friendsString") { friendName ->
+                FriendItem(friendName, userViewModel)
+              }
+
+      // case Friends Requests list
+      friendsRequestsString ->
+          FriendListCard(
+              title = "New $friendsString $friendsRequestsString",
+              items = friendsRequests.value,
+              emptyMessage = "No new friend $friendsRequestsString") { friendName ->
+                FriendRequestItem(friendName, userViewModel)
+              }
+    }
   }
 }
 
@@ -197,15 +235,13 @@ fun AddFriendButton(userViewModel: UserViewModel) {
       }
 }
 
+@SuppressLint("UnrememberedMutableState", "StateFlowValueCalledInComposition")
 @Composable
 fun RemoveFriendButton(userViewModel: UserViewModel) {
-  val context = LocalContext.current
+  val showDialog = mutableStateOf(false) // State to control dialog visibility
+
   Button(
-      onClick = {
-        userViewModel.removeFriend(userViewModel.searchResult.value!!.uid)
-        userViewModel.setSearchResult(null)
-        Toast.makeText(context, "Friend removed.", Toast.LENGTH_SHORT).show()
-      },
+      onClick = { showDialog.value = true }, // Show the dialog when button is clicked
       colors =
           ButtonDefaults.buttonColors(
               containerColor = MaterialTheme.colorScheme.error,
@@ -213,6 +249,11 @@ fun RemoveFriendButton(userViewModel: UserViewModel) {
       modifier = Modifier.fillMaxWidth()) {
         Text("Remove Friend")
       }
+
+  ConfirmationDialog(showDialog) {
+    userViewModel.removeFriend(userViewModel.searchResult.value!!.uid)
+    userViewModel.setSearchResult(null)
+  }
 }
 
 @Composable
@@ -268,7 +309,10 @@ fun SearchBar(
       singleLine = true,
       trailingIcon = {
         ActionButton(
-            { onSearch(searchQuery) },
+            {
+              onSearch(searchQuery)
+              searchQuery = ""
+            },
             Icons.Default.Search,
             MaterialTheme.colorScheme.primary,
             "Search")
@@ -289,7 +333,7 @@ fun FriendListCard(
       border = BorderStroke(2.dp, MaterialTheme.colorScheme.outline),
   ) {
     Column(
-        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        modifier = Modifier.fillMaxSize().padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally) {
           Text(
               text = title,
@@ -305,7 +349,7 @@ fun FriendListCard(
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(top = 32.dp).align(Alignment.CenterHorizontally))
           } else {
-            LazyColumn(modifier = Modifier.height(200.dp).testTag(title)) {
+            LazyColumn(modifier = Modifier.height(450.dp).testTag(title)) {
               items(items.size) { index -> content(items[index]) }
             }
           }
@@ -333,18 +377,22 @@ fun FriendCard(name: String, actions: @Composable RowScope.() -> Unit) {
       }
 }
 
+@SuppressLint("UnrememberedMutableState")
 @Composable
 fun FriendItem(friendName: String, userViewModel: UserViewModel) {
+
+  val showDialog = mutableStateOf(false) // State to control dialog visibility
+
   FriendCard(friendName) {
 
     // Button "Remove"
-    Button(
-        onClick = { userViewModel.removeFriend(friendName) },
-        colors = ButtonDefaults.buttonColors(MaterialTheme.colorScheme.error),
-        shape = RoundedCornerShape(50.dp),
-    ) {
-      Text(text = "Remove", color = MaterialTheme.colorScheme.onError)
-    }
+    ActionButton(
+        { showDialog.value = true },
+        Icons.Default.Delete,
+        MaterialTheme.colorScheme.error,
+        "Remove")
+
+    ConfirmationDialog(showDialog) { userViewModel.removeFriend(friendName) }
   }
 }
 
@@ -398,4 +446,59 @@ fun UserTextName(name: String) {
       color = MaterialTheme.colorScheme.onBackground,
       fontWeight = FontWeight.Bold,
       modifier = Modifier.padding(start = 16.dp))
+}
+
+@Composable
+fun TextButton(onClickAction: () -> Unit, text: String, color: ButtonColors, testTag: String) {
+  Button(onClick = onClickAction, colors = color, modifier = Modifier.testTag(testTag)) {
+    Text(text = text)
+  }
+}
+
+@Composable
+fun ConfirmationDialog(showDialog: MutableState<Boolean>, onClickAction: () -> Unit) {
+  if (showDialog.value) {
+    val context = LocalContext.current
+
+    Dialog(onDismissRequest = { showDialog.value = false }) {
+      Surface(
+          shape = RoundedCornerShape(16.dp),
+          color = MaterialTheme.colorScheme.surface,
+          modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally) {
+                  Text(
+                      text = "Are you sure you want to remove this friend?",
+                      fontWeight = FontWeight.Bold,
+                      color = MaterialTheme.colorScheme.onSurface,
+                      modifier = Modifier.padding(bottom = 16.dp))
+                  Row(
+                      horizontalArrangement = Arrangement.SpaceEvenly,
+                      modifier = Modifier.fillMaxWidth()) {
+                        Button(
+                            onClick = {
+                              onClickAction()
+                              Toast.makeText(context, "Friend removed.", Toast.LENGTH_SHORT).show()
+                              showDialog.value = false // Close the dialog
+                            },
+                            colors =
+                                ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.error,
+                                    contentColor = MaterialTheme.colorScheme.onError)) {
+                              Text("Yes")
+                            }
+                        Button(
+                            onClick = { showDialog.value = false }, // Close the dialog
+                            colors =
+                                ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.primary,
+                                    contentColor = MaterialTheme.colorScheme.onPrimary)) {
+                              Text("No")
+                            }
+                      }
+                }
+          }
+    }
+  }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,4 +79,7 @@ You’ll also find exercises at the bottom to challenge yourself at varying leve
     <string name="tip_y">Tips: Extend your pinky and thumb out to the sides, with the other fingers folded down.</string>
     <string name="tip_z">Tips: Move your index finger to trace a Z shape in the air.</string>
     <integer name="scroll_offset">8</integer>"
+    <string name="friends_requests">Requests</string>
+    <string name="friends">Friends</string>
+
 </resources>


### PR DESCRIPTION
#### Refactoring of the Friends List Screen

This pull request addresses the points we discussed during the meeting and includes the following updates:

1. **Search Bar Behavior**:
   - After searching for a user, the search bar is now automatically cleared to improve user experience.

2. **Confirmation Dialog for Removing Friends**:
   - A dialog has been added to confirm the user's intention before removing a friend. This prevents accidental removals and ensures clarity in user actions.

3. **Simplification of Friend Details**:
   - The profile picture and user name were removed from the screen to avoid confusion with the profile screen, ensuring a clearer separation of concerns.

4. **Separation of Lists**:
   - Friends and friend requests are now displayed in two separate sections, toggled by buttons. Each list occupies the whole screen when selected, providing a better layout and usability.

5. **Consistency in Terminology**:
   - Corrected the inconsistency in naming: "Friends demandes" is now standardized to "Friends requests."

6. **Hardcoded Strings Removed**:
   - Replaced some hardcoded strings with proper resources to enhance localization and maintainability.

7. **Updated and Extended Tests**:
   - Refactored the `FriendsListScreenTest` to align with the changes in the screen.
   - Added tests for the confirmation dialog to ensure the correct behavior when the user confirms or cancels the removal of a friend.

_______

#### Summary
These changes align the Friends List Screen with the agreed-upon improvements, ensuring a more intuitive and consistent user experience while adhering to best practices for maintainability and test coverage.

__________

<img width="316" alt="Capture d’écran 2024-11-27 à 21 00 01" src="https://github.com/user-attachments/assets/4a8bdbd0-552c-45d6-8557-42bd4ee21942">

<img width="316" alt="Capture d’écran 2024-11-27 à 21 00 14" src="https://github.com/user-attachments/assets/e74c8127-3d57-405e-8438-9b5f9e302e6a">

<img width="316" alt="Capture d’écran 2024-11-27 à 21 00 26" src="https://github.com/user-attachments/assets/bf87953d-2a63-48e3-a5b4-8f3dc40f58be">
