### PR TITLE
Refactor challenge database with its tests

### DIFF
--- a/app/src/main/java/com/github/se/signify/model/challenge/Challenge.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/Challenge.kt
@@ -4,11 +4,16 @@ data class Challenge(
     val challengeId: String = "",
     val player1: String = "",
     val player2: String = "",
-    val mode: String = "",
-    val status: String = "pending",
-    val round: Int = 1,
-    val player1Score: Int = 0,
-    val player2Score: Int = 0,
-    val currentGesture: String = "",
-    val responses: Map<String, String> = emptyMap()
+    val mode: String = "", // "chrono" or other types
+    val status: String = "pending", // Possible values: "pending", "in_progress", "completed"
+    var round: Int = 1, // Current round (1, 2, or 3)
+    val roundWords: List<String> = listOf(), // Words for each round
+    val player1Times: MutableList<Long> = mutableListOf(), // Player 1's times for each round
+    val player2Times: MutableList<Long> = mutableListOf(), // Player 2's times for each round
+    val player1RoundCompleted: List<Boolean> =
+        mutableListOf(false, false, false), // Track if player 1 completed each round
+    val player2RoundCompleted: List<Boolean> =
+        mutableListOf(false, false, false), // Track if player 2 completed each round
+    var gameStatus: String =
+        "not_started" // Possible values: "not_started", "in_progress", "completed"
 )

