### PR TITLE
Screen refactor for common element and uniformity

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreenTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.github.se.signify.model.auth.MockUserSession
 import com.github.se.signify.model.stats.StatsRepository
-import com.github.se.signify.model.stats.StatsViewModel
 import com.github.se.signify.ui.navigation.NavigationActions
 import org.junit.Before
 import org.junit.Rule
@@ -22,16 +21,14 @@ class ChallengeHistoryScreenTest {
   private lateinit var userSession: MockUserSession
   private lateinit var navigationActions: NavigationActions
   private lateinit var statsRepository: StatsRepository
-  private lateinit var statsViewModel: StatsViewModel
 
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
     userSession = MockUserSession()
     statsRepository = mock(StatsRepository::class.java)
-    statsViewModel = StatsViewModel(userSession, statsRepository)
     composeTestRule.setContent {
-      ChallengeHistoryScreen(navigationActions, userSession, statsRepository, statsViewModel)
+      ChallengeHistoryScreen(navigationActions, userSession, statsRepository)
     }
   }
 

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/FeedbackScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/FeedbackScreenTest.kt
@@ -27,10 +27,7 @@ class FeedbackScreenTest {
   @Test
   fun feedbackScreen_uiElementsAreDisplayed() {
     composeTestRule.setContent {
-      FeedbackScreen(
-          navigationActions = mockNavigationActions,
-          userSession,
-          feedbackRepository)
+      FeedbackScreen(navigationActions = mockNavigationActions, userSession, feedbackRepository)
     }
 
     // Check that top blue bar and back button are displayed
@@ -57,10 +54,7 @@ class FeedbackScreenTest {
   @Test
   fun feedbackScreen_interactWithDropdownMenu() {
     composeTestRule.setContent {
-      FeedbackScreen(
-          navigationActions = mockNavigationActions,
-          userSession,
-          feedbackRepository)
+      FeedbackScreen(navigationActions = mockNavigationActions, userSession, feedbackRepository)
     }
 
     // Open the dropdown menu
@@ -76,10 +70,7 @@ class FeedbackScreenTest {
   @Test
   fun feedbackScreen_fillAndSendFeedback() {
     composeTestRule.setContent {
-      FeedbackScreen(
-          navigationActions = mockNavigationActions,
-          userSession,
-          feedbackRepository)
+      FeedbackScreen(navigationActions = mockNavigationActions, userSession, feedbackRepository)
     }
 
     // Fill in feedback title
@@ -97,10 +88,7 @@ class FeedbackScreenTest {
   @Test
   fun feedbackScreen_selectRating() {
     composeTestRule.setContent {
-      FeedbackScreen(
-          navigationActions = mockNavigationActions,
-          userSession,
-          feedbackRepository)
+      FeedbackScreen(navigationActions = mockNavigationActions, userSession, feedbackRepository)
     }
 
     // Click on the 5th star for rating

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/FeedbackScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/FeedbackScreenTest.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.signify.model.auth.MockUserSession
 import com.github.se.signify.model.feedback.FeedbackRepository
-import com.github.se.signify.model.feedback.FeedbackViewModel
 import com.github.se.signify.ui.navigation.NavigationActions
 import org.junit.Rule
 import org.junit.Test
@@ -24,7 +23,6 @@ class FeedbackScreenTest {
   private val userSession = MockUserSession()
   private val feedbackRepository = Mockito.mock(FeedbackRepository::class.java)
   private val mockNavigationActions = Mockito.mock(NavigationActions::class.java)
-  private val mockFeedbackViewModel = Mockito.mock(FeedbackViewModel::class.java)
 
   @Test
   fun feedbackScreen_uiElementsAreDisplayed() {
@@ -32,12 +30,11 @@ class FeedbackScreenTest {
       FeedbackScreen(
           navigationActions = mockNavigationActions,
           userSession,
-          feedbackRepository,
-          feedbackViewModel = mockFeedbackViewModel)
+          feedbackRepository)
     }
 
     // Check that top blue bar and back button are displayed
-    composeTestRule.onNodeWithTag("TopBlueBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("TopBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("BackButton").assertIsDisplayed()
 
     // Check that feedback type dropdown is displayed
@@ -63,8 +60,7 @@ class FeedbackScreenTest {
       FeedbackScreen(
           navigationActions = mockNavigationActions,
           userSession,
-          feedbackRepository,
-          feedbackViewModel = mockFeedbackViewModel)
+          feedbackRepository)
     }
 
     // Open the dropdown menu
@@ -83,8 +79,7 @@ class FeedbackScreenTest {
       FeedbackScreen(
           navigationActions = mockNavigationActions,
           userSession,
-          feedbackRepository,
-          feedbackViewModel = mockFeedbackViewModel)
+          feedbackRepository)
     }
 
     // Fill in feedback title
@@ -105,8 +100,7 @@ class FeedbackScreenTest {
       FeedbackScreen(
           navigationActions = mockNavigationActions,
           userSession,
-          feedbackRepository,
-          feedbackViewModel = mockFeedbackViewModel)
+          feedbackRepository)
     }
 
     // Click on the 5th star for rating

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/home/QuizScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/home/QuizScreenTest.kt
@@ -1,3 +1,5 @@
+package com.github.se.signify.ui.screens.home
+
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
@@ -10,10 +12,6 @@ import com.github.se.signify.model.quiz.QuizQuestion
 import com.github.se.signify.model.quiz.QuizRepository
 import com.github.se.signify.ui.getIconResId
 import com.github.se.signify.ui.navigation.NavigationActions
-import com.github.se.signify.ui.screens.home.NoQuizAvailable
-import com.github.se.signify.ui.screens.home.QuizContent
-import com.github.se.signify.ui.screens.home.QuizHeader
-import com.github.se.signify.ui.screens.home.QuizScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -44,7 +42,7 @@ class QuizScreenComponentsTest {
 
   @Test
   fun quizHeader_displaysTitleAndBackButton() {
-    composeTestRule.setContent { QuizHeader(navigationActions = mockNavigationActions) }
+    composeTestRule.setContent { QuizScreen(mockNavigationActions, mockQuizRepository) }
 
     // Verify header components
     composeTestRule.onNodeWithTag("BackButton").assertIsDisplayed()
@@ -53,7 +51,7 @@ class QuizScreenComponentsTest {
 
   @Test
   fun quizHeader_backButtonTriggersNavigation() {
-    composeTestRule.setContent { QuizHeader(navigationActions = mockNavigationActions) }
+    composeTestRule.setContent { QuizScreen(mockNavigationActions, mockQuizRepository) }
 
     // Click back button
     composeTestRule.onNodeWithTag("BackButton").performClick()

--- a/app/src/main/java/com/github/se/signify/model/feedback/Feedback.kt
+++ b/app/src/main/java/com/github/se/signify/model/feedback/Feedback.kt
@@ -8,11 +8,9 @@ data class Feedback(
     val rating: Int = 0
 )
 
-enum class FeedbackOption(
-    val category: String
-) {
-    BUG_REPORT("Bug Report"),
-    FEATURE_SUGGESTION("Feature Suggestion"),
-    QUESTION("Question"),
-    OTHER("Other")
+enum class FeedbackOption(val category: String) {
+  BUG_REPORT("Bug Report"),
+  FEATURE_SUGGESTION("Feature Suggestion"),
+  QUESTION("Question"),
+  OTHER("Other")
 }

--- a/app/src/main/java/com/github/se/signify/model/feedback/Feedback.kt
+++ b/app/src/main/java/com/github/se/signify/model/feedback/Feedback.kt
@@ -7,3 +7,12 @@ data class Feedback(
     val description: String = "",
     val rating: Int = 0
 )
+
+enum class FeedbackOption(
+    val category: String
+) {
+    BUG_REPORT("Bug Report"),
+    FEATURE_SUGGESTION("Feature Suggestion"),
+    QUESTION("Question"),
+    OTHER("Other")
+}

--- a/app/src/main/java/com/github/se/signify/ui/Utils.kt
+++ b/app/src/main/java/com/github/se/signify/ui/Utils.kt
@@ -343,22 +343,22 @@ fun MainScreenScaffold(
         ScreenColumn(
             padding,
             testTagColumn,
-            ) {
-              UtilButton(
-                  { isHelpBoxVisible = !isHelpBoxVisible },
-                  "InfoButton",
-                  "InfoIcon",
-                  Icons.Outlined.Info,
-                  "Help")
-              content()
-              // Show popup when the info button is clicked
-              if (isHelpBoxVisible) {
-                InfoPopup(
-                    onDismiss = { isHelpBoxVisible = false },
-                    helpTitle = helpTitle,
-                    helpText = helpText)
-              }
-            }
+        ) {
+          UtilButton(
+              { isHelpBoxVisible = !isHelpBoxVisible },
+              "InfoButton",
+              "InfoIcon",
+              Icons.Outlined.Info,
+              "Help")
+          content()
+          // Show popup when the info button is clicked
+          if (isHelpBoxVisible) {
+            InfoPopup(
+                onDismiss = { isHelpBoxVisible = false },
+                helpTitle = helpTitle,
+                helpText = helpText)
+          }
+        }
       })
 }
 

--- a/app/src/main/java/com/github/se/signify/ui/Utils.kt
+++ b/app/src/main/java/com/github/se/signify/ui/Utils.kt
@@ -252,7 +252,7 @@ fun TopBar() {
       modifier =
           Modifier.fillMaxWidth()
               .height(5.dp)
-              .background(MaterialTheme.colorScheme.background)
+              .background(MaterialTheme.colorScheme.primary)
               .testTag("TopBar"))
 }
 
@@ -294,14 +294,12 @@ fun BackButton(onClick: () -> Unit) {
  *
  * @param padding The default padding value of the column.
  * @param testTag The test tag of the column (test tag of the screen).
- * @param backgroundColor The color of the background (has to be defined by the theme).
  * @param content A lambda function for the content of the column.
  */
 @Composable
 fun ScreenColumn(
     padding: PaddingValues,
     testTag: String,
-    backgroundColor: Color = MaterialTheme.colorScheme.background,
     content: @Composable ColumnScope.() -> Unit
 ) {
   Column(
@@ -310,7 +308,7 @@ fun ScreenColumn(
               .padding(padding)
               .padding(16.dp)
               .verticalScroll(rememberScrollState())
-              .background(backgroundColor)
+              .background(MaterialTheme.colorScheme.background)
               .testTag(testTag),
       horizontalAlignment = Alignment.CenterHorizontally) {
         content()
@@ -345,7 +343,6 @@ fun MainScreenScaffold(
         ScreenColumn(
             padding,
             testTagColumn,
-            MaterialTheme.colorScheme.background // to replace with the background color theme
             ) {
               UtilButton(
                   { isHelpBoxVisible = !isHelpBoxVisible },
@@ -381,7 +378,7 @@ fun AnnexScreenScaffold(
   Scaffold(
       topBar = { TopBar() },
       content = { padding ->
-        ScreenColumn(padding, testTagColumn, MaterialTheme.colorScheme.background) {
+        ScreenColumn(padding, testTagColumn) {
           BackButton { navigationActions.goBack() }
           content()
         }

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreen.kt
@@ -22,9 +22,10 @@ fun ChallengeHistoryScreen(
     navigationActions: NavigationActions,
     userSession: UserSession,
     statsRepository: StatsRepository,
-    statsViewModel: StatsViewModel =
-        viewModel(factory = StatsViewModel.factory(userSession, statsRepository))
 ) {
+  val statsViewModel: StatsViewModel =
+      viewModel(factory = StatsViewModel.factory(userSession, statsRepository))
+
   val challengesCompleted = statsViewModel.completed.collectAsState()
   val challengesCreated = statsViewModel.created.collectAsState()
   val challengesWon = statsViewModel.won.collectAsState()

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/FeedbackScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/FeedbackScreen.kt
@@ -52,8 +52,8 @@ fun FeedbackScreen(
     userSession: UserSession,
     feedbackRepository: FeedbackRepository
 ) {
-    val feedbackViewModel: FeedbackViewModel =
-        viewModel(factory = FeedbackViewModel.factory(userSession, feedbackRepository))
+  val feedbackViewModel: FeedbackViewModel =
+      viewModel(factory = FeedbackViewModel.factory(userSession, feedbackRepository))
   val context = LocalContext.current
 
   var selectedFeedbackType by remember { mutableStateOf(FeedbackOption.BUG_REPORT.category) }
@@ -62,57 +62,52 @@ fun FeedbackScreen(
   var selectedRating by remember { mutableIntStateOf(0) }
   var isLoading by remember { mutableStateOf(false) }
 
-    AnnexScreenScaffold(
-        navigationActions = navigationActions, testTagColumn = "FeedbackScreen"
-    ) {
-        FeedbackDropdown(
-            selectedFeedbackType = selectedFeedbackType,
-            onFeedbackTypeSelected = { selectedFeedbackType = it })
+  AnnexScreenScaffold(navigationActions = navigationActions, testTagColumn = "FeedbackScreen") {
+    FeedbackDropdown(
+        selectedFeedbackType = selectedFeedbackType,
+        onFeedbackTypeSelected = { selectedFeedbackType = it })
 
-        FeedbackInputField(
-            value = feedbackTitle,
-            onValueChange = { feedbackTitle = it },
-            label = "Feedback Title",
-            modifier =
-            Modifier.fillMaxWidth().padding(bottom = 16.dp).testTag("FeedbackTitleInput"))
+    FeedbackInputField(
+        value = feedbackTitle,
+        onValueChange = { feedbackTitle = it },
+        label = "Feedback Title",
+        modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp).testTag("FeedbackTitleInput"))
 
-        FeedbackInputField(
-            value = feedbackDescription,
-            onValueChange = { feedbackDescription = it },
-            label = "Feedback Description",
-            modifier =
+    FeedbackInputField(
+        value = feedbackDescription,
+        onValueChange = { feedbackDescription = it },
+        label = "Feedback Description",
+        modifier =
             Modifier.fillMaxWidth()
                 .height(150.dp)
                 .padding(bottom = 16.dp)
                 .testTag("FeedbackDescriptionInput"))
 
-        RatingSection(
-            selectedRating = selectedRating, onRatingSelected = { selectedRating = it })
+    RatingSection(selectedRating = selectedRating, onRatingSelected = { selectedRating = it })
 
-        UtilTextButton(
-            onClickAction = {
-                if (feedbackTitle.text.isNotEmpty() && feedbackDescription.text.isNotEmpty()) {
-                    isLoading = true
-                    feedbackViewModel.saveFeedback(
-                        type = selectedFeedbackType,
-                        title = feedbackTitle.text,
-                        description = feedbackDescription.text,
-                        rating = selectedRating)
-                    isLoading = false
-                    Toast.makeText(context, "Review sent", Toast.LENGTH_LONG).show()
-                    navigationActions.navigateTo(Screen.HOME)
-                } else {
-                    Toast.makeText(context, "Please fill all the fields", Toast.LENGTH_SHORT)
-                        .show()
-                }
-            },
-            testTag = "SendFeedbackButton",
-            text = "Send Feedback",
-            backgroundColor = MaterialTheme.colorScheme.primary,
-            textColor = MaterialTheme.colorScheme.onPrimary)
+    UtilTextButton(
+        onClickAction = {
+          if (feedbackTitle.text.isNotEmpty() && feedbackDescription.text.isNotEmpty()) {
+            isLoading = true
+            feedbackViewModel.saveFeedback(
+                type = selectedFeedbackType,
+                title = feedbackTitle.text,
+                description = feedbackDescription.text,
+                rating = selectedRating)
+            isLoading = false
+            Toast.makeText(context, "Review sent", Toast.LENGTH_LONG).show()
+            navigationActions.navigateTo(Screen.HOME)
+          } else {
+            Toast.makeText(context, "Please fill all the fields", Toast.LENGTH_SHORT).show()
+          }
+        },
+        testTag = "SendFeedbackButton",
+        text = "Send Feedback",
+        backgroundColor = MaterialTheme.colorScheme.primary,
+        textColor = MaterialTheme.colorScheme.onPrimary)
 
-        LoadingIndicator(isLoading = isLoading)
-    }
+    LoadingIndicator(isLoading = isLoading)
+  }
 }
 
 @Composable
@@ -140,7 +135,9 @@ private fun FeedbackDropdown(
                     .testTag("DropdownMenu")) {
               FeedbackOption.entries.forEach { option ->
                 DropdownMenuItem(
-                    text = { Text(text = option.category, color = MaterialTheme.colorScheme.onPrimary) },
+                    text = {
+                      Text(text = option.category, color = MaterialTheme.colorScheme.onPrimary)
+                    },
                     onClick = {
                       onFeedbackTypeSelected(option.category)
                       expanded = false

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/FeedbackScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/FeedbackScreen.kt
@@ -6,9 +6,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -23,7 +21,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -41,9 +38,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.signify.model.auth.UserSession
+import com.github.se.signify.model.feedback.FeedbackOption
 import com.github.se.signify.model.feedback.FeedbackRepository
 import com.github.se.signify.model.feedback.FeedbackViewModel
-import com.github.se.signify.ui.BackButton
+import com.github.se.signify.ui.AnnexScreenScaffold
 import com.github.se.signify.ui.UtilTextButton
 import com.github.se.signify.ui.navigation.NavigationActions
 import com.github.se.signify.ui.navigation.Screen
@@ -52,97 +50,75 @@ import com.github.se.signify.ui.navigation.Screen
 fun FeedbackScreen(
     navigationActions: NavigationActions,
     userSession: UserSession,
-    feedbackRepository: FeedbackRepository,
-    feedbackViewModel: FeedbackViewModel =
-        viewModel(factory = FeedbackViewModel.factory(userSession, feedbackRepository))
+    feedbackRepository: FeedbackRepository
 ) {
+    val feedbackViewModel: FeedbackViewModel =
+        viewModel(factory = FeedbackViewModel.factory(userSession, feedbackRepository))
   val context = LocalContext.current
 
-  val feedbackOptions = listOf("Bug Report", "Feature Suggestion", "Question", "Other")
-  var selectedFeedbackType by remember { mutableStateOf(feedbackOptions[0]) }
+  var selectedFeedbackType by remember { mutableStateOf(FeedbackOption.BUG_REPORT.category) }
   var feedbackTitle by remember { mutableStateOf(TextFieldValue("")) }
   var feedbackDescription by remember { mutableStateOf(TextFieldValue("")) }
   var selectedRating by remember { mutableIntStateOf(0) }
   var isLoading by remember { mutableStateOf(false) }
 
-  Scaffold(
-      topBar = {
-        Column {
-          Box(
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .height(4.dp)
-                      .background(MaterialTheme.colorScheme.background)
-                      .testTag("TopBlueBar"))
-          BackButton { navigationActions.goBack() }
-        }
-      },
-      content = { padding ->
-        Column(
+    AnnexScreenScaffold(
+        navigationActions = navigationActions, testTagColumn = "FeedbackScreen"
+    ) {
+        FeedbackDropdown(
+            selectedFeedbackType = selectedFeedbackType,
+            onFeedbackTypeSelected = { selectedFeedbackType = it })
+
+        FeedbackInputField(
+            value = feedbackTitle,
+            onValueChange = { feedbackTitle = it },
+            label = "Feedback Title",
             modifier =
-                Modifier.fillMaxSize()
-                    .padding(padding)
-                    .padding(16.dp)
-                    .testTag("FeedbackScreenContent"),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Top) {
-              FeedbackDropdown(
-                  selectedFeedbackType = selectedFeedbackType,
-                  onFeedbackTypeSelected = { selectedFeedbackType = it },
-                  feedbackOptions = feedbackOptions)
+            Modifier.fillMaxWidth().padding(bottom = 16.dp).testTag("FeedbackTitleInput"))
 
-              FeedbackInputField(
-                  value = feedbackTitle,
-                  onValueChange = { feedbackTitle = it },
-                  label = "Feedback Title",
-                  modifier =
-                      Modifier.fillMaxWidth().padding(bottom = 16.dp).testTag("FeedbackTitleInput"))
+        FeedbackInputField(
+            value = feedbackDescription,
+            onValueChange = { feedbackDescription = it },
+            label = "Feedback Description",
+            modifier =
+            Modifier.fillMaxWidth()
+                .height(150.dp)
+                .padding(bottom = 16.dp)
+                .testTag("FeedbackDescriptionInput"))
 
-              FeedbackInputField(
-                  value = feedbackDescription,
-                  onValueChange = { feedbackDescription = it },
-                  label = "Feedback Description",
-                  modifier =
-                      Modifier.fillMaxWidth()
-                          .height(150.dp)
-                          .padding(bottom = 16.dp)
-                          .testTag("FeedbackDescriptionInput"))
+        RatingSection(
+            selectedRating = selectedRating, onRatingSelected = { selectedRating = it })
 
-              RatingSection(
-                  selectedRating = selectedRating, onRatingSelected = { selectedRating = it })
+        UtilTextButton(
+            onClickAction = {
+                if (feedbackTitle.text.isNotEmpty() && feedbackDescription.text.isNotEmpty()) {
+                    isLoading = true
+                    feedbackViewModel.saveFeedback(
+                        type = selectedFeedbackType,
+                        title = feedbackTitle.text,
+                        description = feedbackDescription.text,
+                        rating = selectedRating)
+                    isLoading = false
+                    Toast.makeText(context, "Review sent", Toast.LENGTH_LONG).show()
+                    navigationActions.navigateTo(Screen.HOME)
+                } else {
+                    Toast.makeText(context, "Please fill all the fields", Toast.LENGTH_SHORT)
+                        .show()
+                }
+            },
+            testTag = "SendFeedbackButton",
+            text = "Send Feedback",
+            backgroundColor = MaterialTheme.colorScheme.primary,
+            textColor = MaterialTheme.colorScheme.onPrimary)
 
-              UtilTextButton(
-                  onClickAction = {
-                    if (feedbackTitle.text.isNotEmpty() && feedbackDescription.text.isNotEmpty()) {
-                      isLoading = true
-                      feedbackViewModel.saveFeedback(
-                          type = selectedFeedbackType,
-                          title = feedbackTitle.text,
-                          description = feedbackDescription.text,
-                          rating = selectedRating)
-                      isLoading = false
-                      Toast.makeText(context, "Review sent", Toast.LENGTH_LONG).show()
-                      navigationActions.navigateTo(Screen.HOME)
-                    } else {
-                      Toast.makeText(context, "Please fill all the fields", Toast.LENGTH_SHORT)
-                          .show()
-                    }
-                  },
-                  testTag = "SendFeedbackButton",
-                  text = "Send Feedback",
-                  backgroundColor = MaterialTheme.colorScheme.primary,
-                  textColor = MaterialTheme.colorScheme.onPrimary)
-
-              LoadingIndicator(isLoading = isLoading)
-            }
-      })
+        LoadingIndicator(isLoading = isLoading)
+    }
 }
 
 @Composable
 private fun FeedbackDropdown(
     selectedFeedbackType: String,
-    onFeedbackTypeSelected: (String) -> Unit,
-    feedbackOptions: List<String>
+    onFeedbackTypeSelected: (String) -> Unit
 ) {
   var expanded by remember { mutableStateOf(false) }
   Box(
@@ -162,14 +138,14 @@ private fun FeedbackDropdown(
                 Modifier.fillMaxWidth()
                     .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(8.dp))
                     .testTag("DropdownMenu")) {
-              feedbackOptions.forEach { option ->
+              FeedbackOption.entries.forEach { option ->
                 DropdownMenuItem(
-                    text = { Text(text = option, color = MaterialTheme.colorScheme.onPrimary) },
+                    text = { Text(text = option.category, color = MaterialTheme.colorScheme.onPrimary) },
                     onClick = {
-                      onFeedbackTypeSelected(option)
+                      onFeedbackTypeSelected(option.category)
                       expanded = false
                     },
-                    modifier = Modifier.testTag("DropdownMenuItem_$option"))
+                    modifier = Modifier.testTag("DropdownMenuItem_${option.category}"))
               }
             }
       }

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/QuizScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/QuizScreen.kt
@@ -67,9 +67,7 @@ fun QuizScreen(navigationActions: NavigationActions, quizRepository: QuizReposit
 
     if (currentQuiz != null) {
       val shuffledOptions =
-          remember(currentQuiz) {
-            currentQuiz.confusers.plus(currentQuiz.correctWord).shuffled()
-          }
+          remember(currentQuiz) { currentQuiz.confusers.plus(currentQuiz.correctWord).shuffled() }
 
       QuizContent(
           currentQuiz = currentQuiz!!,

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/QuizScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/QuizScreen.kt
@@ -67,7 +67,9 @@ fun QuizScreen(navigationActions: NavigationActions, quizRepository: QuizReposit
 
     if (currentQuiz != null) {
       val shuffledOptions =
-          remember(currentQuiz) { currentQuiz.confusers.plus(currentQuiz.correctWord).shuffled() }
+          remember(currentQuiz) {
+            currentQuiz!!.confusers.plus(currentQuiz!!.correctWord).shuffled()
+          }
 
       QuizContent(
           currentQuiz = currentQuiz!!,

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/QuizScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/QuizScreen.kt
@@ -12,20 +12,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -40,12 +35,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.signify.model.quiz.QuizQuestion
 import com.github.se.signify.model.quiz.QuizRepository
 import com.github.se.signify.model.quiz.QuizViewModel
+import com.github.se.signify.ui.AnnexScreenScaffold
 import com.github.se.signify.ui.navigation.NavigationActions
 
 @Composable
@@ -57,70 +54,50 @@ fun QuizScreen(navigationActions: NavigationActions, quizRepository: QuizReposit
 
   val context = LocalContext.current
 
-  Scaffold(
-      modifier = Modifier.fillMaxSize(),
-  ) { padding ->
-    Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
+    AnnexScreenScaffold(
+        navigationActions = navigationActions,
+        testTagColumn = "QuizScreen"
     ) {
-      QuizHeader(navigationActions)
-
-      Spacer(modifier = Modifier.height(24.dp))
-
-      if (currentQuiz != null) {
-        val shuffledOptions =
-            remember(currentQuiz) {
-              currentQuiz!!.confusers.plus(currentQuiz!!.correctWord).shuffled()
-            }
-
-        QuizContent(
-            currentQuiz = currentQuiz!!,
-            shuffledOptions = shuffledOptions,
-            selectedOption = selectedOption,
-            onOptionSelected = { selectedOption = it },
-            onSubmit = {
-              quizViewModel.submitAnswer(
-                  selectedOption = it,
-                  onCorrect = {
-                    Toast.makeText(context, "Correct answer!", Toast.LENGTH_SHORT).show()
-                  },
-                  onIncorrect = {
-                    Toast.makeText(context, "Incorrect answer, try again.", Toast.LENGTH_SHORT)
-                        .show()
-                  })
-              selectedOption = null
-            })
-      } else {
-        NoQuizAvailable()
-      }
-    }
-  }
-}
-
-@Composable
-fun QuizHeader(navigationActions: NavigationActions) {
-  Row(
-      verticalAlignment = Alignment.CenterVertically,
-      modifier =
-          Modifier.fillMaxWidth()
-              .background(MaterialTheme.colorScheme.background)
-              .testTag("QuizHeader")) {
-        IconButton(
-            onClick = { navigationActions.goBack() }, modifier = Modifier.testTag("BackButton")) {
-              Icon(
-                  imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                  contentDescription = "Back",
-                  tint = MaterialTheme.colorScheme.primary)
-            }
-        Spacer(modifier = Modifier.width(40.dp))
-
         Text(
             text = "Quiz Time !",
             fontWeight = FontWeight.Bold,
             fontSize = 30.sp,
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.testTag("QuizTitle"))
-      }
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("QuizTitle")
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        if (currentQuiz != null) {
+            val shuffledOptions =
+                remember(currentQuiz) {
+                    currentQuiz!!.confusers.plus(currentQuiz!!.correctWord).shuffled()
+                }
+
+            QuizContent(
+                currentQuiz = currentQuiz!!,
+                shuffledOptions = shuffledOptions,
+                selectedOption = selectedOption,
+                onOptionSelected = { selectedOption = it },
+                onSubmit = {
+                    quizViewModel.submitAnswer(
+                        selectedOption = it,
+                        onCorrect = {
+                            Toast.makeText(context, "Correct answer!", Toast.LENGTH_SHORT).show()
+                        },
+                        onIncorrect = {
+                            Toast.makeText(context, "Incorrect answer, try again.", Toast.LENGTH_SHORT)
+                                .show()
+                        })
+                    selectedOption = null
+                })
+        } else {
+            NoQuizAvailable()
+        }
+    }
 }
 
 @Composable
@@ -187,7 +164,7 @@ fun QuizContent(
   Spacer(modifier = Modifier.height(24.dp))
 
   Button(
-      onClick = { if (selectedOption != null) onSubmit(selectedOption!!) },
+      onClick = { if (selectedOption != null) onSubmit(selectedOption) },
       enabled = selectedOption != null,
       colors =
           ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/QuizScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/QuizScreen.kt
@@ -68,7 +68,7 @@ fun QuizScreen(navigationActions: NavigationActions, quizRepository: QuizReposit
     if (currentQuiz != null) {
       val shuffledOptions =
           remember(currentQuiz) {
-            currentQuiz!!.confusers.plus(currentQuiz!!.correctWord).shuffled()
+            currentQuiz.confusers.plus(currentQuiz.correctWord).shuffled()
           }
 
       QuizContent(

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/QuizScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/QuizScreen.kt
@@ -54,50 +54,43 @@ fun QuizScreen(navigationActions: NavigationActions, quizRepository: QuizReposit
 
   val context = LocalContext.current
 
-    AnnexScreenScaffold(
-        navigationActions = navigationActions,
-        testTagColumn = "QuizScreen"
-    ) {
-        Text(
-            text = "Quiz Time !",
-            fontWeight = FontWeight.Bold,
-            fontSize = 30.sp,
-            color = MaterialTheme.colorScheme.primary,
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag("QuizTitle")
-        )
+  AnnexScreenScaffold(navigationActions = navigationActions, testTagColumn = "QuizScreen") {
+    Text(
+        text = "Quiz Time !",
+        fontWeight = FontWeight.Bold,
+        fontSize = 30.sp,
+        color = MaterialTheme.colorScheme.primary,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.fillMaxWidth().testTag("QuizTitle"))
 
-        Spacer(modifier = Modifier.height(24.dp))
+    Spacer(modifier = Modifier.height(24.dp))
 
-        if (currentQuiz != null) {
-            val shuffledOptions =
-                remember(currentQuiz) {
-                    currentQuiz!!.confusers.plus(currentQuiz!!.correctWord).shuffled()
-                }
+    if (currentQuiz != null) {
+      val shuffledOptions =
+          remember(currentQuiz) {
+            currentQuiz!!.confusers.plus(currentQuiz!!.correctWord).shuffled()
+          }
 
-            QuizContent(
-                currentQuiz = currentQuiz!!,
-                shuffledOptions = shuffledOptions,
-                selectedOption = selectedOption,
-                onOptionSelected = { selectedOption = it },
-                onSubmit = {
-                    quizViewModel.submitAnswer(
-                        selectedOption = it,
-                        onCorrect = {
-                            Toast.makeText(context, "Correct answer!", Toast.LENGTH_SHORT).show()
-                        },
-                        onIncorrect = {
-                            Toast.makeText(context, "Incorrect answer, try again.", Toast.LENGTH_SHORT)
-                                .show()
-                        })
-                    selectedOption = null
+      QuizContent(
+          currentQuiz = currentQuiz!!,
+          shuffledOptions = shuffledOptions,
+          selectedOption = selectedOption,
+          onOptionSelected = { selectedOption = it },
+          onSubmit = {
+            quizViewModel.submitAnswer(
+                selectedOption = it,
+                onCorrect = {
+                  Toast.makeText(context, "Correct answer!", Toast.LENGTH_SHORT).show()
+                },
+                onIncorrect = {
+                  Toast.makeText(context, "Incorrect answer, try again.", Toast.LENGTH_SHORT).show()
                 })
-        } else {
-            NoQuizAvailable()
-        }
+            selectedOption = null
+          })
+    } else {
+      NoQuizAvailable()
     }
+  }
 }
 
 @Composable

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/MyStatsScreen.kt
@@ -30,11 +30,11 @@ fun MyStatsScreen(
     userSession: UserSession,
     userRepository: UserRepository,
     statsRepository: StatsRepository,
-    userViewModel: UserViewModel =
-        viewModel(factory = UserViewModel.factory(userSession, userRepository)),
-    statsViewModel: StatsViewModel =
-        viewModel(factory = StatsViewModel.factory(userSession, statsRepository))
 ) {
+  val userViewModel: UserViewModel =
+      viewModel(factory = UserViewModel.factory(userSession, userRepository))
+  val statsViewModel: StatsViewModel =
+      viewModel(factory = StatsViewModel.factory(userSession, statsRepository))
 
   LaunchedEffect(Unit) {
     userViewModel.getUserName()

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
@@ -39,11 +39,12 @@ fun ProfileScreen(
     userSession: UserSession,
     userRepository: UserRepository,
     statsRepository: StatsRepository,
-    userViewModel: UserViewModel =
-        viewModel(factory = UserViewModel.factory(userSession, userRepository)),
-    statsViewModel: StatsViewModel =
-        viewModel(factory = StatsViewModel.factory(userSession, statsRepository))
 ) {
+  val userViewModel: UserViewModel =
+      viewModel(factory = UserViewModel.factory(userSession, userRepository))
+  val statsViewModel: StatsViewModel =
+      viewModel(factory = StatsViewModel.factory(userSession, statsRepository))
+
   MainScreenScaffold(
       navigationActions = navigationActions,
       testTagColumn = "ProfileScreen",


### PR DESCRIPTION
## PR Description:
The changes made in this PR are mostly code refactoring and don't affect the behaviour of our app.

Related issues: #315 , #316 .

## Changes made:
- `QuizScreen` and `FeedbackScreen` use `AnnexScreenScaffold()` from Utils.kt now
- `ChallengeHistoryScreen`, `FeedbackScreen`, `MyStatsScreen` and `ProfileScreen` have their viewModels as a val and are not anymore in the list of argument.
- Color change in Utils.kt for the `topBar()` and remove useless argument in the `ScreenColumn()`

## Future improvement:
- ASLRecognition might need change in its design to help user doing the sign they want.
- QuestScreen will have a new design and implementation.
- FriendsListScreen is tested with a given viewModel, if we want to change it, we have to addapt the test.

## Test:
- There is no added test for this part as the main changes are on the use of already tested composable.