### PR TITLE
Playable Chrono Game UI

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/ChronoChallengeGameScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/ChronoChallengeGameScreenTest.kt
@@ -1,2 +1,185 @@
 package com.github.se.signify.ui.screens.challenge
 
+import android.Manifest
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import com.github.se.signify.model.auth.MockUserSession
+import com.github.se.signify.model.challenge.Challenge
+import com.github.se.signify.model.challenge.MockChallengeRepository
+import com.github.se.signify.model.di.AppDependencyProvider
+import com.github.se.signify.model.hand.HandLandMarkViewModel
+import com.github.se.signify.ui.navigation.NavigationActions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+
+@RunWith(AndroidJUnit4::class)
+class ChronoChallengeGameScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @get:Rule
+  val cameraAccess: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.CAMERA)
+
+  private lateinit var mockNavigationActions: NavigationActions
+  private lateinit var handLandMarkViewModel: HandLandMarkViewModel
+  private lateinit var challengeRepository: MockChallengeRepository
+  private val challengeId = "challenge123"
+
+  @Before
+  fun setup() {
+    val context = mock(Context::class.java)
+    val handLandMarkImplementation = AppDependencyProvider.handLandMarkRepository()
+    handLandMarkViewModel = HandLandMarkViewModel(handLandMarkImplementation, context)
+    mockNavigationActions = mock(NavigationActions::class.java)
+
+    // Set up a mock challenge repository with test challenge data
+    challengeRepository =
+        MockChallengeRepository().apply {
+          setChallenges(
+              listOf(
+                  Challenge(
+                      challengeId = challengeId,
+                      player1 = "user1",
+                      player2 = "user2",
+                      mode = "Chrono",
+                      status = "in_progress",
+                      round = 1,
+                      roundWords = listOf("apple", "banana", "cherry"),
+                      player1Times = mutableListOf(),
+                      player2Times = mutableListOf(),
+                      player1RoundCompleted = listOf(false, false, false),
+                      player2RoundCompleted = listOf(false, false, false),
+                      gameStatus = "in_progress")))
+        }
+  }
+
+  @Test
+  fun chronoChallengeGameScreen_displaysComponentsCorrectly() {
+    composeTestRule.setContent {
+      ChronoChallengeGameScreen(
+          navigationActions = mockNavigationActions,
+          userSession = MockUserSession(),
+          challengeRepository = challengeRepository,
+          handLandMarkViewModel = handLandMarkViewModel,
+          challengeId = challengeId)
+    }
+
+    // Wait for the challenge to load
+    composeTestRule.waitForIdle()
+
+    // Assert that components are displayed after loading
+    composeTestRule.onNodeWithTag("ElapsedTimeText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("CurrentLetterBox").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("SentenceLayerBox").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("CameraPlaceholder").assertIsDisplayed()
+  }
+
+  @Test
+  fun imageIsDisplayed_ifImageExists() {
+    composeTestRule.setContent {
+      ChronoChallengeGameScreen(
+          navigationActions = mockNavigationActions,
+          userSession = MockUserSession(),
+          challengeRepository = challengeRepository,
+          handLandMarkViewModel = handLandMarkViewModel,
+          challengeId = challengeId)
+    }
+
+    // Wait for the challenge to load
+    composeTestRule.waitForIdle()
+
+    // Check if the image with content description "Sign image" is displayed
+    composeTestRule.onNodeWithContentDescription("Sign image").assertIsDisplayed()
+  }
+
+  @Test
+  fun chronoChallengeGameScreen_displaysNoWordAvailableText_whenNoWordsPresent() {
+    // Update the challenge repository to have an empty word list
+    challengeRepository.setChallenges(
+        listOf(
+            Challenge(
+                challengeId = challengeId,
+                player1 = "user1",
+                player2 = "user2",
+                mode = "Chrono",
+                status = "in_progress",
+                round = 1,
+                roundWords = emptyList(), // No words
+                player1Times = mutableListOf(),
+                player2Times = mutableListOf(),
+                player1RoundCompleted = listOf(false, false, false),
+                player2RoundCompleted = listOf(false, false, false),
+                gameStatus = "in_progress")))
+
+    // Relaunch the composable with the updated challenge
+    composeTestRule.setContent {
+      ChronoChallengeGameScreen(
+          navigationActions = mockNavigationActions,
+          userSession = MockUserSession(),
+          challengeRepository = challengeRepository,
+          handLandMarkViewModel = handLandMarkViewModel,
+          challengeId = challengeId)
+    }
+
+    // Assert that the "No word available" text is displayed
+    composeTestRule.onNodeWithTag("NoWordAvailableText").assertIsDisplayed()
+  }
+
+  @Test
+  fun chronoChallengeGameScreen_displaysChallengeCompletedText_whenChallengeIsCompleted() {
+    challengeRepository.setChallenges(
+        listOf(
+            Challenge(
+                challengeId = challengeId,
+                player1 = "user1",
+                player2 = "user2",
+                mode = "Chrono",
+                status = "completed",
+                round = 1,
+                roundWords = listOf("apple", "banana", "cherry"),
+                player1Times = mutableListOf(),
+                player2Times = mutableListOf(),
+                player1RoundCompleted = listOf(true, true, true),
+                player2RoundCompleted = listOf(true, true, true),
+                gameStatus = "completed")))
+
+    composeTestRule.setContent {
+      ChronoChallengeGameScreen(
+          navigationActions = mockNavigationActions,
+          userSession = MockUserSession(),
+          challengeRepository = challengeRepository,
+          handLandMarkViewModel = handLandMarkViewModel,
+          challengeId = challengeId)
+    }
+
+    // Assert that the challenge completed text is displayed
+    composeTestRule.onNodeWithTag("ChallengeCompletedText").assertIsDisplayed()
+  }
+
+  @Test
+  fun chronoChallengeGameScreen_updatesElapsedTime_whenGameIsActive() {
+    composeTestRule.setContent {
+      ChronoChallengeGameScreen(
+          navigationActions = mockNavigationActions,
+          userSession = MockUserSession(),
+          challengeRepository = challengeRepository,
+          handLandMarkViewModel = handLandMarkViewModel,
+          challengeId = challengeId)
+    }
+
+    // Assert the initial state
+    composeTestRule.onNodeWithTag("ElapsedTimeText").assertIsDisplayed()
+
+    // Wait to ensure the elapsed time has some time to change
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("ElapsedTimeText").assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/ChronoChallengeGameScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/ChronoChallengeGameScreenTest.kt
@@ -1,0 +1,2 @@
+package com.github.se.signify.ui.screens.challenge
+

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.se.signify.model.auth.MockUserSession
 import com.github.se.signify.model.auth.UserSession
+import com.github.se.signify.model.challenge.ChallengeMode
 import com.github.se.signify.model.challenge.MockChallengeRepository
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.ui.navigation.NavigationActions
@@ -117,6 +118,77 @@ class CreateAChallengeScreenTest {
     // Click "Cancel" button
     composeTestRule.onNodeWithTag("CancelButton").performClick()
     // Verify that the dialog is dismissed
+    composeTestRule.onNodeWithTag("DialogTitle").assertDoesNotExist()
+  }
+
+  @Test
+  fun testDialogAppearsForCorrectFriend() {
+    val friend = friends[1]
+    composeTestRule.onNodeWithTag("ChallengeButton_$friend").performClick()
+    composeTestRule.onNodeWithTag("DialogTitle").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("FriendName_$friend")
+        .assertIsDisplayed() // Verify correct friend in dialog
+  }
+
+  @Test
+  fun testDifferentChallengeModesSelectable() {
+    val friend = friends[0]
+    composeTestRule.onNodeWithTag("ChallengeButton_$friend").performClick()
+    composeTestRule.onNodeWithTag("DialogTitle").assertIsDisplayed()
+
+    ChallengeMode.entries.forEach { mode ->
+      composeTestRule.onNodeWithTag("${mode.modeName}ModeButton").performClick()
+      composeTestRule.onNodeWithTag("SendChallengeButton").assertIsEnabled()
+    }
+  }
+
+  @Test
+  fun testConfirmAndCancelDialogActions() {
+    val friend = friends[0]
+    composeTestRule.onNodeWithTag("ChallengeButton_$friend").performClick()
+    composeTestRule.onNodeWithTag("DialogTitle").assertIsDisplayed()
+
+    // Test confirm button is disabled by default
+    composeTestRule.onNodeWithTag("SendChallengeButton").assertIsNotEnabled()
+
+    // Select "Sprint" mode
+    composeTestRule.onNodeWithTag("SprintModeButton").performClick()
+    composeTestRule.onNodeWithTag("SendChallengeButton").assertIsEnabled()
+
+    // Test cancel button
+    composeTestRule.onNodeWithTag("CancelButton").performClick()
+    composeTestRule.onNodeWithTag("DialogTitle").assertDoesNotExist()
+
+    // Test that dialog no longer appears after cancel
+    composeTestRule.onNodeWithTag("ChallengeButton_$friend").assertIsDisplayed()
+  }
+
+  @Test
+  fun testFriendsListUpdatesCorrectly() {
+    // Initially, verify all friends are displayed
+    friends.forEach { friend ->
+      composeTestRule.onNodeWithTag("FriendCard_$friend").assertIsDisplayed()
+    }
+
+    // Update friends list to contain only one friend
+    friends.clear()
+    friends.add("David")
+    composeTestRule.waitForIdle()
+
+    // Verify the new friend list is displayed
+    composeTestRule.onNodeWithTag("FriendCard_David").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("FriendCard_Alice").assertDoesNotExist()
+  }
+
+  @Test
+  fun testDismissDialogWithoutSelectionDoesNotCrash() {
+    val friend = friends[0]
+    composeTestRule.onNodeWithTag("ChallengeButton_$friend").performClick()
+    composeTestRule.onNodeWithTag("DialogTitle").assertIsDisplayed()
+
+    // Dismiss the dialog without selecting anything
+    composeTestRule.onNodeWithTag("CancelButton").performClick()
     composeTestRule.onNodeWithTag("DialogTitle").assertDoesNotExist()
   }
 }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreenTest.kt
@@ -10,19 +10,18 @@ import com.github.se.signify.model.challenge.MockChallengeRepository
 import com.github.se.signify.model.user.UserRepository
 import com.github.se.signify.ui.navigation.NavigationActions
 import com.github.se.signify.ui.navigation.Screen
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
-import org.mockito.Mockito.doAnswer
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class NewChallengeScreenTest {
+
   @get:Rule val composeTestRule = createComposeRule()
 
   private lateinit var userSession: UserSession
@@ -52,7 +51,7 @@ class NewChallengeScreenTest {
     userRepository = Mockito.mock(UserRepository::class.java)
     challengeRepository = MockChallengeRepository()
 
-    // Mock UserRepository
+    // Mock UserRepository to provide ongoing challenges list
     doAnswer { invocation ->
           val onSuccess = invocation.arguments[1] as (List<Challenge>) -> Unit
           onSuccess(ongoingChallenges)
@@ -75,55 +74,47 @@ class NewChallengeScreenTest {
   }
 
   @Test
-  fun testTopBlueBarIsDisplayed() {
-    composeTestRule.onNodeWithTag("TopBar").assertIsDisplayed()
-  }
+  fun testMyFriendsButton_click_navigatesToFriendsScreen() {
+    composeTestRule.onNodeWithTag("MyFriendsButton").assertIsDisplayed().performClick()
 
-  @Test
-  fun testBackButtonNavigatesBack() {
-    composeTestRule.onNodeWithTag("BackButton").performClick()
-    verify(navigationActions).goBack()
-  }
-
-  @Test
-  fun testMyFriendsButtonIsDisplayedAndNavigates() {
-    composeTestRule.onNodeWithTag("MyFriendsButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("MyFriendsButton").performClick()
     verify(navigationActions).navigateTo(Screen.FRIENDS)
   }
 
   @Test
-  fun testCreateChallengeButtonIsDisplayedAndNavigates() {
-    composeTestRule.onNodeWithTag("CreateChallengeButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("CreateChallengeButton").performClick()
+  fun testCreateChallengeButton_click_navigatesToCreateChallengeScreen() {
+    composeTestRule.onNodeWithTag("CreateChallengeButton").assertIsDisplayed().performClick()
+
     verify(navigationActions).navigateTo(Screen.CREATE_CHALLENGE)
   }
 
   @Test
-  fun testOngoingChallengesDisplayed() {
-    composeTestRule.onNodeWithTag("OngoingChallengesTitle").assertIsDisplayed()
-    ongoingChallenges.forEachIndexed { index, challenge ->
-      composeTestRule.onNodeWithTag("OngoingChallengeCard$index").assertIsDisplayed()
-      composeTestRule.onNodeWithText("Opponent: ${challenge.player2}").assertIsDisplayed()
-      composeTestRule.onNodeWithText("Mode: ${challenge.mode}").assertIsDisplayed()
+  fun testOngoingChallengesBox_isDisplayed() {
+    composeTestRule.onNodeWithTag("OngoingChallengesBox").assertIsDisplayed()
+  }
+
+  @Test
+  fun testOngoingChallengesTitle_isDisplayed() {
+    composeTestRule
+        .onNodeWithTag("OngoingChallengesTitle")
+        .assertIsDisplayed()
+        .assertTextEquals("My Ongoing Challenges")
+  }
+
+  @Test
+  fun testOngoingChallengesLazyColumn_displaysAllChallenges() {
+    composeTestRule.onNodeWithTag("OngoingChallengesLazyColumn").assertIsDisplayed()
+
+    ongoingChallenges.forEachIndexed { index, _ ->
+      val challengeCardTag = "OngoingChallengeCard$index"
+      composeTestRule.onNodeWithTag(challengeCardTag).assertIsDisplayed()
     }
   }
 
   @Test
-  fun testDeleteOngoingChallenge() {
-    val challengeIdToDelete = ongoingChallenges[0].challengeId
+  fun testDeleteButton_click() {
+    val challengeId = ongoingChallenges[0].challengeId
 
-    composeTestRule.onNodeWithTag("DeleteButton$challengeIdToDelete").assertExists()
-    composeTestRule.onNodeWithTag("DeleteButton$challengeIdToDelete").performClick()
-
-    // Verify that the MockChallengeRepository is updated
-    assertTrue(challengeRepository.wasDeleteChallengeCalled())
-    assertEquals(challengeIdToDelete, challengeRepository.lastDeletedChallengeId())
-  }
-
-  @Test
-  fun testNewChallengeScreenViewModelInitialization() {
-    verify(userRepository).getFriendsList(eq(userSession.getUserId()!!), any(), any())
-    verify(userRepository).getOngoingChallenges(eq(userSession.getUserId()!!), any(), any())
+    // Click the delete button for the first ongoing challenge
+    composeTestRule.onNodeWithTag("DeleteButton$challengeId").assertIsDisplayed().performClick()
   }
 }

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -15,10 +15,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.github.se.signify.model.di.AppDependencyProvider
 import com.github.se.signify.model.di.DependencyProvider
 import com.github.se.signify.model.exercise.ExerciseLevel
@@ -31,6 +33,7 @@ import com.github.se.signify.ui.screens.auth.LoginScreen
 import com.github.se.signify.ui.screens.auth.UnauthenticatedScreen
 import com.github.se.signify.ui.screens.challenge.ChallengeHistoryScreen
 import com.github.se.signify.ui.screens.challenge.ChallengeScreen
+import com.github.se.signify.ui.screens.challenge.ChronoChallengeGameScreen
 import com.github.se.signify.ui.screens.challenge.CreateAChallengeScreen
 import com.github.se.signify.ui.screens.challenge.NewChallengeScreen
 import com.github.se.signify.ui.screens.home.ASLRecognition
@@ -124,6 +127,22 @@ fun SignifyAppPreview(
             dependencyProvider.userRepository(),
             dependencyProvider.challengeRepository())
       }
+
+      composable(
+          route = Screen.CHRONO_CHALLENGE.route, // Define the base route with `{challengeId}`
+          arguments = listOf(navArgument("challengeId") { type = NavType.StringType })) {
+              backStackEntry ->
+            val challengeId =
+                backStackEntry.arguments?.getString("challengeId") ?: return@composable
+
+            // Pass all dependencies
+            ChronoChallengeGameScreen(
+                navigationActions = navigationActions,
+                userSession = dependencyProvider.userSession(),
+                challengeRepository = dependencyProvider.challengeRepository(),
+                handLandMarkViewModel = handLandMarkViewModel,
+                challengeId = challengeId)
+          }
       composable(Screen.CREATE_CHALLENGE.route) {
         CreateAChallengeScreen(
             navigationActions,

--- a/app/src/main/java/com/github/se/signify/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/signify/ui/navigation/NavigationActions.kt
@@ -50,12 +50,24 @@ open class NavigationActions(
    *
    * @param screen The screen to navigate to.
    */
-  open fun navigateTo(screen: Screen) {
+  open fun navigateTo(screen: Screen, params: Map<String, String>? = null) {
     if (screen.requiresAuth && !userSession.isLoggedIn()) {
       onUnauthenticated()
       return
     }
-    navController.navigate(screen.route)
+
+    val route =
+        if (params != null) {
+          var routeWithParams = screen.route
+          params.forEach { (key, value) ->
+            routeWithParams = routeWithParams.replace("{$key}", value)
+          }
+          routeWithParams
+        } else {
+          screen.route
+        }
+
+    navController.navigate(route)
   }
 
   open fun goBack() {

--- a/app/src/main/java/com/github/se/signify/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/navigation/Screen.kt
@@ -19,5 +19,11 @@ enum class Screen(val route: String, val requiresAuth: Boolean = true) {
   CHALLENGE("Challenge Screen"),
   NEW_CHALLENGE("NewChallenge Screen"),
   CREATE_CHALLENGE("CreateChallenge Screen"),
-  CHALLENGE_HISTORY("ChallengeHistory Screen")
+  CHALLENGE_HISTORY("ChallengeHistory Screen"),
+  CHRONO_CHALLENGE("ChronoChallenge Screen/{challengeId}");
+
+  companion object {
+    // Generate dynamic route for a specific challenge ID
+    fun chronoChallengeWithId(challengeId: String) = "ChronoChallenge Screen/$challengeId"
+  }
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChronoChallengeGameScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChronoChallengeGameScreen.kt
@@ -1,2 +1,299 @@
 package com.github.se.signify.ui.screens.challenge
 
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.SystemClock
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.signify.model.auth.UserSession
+import com.github.se.signify.model.challenge.Challenge
+import com.github.se.signify.model.challenge.ChallengeRepository
+import com.github.se.signify.model.hand.HandLandMarkViewModel
+import com.github.se.signify.ui.AnnexScreenScaffold
+import com.github.se.signify.ui.CameraPlaceholder
+import com.github.se.signify.ui.navigation.NavigationActions
+import com.github.se.signify.ui.navigation.Screen
+import kotlinx.coroutines.delay
+
+@Composable
+fun ChronoChallengeGameScreen(
+    navigationActions: NavigationActions,
+    userSession: UserSession,
+    challengeRepository: ChallengeRepository,
+    handLandMarkViewModel: HandLandMarkViewModel,
+    challengeId: String
+) {
+  val context = LocalContext.current
+  val currentUserId = userSession.getUserId() ?: return
+
+  // Mutable state for tracking challenge information
+  var currentChallenge by remember { mutableStateOf<Challenge?>(null) }
+  var currentWord by remember { mutableStateOf("") }
+  var startTime by remember { mutableLongStateOf(0L) }
+  var elapsedTime by remember { mutableLongStateOf(0L) }
+  var currentLetterIndex by rememberSaveable { mutableIntStateOf(0) }
+  var typedWord by rememberSaveable { mutableStateOf("") }
+  var isGameActive by remember { mutableStateOf(false) }
+
+  // Fetch the current challenge
+  LaunchedEffect(challengeId) {
+    challengeRepository.getChallengeById(
+        challengeId = challengeId,
+        onSuccess = { challenge ->
+          currentChallenge = challenge
+          if (challenge.roundWords.isNotEmpty() &&
+              challenge.round > 0 &&
+              challenge.round <= challenge.roundWords.size) {
+            currentWord = challenge.roundWords[challenge.round - 1]
+            currentLetterIndex = 0
+            typedWord = ""
+            isGameActive = true
+            startTime = SystemClock.elapsedRealtime()
+          } else {
+            Toast.makeText(context, "Invalid round information in challenge", Toast.LENGTH_SHORT)
+                .show()
+          }
+        },
+        onFailure = {
+          Toast.makeText(context, "Failed to fetch challenge", Toast.LENGTH_SHORT).show()
+        })
+  }
+
+  // Real-time update of the elapsed time when the game is active
+  LaunchedEffect(isGameActive) {
+    if (isGameActive) {
+      while (isGameActive) {
+        elapsedTime = SystemClock.elapsedRealtime() - startTime
+        delay(100)
+      }
+    }
+  }
+
+  // Gesture Recognition Updates
+  val landmarksState by handLandMarkViewModel.landMarks().collectAsState()
+  val detectedGesture = handLandMarkViewModel.getSolution()
+
+  LaunchedEffect(landmarksState) {
+    if (!landmarksState.isNullOrEmpty() && isGameActive) {
+      val currentLetter = currentWord.getOrNull(currentLetterIndex)?.uppercaseChar()
+      if (currentLetter != null &&
+          detectedGesture.equals(currentLetter.toString(), ignoreCase = true)) {
+        currentLetterIndex++
+        if (currentLetterIndex <= currentWord.length) {
+          typedWord += currentLetter
+        }
+
+        if (typedWord.length == currentWord.length) {
+          isGameActive = false
+          elapsedTime = SystemClock.elapsedRealtime() - startTime
+          onWordCompletion(
+              context,
+              currentUserId,
+              challengeRepository,
+              currentChallenge,
+              elapsedTime,
+              navigationActions)
+        }
+      }
+    }
+  }
+
+  // If current challenge is null, show loading text
+  if (currentChallenge == null) {
+    DisplayLoadingText()
+    return
+  }
+
+  // If the challenge is completed, show completed message
+  if (currentChallenge?.gameStatus == "completed") {
+    DisplayChallengeCompletedText()
+    return
+  }
+
+  // Render the challenge screen
+  AnnexScreenScaffold(
+      navigationActions = navigationActions, testTagColumn = "ChronoChallengeScreen") {
+        if (currentWord.isNotEmpty()) {
+          ChronoChallengeContent(
+              elapsedTime = elapsedTime,
+              currentWord = currentWord,
+              currentLetterIndex = currentLetterIndex,
+              handLandMarkViewModel = handLandMarkViewModel,
+          )
+        } else {
+          // If no words are available, show appropriate message
+          Text(
+              "No word available for this round.",
+              modifier = Modifier.testTag("NoWordAvailableText"))
+        }
+      }
+}
+
+@Composable
+fun ChronoChallengeContent(
+    elapsedTime: Long,
+    currentWord: String,
+    currentLetterIndex: Int,
+    handLandMarkViewModel: HandLandMarkViewModel
+) {
+  Column(
+      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("ChronoChallengeContent"),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Top) {
+        Chronometer(elapsedTime)
+        Spacer(modifier = Modifier.height(32.dp))
+
+        CurrentLetterDisplay(currentWord, currentLetterIndex)
+        SentenceLayerDisplay(currentWord, currentLetterIndex)
+        CameraPlaceholder(handLandMarkViewModel, Modifier.testTag("CameraPlaceholder"))
+      }
+}
+
+@Composable
+fun Chronometer(elapsedTime: Long) {
+  Row(
+      modifier = Modifier.fillMaxWidth().testTag("ChronometerRow"),
+      horizontalArrangement = Arrangement.End) {
+        Text(
+            text = "Time: ${elapsedTime / 1000}s",
+            fontSize = 20.sp,
+            modifier = Modifier.padding(8.dp).testTag("ElapsedTimeText"))
+      }
+}
+
+@SuppressLint("DiscouragedApi")
+@Composable
+fun CurrentLetterDisplay(currentWord: String, currentLetterIndex: Int) {
+  val context = LocalContext.current
+  val currentLetter = currentWord.getOrNull(currentLetterIndex)?.uppercaseChar() ?: 'A'
+  val imageName = "letter_${currentLetter.lowercase()}"
+  val imageResId = context.resources.getIdentifier(imageName, "drawable", context.packageName)
+
+  if (imageResId != 0) {
+    Box(
+        modifier =
+            Modifier.fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .height(150.dp)
+                .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(16.dp))
+                .border(2.dp, MaterialTheme.colorScheme.outline, shape = RoundedCornerShape(16.dp))
+                .testTag("CurrentLetterBox"),
+        contentAlignment = Alignment.Center) {
+          Icon(
+              painter = painterResource(id = imageResId),
+              contentDescription = "Sign image",
+              tint = MaterialTheme.colorScheme.onSurface,
+              modifier = Modifier.size(120.dp).testTag("CurrentLetterIcon"))
+        }
+    Spacer(modifier = Modifier.height(16.dp))
+  }
+}
+
+@Composable
+fun SentenceLayerDisplay(currentWord: String, currentLetterIndex: Int) {
+  Box(
+      modifier =
+          Modifier.fillMaxWidth()
+              .height(150.dp)
+              .padding(horizontal = 16.dp)
+              .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(16.dp))
+              .border(2.dp, MaterialTheme.colorScheme.outline, shape = RoundedCornerShape(16.dp))
+              .testTag("SentenceLayerBox")) {
+        Text(
+            text = buildForegroundText(currentWord, currentLetterIndex),
+            style = TextStyle(fontSize = 30.sp),
+            color = MaterialTheme.colorScheme.onSecondary,
+            modifier = Modifier.align(Alignment.Center).testTag("CurrentWordText"))
+      }
+}
+
+@Composable
+fun DisplayLoadingText() {
+  Text("Loading challenge...", modifier = Modifier.testTag("LoadingChallengeText"))
+}
+
+@Composable
+fun DisplayChallengeCompletedText() {
+  Text(
+      "Challenge Completed! Go to History to see the results.",
+      modifier = Modifier.testTag("ChallengeCompletedText"))
+}
+
+@Composable
+fun buildForegroundText(currentWord: String, currentLetterIndex: Int): AnnotatedString {
+  val clampedIndex = currentLetterIndex.coerceAtMost(currentWord.length - 1)
+
+  return buildAnnotatedString {
+    append(currentWord.substring(0, clampedIndex)) // Before the current letter
+    if (clampedIndex < currentWord.length) {
+      withStyle(
+          style =
+              SpanStyle(
+                  letterSpacing = 10.sp,
+                  color = MaterialTheme.colorScheme.secondary,
+                  fontSize = 50.sp)) {
+            append(currentWord[clampedIndex].uppercase()) // Current letter in uppercase
+      }
+    }
+    if (clampedIndex + 1 < currentWord.length) {
+      append(currentWord.substring(clampedIndex + 1)) // After the current letter
+    }
+  }
+}
+
+fun onWordCompletion(
+    context: Context,
+    currentUserId: String,
+    challengeRepository: ChallengeRepository,
+    challenge: Challenge?,
+    elapsedTime: Long,
+    navigationActions: NavigationActions
+) {
+  challenge?.let {
+    val updatedChallenge =
+        it.copy(
+            gameStatus = if (it.round == 3) "completed" else "in_progress",
+            round = it.round + 1,
+            player1RoundCompleted =
+                it.player1RoundCompleted.toMutableList().apply {
+                  if (currentUserId == it.player1) this[it.round - 1] = true
+                },
+            player2RoundCompleted =
+                it.player2RoundCompleted.toMutableList().apply {
+                  if (currentUserId == it.player2) this[it.round - 1] = true
+                },
+            player1Times =
+                it.player1Times.toMutableList().apply {
+                  if (currentUserId == it.player1) add(elapsedTime)
+                },
+            player2Times =
+                it.player2Times.toMutableList().apply {
+                  if (currentUserId == it.player2) add(elapsedTime)
+                })
+    challengeRepository.updateChallenge(
+        updatedChallenge = updatedChallenge,
+        onSuccess = {
+          Toast.makeText(context, "Score saved successfully", Toast.LENGTH_SHORT).show()
+          navigationActions.navigateTo(Screen.CHALLENGE)
+        },
+        onFailure = { Toast.makeText(context, "Failed to save score", Toast.LENGTH_SHORT).show() })
+  }
+}

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChronoChallengeGameScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChronoChallengeGameScreen.kt
@@ -1,0 +1,2 @@
+package com.github.se.signify.ui.screens.challenge
+

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
@@ -1,31 +1,17 @@
 package com.github.se.signify.ui.screens.challenge
 
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -67,7 +53,6 @@ fun CreateAChallengeScreen(
     Text(
         text = "Select a Friend to Challenge",
         fontSize = 24.sp,
-        color = MaterialTheme.colorScheme.onBackground,
         modifier = Modifier.testTag("ChallengeTitle"))
 
     Spacer(modifier = Modifier.height(16.dp))
@@ -77,7 +62,7 @@ fun CreateAChallengeScreen(
       Text(
           text = "No friends available",
           fontSize = 18.sp,
-          color = MaterialTheme.colorScheme.error,
+          color = Color.Gray,
           modifier = Modifier.testTag("NoFriendsText"))
     } else {
       // List of Friends
@@ -119,7 +104,7 @@ fun FriendCard(friendId: String, content: @Composable () -> Unit) {
       modifier =
           Modifier.fillMaxWidth()
               .padding(8.dp)
-              .border(1.dp, MaterialTheme.colorScheme.onBackground, RoundedCornerShape(16.dp))
+              .border(1.dp, Color.Gray, RoundedCornerShape(16.dp))
               .testTag("FriendCard_$friendId"), // Add test tag for each friend card
       shape = RoundedCornerShape(16.dp),
   ) {
@@ -131,7 +116,7 @@ fun FriendCard(friendId: String, content: @Composable () -> Unit) {
           Text(
               text = friendId,
               fontSize = 20.sp,
-              color = MaterialTheme.colorScheme.primary,
+              color = Color.Black,
               modifier = Modifier.testTag("FriendName_$friendId"))
 
           Spacer(modifier = Modifier.width(16.dp))
@@ -172,8 +157,9 @@ fun ChallengeModeAlertDialog(
             testTag = "SendChallengeButton",
             text = "Send Challenge",
             backgroundColor = MaterialTheme.colorScheme.primary,
+            textColor = MaterialTheme.colorScheme.onPrimary,
             enabled = selectedMode.value != null,
-            textColor = MaterialTheme.colorScheme.onPrimary)
+        )
       },
       dismissButton = {
         UtilTextButton(
@@ -201,7 +187,7 @@ fun ChallengeModeAlertDialog(
           }
         }
       },
-      containerColor = MaterialTheme.colorScheme.background.copy(alpha = 0.5f),
+      containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.5f),
   )
 }
 

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
@@ -1,20 +1,16 @@
 package com.github.se.signify.ui.screens.challenge
 
 import android.annotation.SuppressLint
+import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -26,6 +22,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -54,7 +52,6 @@ fun NewChallengeScreen(
   val challengeViewModel: ChallengeViewModel =
       viewModel(factory = ChallengeViewModel.factory(userSession, challengeRepository))
 
-  // Fetch friends list and ongoing challenges when this screen is first displayed
   LaunchedEffect(Unit) {
     userViewModel.getFriendsList()
     userViewModel.getOngoingChallenges()
@@ -71,7 +68,7 @@ fun NewChallengeScreen(
         backgroundColor = MaterialTheme.colorScheme.primary,
         textColor = MaterialTheme.colorScheme.onPrimary)
 
-    Spacer(modifier = Modifier.height(32.dp)) // Increased space between buttons
+    Spacer(modifier = Modifier.height(32.dp))
 
     // Create a challenge button
     UtilTextButton(
@@ -81,7 +78,7 @@ fun NewChallengeScreen(
         backgroundColor = MaterialTheme.colorScheme.primary,
         textColor = MaterialTheme.colorScheme.onPrimary)
 
-    Spacer(modifier = Modifier.height(32.dp)) // Increased space between buttons and the box
+    Spacer(modifier = Modifier.height(32.dp))
 
     // Ongoing Challenges Section
     Box(
@@ -100,33 +97,38 @@ fun NewChallengeScreen(
                     color = MaterialTheme.colorScheme.onPrimary,
                     modifier = Modifier.testTag("OngoingChallengesTitle"))
 
-                Spacer(
-                    modifier =
-                        Modifier.height(24.dp)) // Increased space between title and challenges
+                Spacer(modifier = Modifier.height(24.dp))
 
                 // Scrollable Ongoing Challenges List
                 Box(
                     modifier =
                         Modifier.fillMaxWidth()
-                            .height(250.dp) // Set a maximum height to make the box
-                            // scrollable
+                            .height(250.dp)
                             .testTag("OngoingChallengesListBox")) {
                       LazyColumn(
                           verticalArrangement = Arrangement.spacedBy(16.dp),
                           modifier = Modifier.testTag("OngoingChallengesLazyColumn")) {
                             items(ongoingChallenges.size) { index ->
                               val challenge = ongoingChallenges[index]
+
                               OngoingChallengeCard(
                                   challenge = challenge,
                                   onDeleteClick = {
-                                    // Delete challenge from user's ongoing list and
-                                    // Firestore
                                     userViewModel.removeOngoingChallenge(
                                         userSession.getUserId()!!, challenge.challengeId)
                                     userViewModel.removeOngoingChallenge(
                                         challenge.player2, challenge.challengeId)
                                     challengeViewModel.deleteChallenge(challenge.challengeId)
                                   },
+                                  onPlayClick = {
+                                    Log.d(
+                                        "Navigation",
+                                        "Navigating with challengeId: ${challenge.challengeId}")
+                                    navigationActions.navigateTo(
+                                        Screen.CHRONO_CHALLENGE,
+                                        params = mapOf("challengeId" to challenge.challengeId))
+                                  },
+                                  userSession = userSession,
                                   modifier = Modifier.testTag("OngoingChallengeCard$index"))
                             }
                           }
@@ -138,52 +140,123 @@ fun NewChallengeScreen(
 
 @Composable
 fun OngoingChallengeCard(
-    challenge: Challenge, // Using the existing Challenge data class
+    challenge: Challenge,
     onDeleteClick: () -> Unit,
+    onPlayClick: () -> Unit,
+    userSession: UserSession,
     modifier: Modifier = Modifier
 ) {
+  val context = LocalContext.current
+
+  // Determine if the current player has completed all rounds
+  val currentUserId = userSession.getUserId()
+  val isChallengeCompleted =
+      if (currentUserId == challenge.player1) {
+        challenge.player1RoundCompleted.all { it }
+      } else {
+        challenge.player2RoundCompleted.all { it }
+      }
+
+  // Calculate the personal total time if the challenge is completed
+  val totalTime =
+      if (isChallengeCompleted) {
+        if (currentUserId == challenge.player1) {
+          challenge.player1Times.sum() / 1000
+        } else {
+          challenge.player2Times.sum() / 1000
+        }
+      } else null
+
   Card(
       modifier =
           modifier
               .fillMaxWidth()
-              .padding(
-                  horizontal = 8.dp, vertical = 4.dp) // Padding for better separation between cards
-              .border(
-                  1.dp,
-                  MaterialTheme.colorScheme.onPrimary,
-                  RoundedCornerShape(16.dp)), // Adding border for better visual separation
-      shape = RoundedCornerShape(16.dp), // Rounded corners
+              .padding(horizontal = 8.dp, vertical = 4.dp)
+              .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(16.dp))
+              .background(
+                  MaterialTheme.colorScheme
+                      .primary), // Explicitly set background color for better contrast
+      shape = RoundedCornerShape(16.dp),
   ) {
     Row(
-        modifier =
-            Modifier.fillMaxWidth().padding(16.dp), // Padding inside the card for the content
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement =
-            Arrangement.SpaceBetween // Space between opponent info and delete button
-        ) {
-          Column(
-              verticalArrangement = Arrangement.Center,
-              modifier = Modifier.weight(1f) // Take up all available space
-              ) {
-                // Opponent information
-                Text(
-                    text = "Opponent: ${challenge.player2}",
-                    fontSize = 18.sp,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold)
-                Text(
-                    text = "Mode: ${challenge.mode}",
-                    fontSize = 14.sp,
-                    color = MaterialTheme.colorScheme.onPrimary)
-              }
-          IconButton(
-              onClick = onDeleteClick,
+        horizontalArrangement = Arrangement.SpaceBetween) {
+          // Opponent Info Column
+          Column(verticalArrangement = Arrangement.Center, modifier = Modifier.weight(1f)) {
+            val opponentName =
+                if (currentUserId == challenge.player1) {
+                  challenge.player2
+                } else {
+                  challenge.player1
+                }
+            Text(
+                text = "Opponent: $opponentName",
+                fontSize = 18.sp,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold)
+            Text(
+                text = "Mode: ${challenge.mode}",
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onSurface)
+            if (isChallengeCompleted) {
+              Text(
+                  text = "Your Total Time: ${totalTime}s",
+                  fontSize = 14.sp,
+                  color = MaterialTheme.colorScheme.onSurface)
+            }
+          }
+
+          // Play Button
+          Box(
               modifier =
-                  Modifier.padding(start = 8.dp).testTag("DeleteButton${challenge.challengeId}")) {
-                Icon(
-                    imageVector = Icons.Default.Delete,
-                    contentDescription = "Delete Challenge",
-                    tint = MaterialTheme.colorScheme.error)
+                  Modifier.padding(start = 8.dp)
+                      .size(48.dp) // Set size to ensure consistency between buttons
+              ) {
+                IconButton(
+                    onClick = {
+                      if (isChallengeCompleted) {
+                        Toast.makeText(
+                                context,
+                                "Challenge already completed, wait for result",
+                                Toast.LENGTH_SHORT)
+                            .show()
+                      } else {
+                        onPlayClick()
+                      }
+                    },
+                    modifier =
+                        Modifier.fillMaxSize() // Make the button fill the Box size
+                            .testTag("PlayButton${challenge.challengeId}")) {
+                      Icon(
+                          imageVector = Icons.Default.PlayArrow,
+                          contentDescription = "Play Challenge",
+                          tint =
+                              if (isChallengeCompleted) Color.Gray
+                              else MaterialTheme.colorScheme.primary,
+                          modifier = Modifier.size(36.dp) // Icon size for better visibility
+                          )
+                    }
+              }
+
+          // Delete Button
+          Box(
+              modifier =
+                  Modifier.padding(start = 8.dp)
+                      .size(48.dp) // Set size to ensure consistency between buttons
+              ) {
+                IconButton(
+                    onClick = onDeleteClick,
+                    modifier =
+                        Modifier.fillMaxSize() // Make the button fill the Box size
+                            .testTag("DeleteButton${challenge.challengeId}")) {
+                      Icon(
+                          imageVector = Icons.Default.Delete,
+                          contentDescription = "Delete Challenge",
+                          tint = Color.Gray, // Explicitly set color for visibility
+                          modifier = Modifier.size(30.dp) // Icon size for better visibility
+                          )
+                    }
               }
         }
   }


### PR DESCRIPTION
## Summary
This Pull Request implements a new challenge feature in the Signify app — the *Chrono Challenge*. The changes include  creation of new screens, and enhancement of existing screens to support this new gameplay. The goal is to provide users with an engaging experience where they complete challenges against friends in the minimum time possible.

## Game Functionality
The *Chrono Challenge* mode is a new competitive feature where players are tasked with completing three ASL words as quickly as possible. Here are the key details:
- Players can play their three rounds at their convenience — there is no specific order in which they must play compared to their opponent.
- Once a player completes all three rounds, they wait for their opponent to finish before viewing the final challenge results.
- The goal is to complete the three words in the minimum total time, with progress tracked in real-time through gesture recognition and an in-game chronometer.

### 1. **ChronoChallengeGameScreen Implementation**
- Created a new `ChronoChallengeGameScreen` composable to facilitate the game:
  - Displayed a real-time chronometer in the top-right corner.
  - Implemented gesture recognition using the `HandLandMarkViewModel` to progress through the challenge rounds.
  - Updated the screen in real-time as gestures are successfully recognized and letters/words are completed.
  - Redirected to `NewChallengeScreen` upon successful completion of all rounds, while ensuring the play button becomes non-interactive for completed challenges.

### 2. **Modifications to CreateAChallengeScreen and NewChallengeScreen**
- Updated `CreateAChallengeScreen` and `NewChallengeScreen` to support the new challenge workflow:
  - Added a dynamic "Play" button to each challenge that redirects players to `ChronoChallengeGameScreen` using the appropriate `challengeId`.
  - Displayed the total time taken by the player once all rounds are completed.
  - Removed the `isTurnToPlay` field — players can now play rounds whenever they wish.
  - If all rounds are completed, the "Play" button is grayed out and non-clickable. If clicked, a toast appears stating: "*Challenge already completed, wait for result*."

### 3. **Bug Fix: Opponent Name Display**
- Fixed a bug that resulted in the incorrect display of the opponent's name in ongoing challenges.
- Properly distinguished between `player1` and `player2` to ensure that the correct opponent name is always displayed in various states of the challenge.

## Additional Information
- Total time taken for each player's rounds is calculated and displayed under the challenge mode in the `NewChallengeScreen` once all rounds are completed.
- The "Play" button's color dynamically updates:
  - **Blue**: Indicates that rounds are still available to play.
  - **Gray**: Indicates that all rounds have been completed, with no further action possible.

### Estimated Time for Review
The changes are extensive and impact multiple parts of the app, including database handling, UI screens, and game logic. Please allocate sufficient time for testing and review to ensure all functionalities are well integrated.

## Checklist
- [x] Created `ChronoChallengeGameScreen` with real-time updates and gesture recognition.
- [x] Updated `CreateAChallengeScreen` and `NewChallengeScreen` for smooth challenge management.
- [x] Fixed opponent name display bug.

Thank you for reviewing this pull request. Feel free to provide feedback or ask questions regarding any of the changes made.