--- a/app/src/main/java/com/github/se/signify/model/challenge/ChallengeRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/ChallengeRepository.kt
@@ -11,4 +11,25 @@ interface ChallengeRepository {
   )
 
   fun deleteChallenge(challengeId: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+
+  fun getChallengeById(
+      challengeId: String,
+      onSuccess: (Challenge) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+
+  fun updateChallenge(
+      updatedChallenge: Challenge,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+
+  // New function to record player time when a challenge round is completed
+  fun recordPlayerTime(
+      challengeId: String,
+      playerId: String,
+      timeTaken: Long,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 }

--- a/app/src/main/java/com/github/se/signify/model/challenge/ChallengeRepositoryFireStore.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/ChallengeRepositoryFireStore.kt
@@ -99,6 +99,7 @@ class ChallengeRepositoryFireStore(private val db: FirebaseFirestore) : Challeng
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
+    assert(timeTaken > 0)
     db.collection("challenges")
         .document(challengeId)
         .update("playerTime", timeTaken)

--- a/app/src/main/java/com/github/se/signify/model/challenge/MockChallengeRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/MockChallengeRepository.kt
@@ -78,4 +78,74 @@ class MockChallengeRepository : ChallengeRepository {
     challenges.remove(challengeId)
     onSuccess()
   }
+
+  override fun getChallengeById(
+      challengeId: String,
+      onSuccess: (Challenge) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (!shouldSucceed) {
+      onFailure(exceptionToThrow)
+      return
+    }
+
+    val challenge = challenges[challengeId]
+    if (challenge != null) {
+      onSuccess(challenge)
+    } else {
+      onFailure(Exception("Challenge with ID $challengeId not found"))
+    }
+  }
+
+  override fun updateChallenge(
+      updatedChallenge: Challenge,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (!shouldSucceed) {
+      onFailure(exceptionToThrow)
+      return
+    }
+
+    val existingChallenge = challenges[updatedChallenge.challengeId]
+    if (existingChallenge != null) {
+      challenges[updatedChallenge.challengeId] = updatedChallenge
+      onSuccess()
+    } else {
+      onFailure(Exception("Challenge with ID ${updatedChallenge.challengeId} not found"))
+    }
+  }
+
+  override fun recordPlayerTime(
+      challengeId: String,
+      playerId: String,
+      timeTaken: Long,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (!shouldSucceed) {
+      onFailure(exceptionToThrow)
+      return
+    }
+
+    val challenge = challenges[challengeId]
+    if (challenge != null) {
+      // Update the player's time accordingly (assuming player1Times or player2Times)
+      when (playerId) {
+        challenge.player1 -> {
+          challenge.player1Times.add(timeTaken)
+        }
+        challenge.player2 -> {
+          challenge.player2Times.add(timeTaken)
+        }
+        else -> {
+          onFailure(Exception("Invalid player ID"))
+          return
+        }
+      }
+      onSuccess()
+    } else {
+      onFailure(Exception("Challenge with ID $challengeId not found"))
+    }
+  }
 }

--- a/app/src/test/java/com/github/se/signify/model/challenge/ChallengeRepositoryFireStoreTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/challenge/ChallengeRepositoryFireStoreTest.kt
@@ -4,10 +4,7 @@ import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
-import com.google.firebase.firestore.CollectionReference
-import com.google.firebase.firestore.DocumentReference
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.SetOptions
+import com.google.firebase.firestore.*
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
@@ -15,6 +12,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
@@ -27,138 +25,235 @@ import org.robolectric.Shadows.shadowOf
 class ChallengeRepositoryFireStoreTest {
 
   @Mock private lateinit var mockFirestore: FirebaseFirestore
+
   @Mock private lateinit var mockChallengesCollection: CollectionReference
+
   @Mock private lateinit var mockChallengeDocRef: DocumentReference
+
+  @Mock private lateinit var mockBatch: WriteBatch
 
   private lateinit var challengeRepositoryFireStore: ChallengeRepositoryFireStore
 
   private val challengeId = "challengeId"
-  private val player1Id = "player1Id"
-  private val player2Id = "player2Id"
-  private val mode = ChallengeMode.SPRINT
 
   @Before
   fun setUp() {
     MockitoAnnotations.openMocks(this)
 
-    // Initialize Firebase if necessary
     if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
       FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
     }
 
-    // Set up the mocks
     `when`(mockFirestore.collection(any())).thenReturn(mockChallengesCollection)
     `when`(mockChallengesCollection.document(eq(challengeId))).thenReturn(mockChallengeDocRef)
+    `when`(mockFirestore.batch()).thenReturn(mockBatch)
+
+    `when`(mockBatch.set(any<DocumentReference>(), any<Challenge>(), any<SetOptions>()))
+        .thenReturn(mockBatch)
+
+    val mockPlayer1Collection = Mockito.mock(CollectionReference::class.java)
+    val mockPlayer2Collection = Mockito.mock(CollectionReference::class.java)
+    val mockPlayer1DocRef = Mockito.mock(DocumentReference::class.java)
+    val mockPlayer2DocRef = Mockito.mock(DocumentReference::class.java)
+
+    `when`(mockFirestore.collection("users")).thenReturn(mockChallengesCollection)
+    `when`(mockChallengesCollection.document(eq("player1"))).thenReturn(mockPlayer1DocRef)
+    `when`(mockChallengesCollection.document(eq("player2"))).thenReturn(mockPlayer2DocRef)
+    `when`(mockPlayer1DocRef.collection("challenges")).thenReturn(mockPlayer1Collection)
+    `when`(mockPlayer2DocRef.collection("challenges")).thenReturn(mockPlayer2Collection)
+    `when`(mockPlayer1Collection.document(eq(challengeId))).thenReturn(mockPlayer1DocRef)
+    `when`(mockPlayer2Collection.document(eq(challengeId))).thenReturn(mockPlayer2DocRef)
+
+    `when`(mockBatch.set(eq(mockPlayer1DocRef), any<Challenge>(), any<SetOptions>()))
+        .thenReturn(mockBatch)
+    `when`(mockBatch.set(eq(mockPlayer2DocRef), any<Challenge>(), any<SetOptions>()))
+        .thenReturn(mockBatch)
 
     challengeRepositoryFireStore = ChallengeRepositoryFireStore(mockFirestore)
   }
 
   @Test
-  fun sendChallengeRequest_shouldCreateChallengeInFirestore() {
-    // Arrange
-    val challenge =
-        hashMapOf(
-            "challengeId" to challengeId,
-            "player1" to player1Id,
-            "player2" to player2Id,
-            "status" to "pending",
-            "round" to 1,
-            "mode" to mode.name,
-            "player1Score" to 0,
-            "player2Score" to 0,
-            "currentGesture" to "",
-            "responses" to hashMapOf<String, String>())
-
-    `when`(mockChallengeDocRef.set(eq(challenge), any<SetOptions>()))
-        .thenReturn(Tasks.forResult(null))
-
-    // Act
-    var successCalled = false
-    challengeRepositoryFireStore.sendChallengeRequest(
-        player1Id,
-        player2Id,
-        mode,
-        challengeId,
-        onSuccess = { successCalled = true },
-        onFailure = { fail("Failure callback should not be called") })
-
-    // Idle the main looper to process the tasks
-    shadowOf(Looper.getMainLooper()).idle()
-
-    // Assert
-    assertTrue(successCalled)
-    verify(mockChallengeDocRef).set(eq(challenge), any<SetOptions>())
-  }
-
-  @Test
-  fun sendChallengeRequest_shouldCallOnFailureOnFirestoreError() {
-    // Arrange
-    val exception = Exception("Firestore error")
-    `when`(mockChallengeDocRef.set(any(), any<SetOptions>()))
-        .thenReturn(Tasks.forException(exception))
-
-    // Act
-    var failureCalled = false
-    challengeRepositoryFireStore.sendChallengeRequest(
-        player1Id,
-        player2Id,
-        mode,
-        challengeId,
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = {
-          failureCalled = true
-          assertEquals(exception, it)
-        })
-
-    // Idle the main looper to process the tasks
-    shadowOf(Looper.getMainLooper()).idle()
-
-    // Assert
-    assertTrue(failureCalled)
-    verify(mockChallengeDocRef).set(any(), any<SetOptions>())
-  }
-
-  @Test
   fun deleteChallenge_shouldDeleteChallengeFromFirestore() {
-    // Arrange
     `when`(mockChallengeDocRef.delete()).thenReturn(Tasks.forResult(null))
 
-    // Act
     var successCalled = false
     challengeRepositoryFireStore.deleteChallenge(
-        challengeId,
+        challengeId = challengeId,
         onSuccess = { successCalled = true },
         onFailure = { fail("Failure callback should not be called") })
 
-    // Idle the main looper to process the tasks
     shadowOf(Looper.getMainLooper()).idle()
 
-    // Assert
     assertTrue(successCalled)
     verify(mockChallengeDocRef).delete()
   }
 
   @Test
   fun deleteChallenge_shouldCallOnFailureOnFirestoreError() {
-    // Arrange
     val exception = Exception("Firestore error")
     `when`(mockChallengeDocRef.delete()).thenReturn(Tasks.forException(exception))
 
-    // Act
     var failureCalled = false
     challengeRepositoryFireStore.deleteChallenge(
-        challengeId,
+        challengeId = challengeId,
         onSuccess = { fail("Success callback should not be called") },
         onFailure = {
           failureCalled = true
           assertEquals(exception, it)
         })
 
-    // Idle the main looper to process the tasks
     shadowOf(Looper.getMainLooper()).idle()
 
-    // Assert
     assertTrue(failureCalled)
     verify(mockChallengeDocRef).delete()
+  }
+
+  @Test
+  fun sendChallengeRequest_shouldCallOnFailureOnFirestoreError() {
+    val exception = Exception("Firestore error")
+    val mockTask = Tasks.forException<Void>(exception)
+
+    `when`(mockBatch.set(any(), any<Challenge>(), any<SetOptions>())).thenReturn(mockBatch)
+    `when`(mockBatch.commit()).thenReturn(mockTask)
+
+    var failureCalled = false
+    challengeRepositoryFireStore.sendChallengeRequest(
+        player1Id = "player1",
+        player2Id = "player2",
+        mode = ChallengeMode.CHRONO,
+        challengeId = challengeId,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = {
+          failureCalled = true
+          assertEquals(exception, it)
+        })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assertTrue(failureCalled)
+    verify(mockBatch).commit()
+  }
+
+  @Test
+  fun getChallengeById_shouldReturnChallengeOnSuccess() {
+    val mockDocumentSnapshot = Mockito.mock(DocumentSnapshot::class.java)
+    val challenge = Challenge(challengeId = challengeId)
+    `when`(mockDocumentSnapshot.toObject(Challenge::class.java)).thenReturn(challenge)
+
+    `when`(mockChallengeDocRef.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+
+    var successChallenge: Challenge? = null
+    challengeRepositoryFireStore.getChallengeById(
+        challengeId = challengeId,
+        onSuccess = { successChallenge = it },
+        onFailure = { fail("Failure callback should not be called") })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assertEquals(challenge, successChallenge)
+    verify(mockChallengeDocRef).get()
+  }
+
+  @Test
+  fun getChallengeById_shouldCallOnFailureOnFirestoreError() {
+    val exception = Exception("Firestore error")
+    `when`(mockChallengeDocRef.get()).thenReturn(Tasks.forException(exception))
+
+    var failureCalled = false
+    challengeRepositoryFireStore.getChallengeById(
+        challengeId = challengeId,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = {
+          failureCalled = true
+          assertEquals(exception, it)
+        })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assertTrue(failureCalled)
+    verify(mockChallengeDocRef).get()
+  }
+
+  @Test
+  fun updateChallenge_shouldUpdateChallengeInFirestore() {
+    val updatedChallenge = Challenge(challengeId = challengeId, status = "in_progress")
+    `when`(mockChallengeDocRef.set(updatedChallenge)).thenReturn(Tasks.forResult(null))
+
+    var successCalled = false
+    challengeRepositoryFireStore.updateChallenge(
+        updatedChallenge = updatedChallenge,
+        onSuccess = { successCalled = true },
+        onFailure = { fail("Failure callback should not be called") })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assertTrue(successCalled)
+    verify(mockChallengeDocRef).set(updatedChallenge)
+  }
+
+  @Test
+  fun updateChallenge_shouldCallOnFailureOnFirestoreError() {
+    val updatedChallenge = Challenge(challengeId = challengeId, status = "in_progress")
+    val exception = Exception("Firestore error")
+    `when`(mockChallengeDocRef.set(updatedChallenge)).thenReturn(Tasks.forException(exception))
+
+    var failureCalled = false
+    challengeRepositoryFireStore.updateChallenge(
+        updatedChallenge = updatedChallenge,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = {
+          failureCalled = true
+          assertEquals(exception, it)
+        })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assertTrue(failureCalled)
+    verify(mockChallengeDocRef).set(updatedChallenge)
+  }
+
+  @Test
+  fun recordPlayerTime_shouldUpdatePlayerTimeInFirestore() {
+    val playerId = "player1"
+    val timeTaken: Long = 120
+    `when`(mockChallengeDocRef.update("playerTime", timeTaken)).thenReturn(Tasks.forResult(null))
+
+    var successCalled = false
+    challengeRepositoryFireStore.recordPlayerTime(
+        challengeId = challengeId,
+        playerId = playerId,
+        timeTaken = timeTaken,
+        onSuccess = { successCalled = true },
+        onFailure = { fail("Failure callback should not be called") })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assertTrue(successCalled)
+    verify(mockChallengeDocRef).update("playerTime", timeTaken)
+  }
+
+  @Test
+  fun recordPlayerTime_shouldCallOnFailureOnFirestoreError() {
+    val playerId = "player1"
+    val timeTaken: Long = 120
+    val exception = Exception("Firestore error")
+    `when`(mockChallengeDocRef.update("playerTime", timeTaken))
+        .thenReturn(Tasks.forException(exception))
+
+    var failureCalled = false
+    challengeRepositoryFireStore.recordPlayerTime(
+        challengeId = challengeId,
+        playerId = playerId,
+        timeTaken = timeTaken,
+        onSuccess = { fail("Success callback should not be called") },
+        onFailure = {
+          failureCalled = true
+          assertEquals(exception, it)
+        })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    assertTrue(failureCalled)
+    verify(mockChallengeDocRef).update("playerTime", timeTaken)
   }
 }

--- a/app/src/test/java/com/github/se/signify/model/challenge/ChallengeTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/challenge/ChallengeTest.kt
@@ -16,38 +16,45 @@ class ChallengeTest {
     assertEquals("", challenge.mode)
     assertEquals("pending", challenge.status)
     assertEquals(1, challenge.round)
-    assertEquals(0, challenge.player1Score)
-    assertEquals(0, challenge.player2Score)
-    assertEquals("", challenge.currentGesture)
-    assertEquals(emptyMap<String, String>(), challenge.responses)
+    assertEquals(emptyList<Long>(), challenge.player1Times)
+    assertEquals(emptyList<Long>(), challenge.player2Times)
+    assertEquals(listOf(false, false, false), challenge.player1RoundCompleted)
+    assertEquals(listOf(false, false, false), challenge.player2RoundCompleted)
+    assertEquals("not_started", challenge.gameStatus)
   }
 
   @Test
   fun `parameterized constructor initializes properties correctly`() {
-    val responses = mapOf("player1" to "response1", "player2" to "response2")
+    val player1Times = mutableListOf(5000L, 6000L, 7000L)
+    val player2Times = mutableListOf(4000L, 3000L, 8000L)
+    val player1RoundCompleted = mutableListOf(true, true, true)
+    val player2RoundCompleted = mutableListOf(true, false, true)
+
     val challenge =
         Challenge(
             challengeId = "challenge123",
             player1 = "player1",
             player2 = "player2",
-            mode = "sprint",
-            status = "active",
+            mode = "chrono",
+            status = "in_progress",
             round = 2,
-            player1Score = 5,
-            player2Score = 3,
-            currentGesture = "wave",
-            responses = responses)
+            player1Times = player1Times,
+            player2Times = player2Times,
+            player1RoundCompleted = player1RoundCompleted,
+            player2RoundCompleted = player2RoundCompleted,
+            gameStatus = "in_progress")
 
     assertEquals("challenge123", challenge.challengeId)
     assertEquals("player1", challenge.player1)
     assertEquals("player2", challenge.player2)
-    assertEquals("sprint", challenge.mode)
-    assertEquals("active", challenge.status)
+    assertEquals("chrono", challenge.mode)
+    assertEquals("in_progress", challenge.status)
     assertEquals(2, challenge.round)
-    assertEquals(5, challenge.player1Score)
-    assertEquals(3, challenge.player2Score)
-    assertEquals("wave", challenge.currentGesture)
-    assertEquals(responses, challenge.responses)
+    assertEquals(player1Times, challenge.player1Times)
+    assertEquals(player2Times, challenge.player2Times)
+    assertEquals(player1RoundCompleted, challenge.player1RoundCompleted)
+    assertEquals(player2RoundCompleted, challenge.player2RoundCompleted)
+    assertEquals("in_progress", challenge.gameStatus)
   }
 
   @Test
@@ -57,25 +64,27 @@ class ChallengeTest {
             challengeId = "challenge123",
             player1 = "player1",
             player2 = "player2",
-            mode = "sprint",
-            status = "active",
+            mode = "chrono",
+            status = "in_progress",
             round = 2,
-            player1Score = 5,
-            player2Score = 3,
-            currentGesture = "wave",
-            responses = mapOf("player1" to "response1"))
+            player1Times = mutableListOf(5000L, 6000L, 7000L),
+            player2Times = mutableListOf(4000L, 3000L, 8000L),
+            player1RoundCompleted = mutableListOf(true, true, true),
+            player2RoundCompleted = mutableListOf(true, false, true),
+            gameStatus = "in_progress")
     val challenge2 =
         Challenge(
             challengeId = "challenge123",
             player1 = "player1",
             player2 = "player2",
-            mode = "sprint",
-            status = "active",
+            mode = "chrono",
+            status = "in_progress",
             round = 2,
-            player1Score = 5,
-            player2Score = 3,
-            currentGesture = "wave",
-            responses = mapOf("player1" to "response1"))
+            player1Times = mutableListOf(5000L, 6000L, 7000L),
+            player2Times = mutableListOf(4000L, 3000L, 8000L),
+            player1RoundCompleted = mutableListOf(true, true, true),
+            player2RoundCompleted = mutableListOf(true, false, true),
+            gameStatus = "in_progress")
 
     assertEquals(challenge1, challenge2)
     assertEquals(challenge1.hashCode(), challenge2.hashCode())
@@ -96,25 +105,27 @@ class ChallengeTest {
             challengeId = "challenge123",
             player1 = "player1",
             player2 = "player2",
-            mode = "sprint",
-            status = "active",
+            mode = "chrono",
+            status = "in_progress",
             round = 2,
-            player1Score = 5,
-            player2Score = 3,
-            currentGesture = "wave",
-            responses = mapOf("player1" to "response1"))
+            player1Times = mutableListOf(5000L, 6000L, 7000L),
+            player2Times = mutableListOf(4000L, 3000L, 8000L),
+            player1RoundCompleted = mutableListOf(true, true, true),
+            player2RoundCompleted = mutableListOf(true, false, true),
+            gameStatus = "in_progress")
 
-    val modifiedChallenge = challenge.copy(status = "completed", player1Score = 10)
+    val modifiedChallenge = challenge.copy(status = "completed", round = 3)
 
     assertEquals("challenge123", modifiedChallenge.challengeId)
     assertEquals("player1", modifiedChallenge.player1)
     assertEquals("player2", modifiedChallenge.player2)
-    assertEquals("sprint", modifiedChallenge.mode)
+    assertEquals("chrono", modifiedChallenge.mode)
     assertEquals("completed", modifiedChallenge.status) // Modified
-    assertEquals(2, modifiedChallenge.round)
-    assertEquals(10, modifiedChallenge.player1Score) // Modified
-    assertEquals(3, modifiedChallenge.player2Score)
-    assertEquals("wave", modifiedChallenge.currentGesture)
-    assertEquals(mapOf("player1" to "response1"), modifiedChallenge.responses)
+    assertEquals(3, modifiedChallenge.round) // Modified
+    assertEquals(challenge.player1Times, modifiedChallenge.player1Times)
+    assertEquals(challenge.player2Times, modifiedChallenge.player2Times)
+    assertEquals(challenge.player1RoundCompleted, modifiedChallenge.player1RoundCompleted)
+    assertEquals(challenge.player2RoundCompleted, modifiedChallenge.player2RoundCompleted)
+    assertEquals(challenge.gameStatus, modifiedChallenge.gameStatus)
   }
 }


### PR DESCRIPTION
## Summary
This Pull Request implements a new challenge feature in the Signify app — the *Chrono Challenge*. The changes include modifications to the database. The goal is to provide users with an engaging experience where they complete challenges against friends in the minimum time possible.

## Changes in this PR
### 1. **Database Handling and Challenge Logic Modifications**
- Added new fields to the `Challenge` class:
  - Track player-specific round completion (`player1RoundCompleted`, `player2RoundCompleted`).
  - Track player times (`player1Times`, `player2Times`) for each round, recorded in milliseconds.
- Updated `ChallengeRepository` and `ChallengeRepositoryFirestore` to handle:
  - Creation, update, and retrieval of challenge states.
  - Saving player times and tracking each round's completion status.
  - Proper calculation and display of the player's total time after all rounds are completed.

## Checklist
- [x] Database modifications for tracking challenge states and player times.

Thank you for reviewing this pull request. Feel free to provide feedback or ask questions regarding any of the changes made.