### PR TITLE
Mock the user repository

### DIFF
--- a/app/src/main/java/com/github/se/signify/model/user/MockUserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/MockUserRepository.kt
@@ -37,6 +37,8 @@ class MockUserRepository : UserRepository {
   }
 
   override fun init(onSuccess: () -> Unit) {
+    if (checkFailure {}) return
+
     onSuccess()
   }
 

--- a/app/src/main/java/com/github/se/signify/model/user/MockUserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/MockUserRepository.kt
@@ -1,0 +1,311 @@
+package com.github.se.signify.model.user
+
+import android.net.Uri
+import com.github.se.signify.model.challenge.Challenge
+
+private val failureException: Exception = Exception("Simulated failure")
+
+class MockUserRepository : UserRepository {
+  private val users = mutableMapOf<String, User>()
+  private var shouldFail: Boolean = false
+
+  fun succeed() {
+    shouldFail = false
+  }
+
+  fun fail() {
+    shouldFail = true
+  }
+
+  fun setUsers(users: List<User>) {
+    this.users.clear()
+    for (user in users) {
+      addUser(user)
+    }
+  }
+
+  fun addUser(user: User) {
+    users[user.uid] = user
+  }
+
+  fun removeUser(userId: String) {
+    users.remove(userId)
+  }
+
+  override fun init(onSuccess: () -> Unit) {
+    onSuccess()
+  }
+
+  override fun getFriendsList(
+      userId: String,
+      onSuccess: (List<String>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    onSuccess(user.friends)
+  }
+
+  override fun getRequestsFriendsList(
+      userId: String,
+      onSuccess: (List<String>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    onSuccess(user.friendRequests)
+  }
+
+  override fun getUserById(
+      userId: String,
+      onSuccess: (User) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    onSuccess(user)
+  }
+
+  override fun getUserName(
+      userId: String,
+      onSuccess: (String) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+
+    // This was done to match the implementation of the UserRepositoryFireStore
+    // TODO: Make this non-nullable
+    onSuccess(user.name ?: "unknown")
+  }
+
+  override fun updateUserName(
+      userId: String,
+      newName: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    users[userId] = user.copy(name = newName)
+    onSuccess()
+  }
+
+  override fun getProfilePictureUrl(
+      userId: String,
+      onSuccess: (String?) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    onSuccess(user.profileImageUrl)
+  }
+
+  override fun updateProfilePictureUrl(
+      userId: String,
+      newProfilePictureUrl: Uri?,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    users[userId] = user.copy(profileImageUrl = newProfilePictureUrl.toString())
+    onSuccess()
+  }
+
+  override fun sendFriendRequest(
+      currentUserId: String,
+      targetUserId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(currentUserId, onFailure)) return
+    if (checkUser(targetUserId, onFailure)) return
+
+    val targetUser = users[targetUserId]!!
+    users[targetUserId] =
+        targetUser.copy(friendRequests = targetUser.friendRequests + currentUserId)
+    onSuccess()
+  }
+
+  override fun acceptFriendRequest(
+      currentUserId: String,
+      friendUserId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(currentUserId, onFailure)) return
+    if (checkUser(friendUserId, onFailure)) return
+
+    val currentUser = users[currentUserId]!!
+    val friendUser = users[friendUserId]!!
+
+    users[currentUserId] =
+        currentUser.copy(
+            friendRequests = currentUser.friendRequests - friendUserId,
+            friends = currentUser.friends + friendUserId)
+    users[friendUserId] = friendUser.copy(friends = friendUser.friends + currentUserId)
+    onSuccess()
+  }
+
+  override fun removeFriend(
+      currentUserId: String,
+      friendUserId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(currentUserId, onFailure)) return
+    if (checkUser(friendUserId, onFailure)) return
+
+    val currentUser = users[currentUserId]!!
+    val friendUser = users[friendUserId]!!
+
+    users[currentUserId] = currentUser.copy(friends = currentUser.friends - friendUserId)
+    users[friendUserId] = friendUser.copy(friends = friendUser.friends - currentUserId)
+    onSuccess()
+  }
+
+  override fun declineFriendRequest(
+      currentUserId: String,
+      friendUserId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(currentUserId, onFailure)) return
+    if (checkUser(friendUserId, onFailure)) return
+
+    val currentUser = users[currentUserId]!!
+    users[currentUserId] =
+        currentUser.copy(friendRequests = currentUser.friendRequests - friendUserId)
+    onSuccess()
+  }
+
+  override fun addOngoingChallenge(
+      userId: String,
+      challengeId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    users[userId] = user.copy(ongoingChallenges = user.ongoingChallenges + challengeId)
+    onSuccess()
+  }
+
+  // This mock returns empty challenges. The current implementation of `UserRepositoryFireStore`
+  // returns the challenges from the Firestore database, which it should not be responsible for.
+  // This behavior can't possibly be mocked here.
+  // This method should be changed in the `UserRepository` interface to return only the challenge
+  // IDs.
+  override fun getOngoingChallenges(
+      userId: String,
+      onSuccess: (List<Challenge>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    val challenges = user.ongoingChallenges.map { Challenge(it) }
+    onSuccess(challenges)
+  }
+
+  override fun removeOngoingChallenge(
+      userId: String,
+      challengeId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    users[userId] = user.copy(ongoingChallenges = user.ongoingChallenges - challengeId)
+    onSuccess()
+  }
+
+  override fun getInitialQuestAccessDate(
+      userId: String,
+      onSuccess: (String?) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    onSuccess(user.lastLoginDate)
+  }
+
+  override fun setInitialQuestAccessDate(
+      userId: String,
+      date: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    users[userId] = user.copy(lastLoginDate = date)
+    onSuccess()
+  }
+
+  // This was simplified to not use the current date. It does not match the implementation of
+  // `UserRepositoryFireStore`.
+  override fun updateStreak(userId: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    users[userId] = user.copy(currentStreak = user.currentStreak + 1)
+    onSuccess()
+  }
+
+  override fun getStreak(
+      userId: String,
+      onSuccess: (Long) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    if (checkFailure(onFailure)) return
+    if (checkUser(userId, onFailure)) return
+
+    val user = users[userId]!!
+    onSuccess(user.currentStreak)
+  }
+
+  private fun checkFailure(onFailure: (Exception) -> Unit): Boolean {
+    if (shouldFail) {
+      onFailure(failureException)
+      return false
+    }
+    return true
+  }
+
+  private fun checkUser(userId: String, onFailure: (Exception) -> Unit): Boolean {
+    if (users[userId] == null) {
+      onFailure(Exception(USER_NOT_FOUND_MESSAGE))
+      return false
+    }
+    return true
+  }
+}

--- a/app/src/main/java/com/github/se/signify/model/user/MockUserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/MockUserRepository.kt
@@ -50,7 +50,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
     onSuccess(user.friends)
   }
 
@@ -62,7 +62,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
     onSuccess(user.friendRequests)
   }
 
@@ -74,7 +74,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
     onSuccess(user)
   }
 
@@ -86,7 +86,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
 
     // This was done to match the implementation of the UserRepositoryFireStore
     // TODO: Make this non-nullable
@@ -102,7 +102,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
     users[userId] = user.copy(name = newName)
     onSuccess()
   }
@@ -115,7 +115,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
     onSuccess(user.profileImageUrl)
   }
 
@@ -128,7 +128,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
     users[userId] = user.copy(profileImageUrl = newProfilePictureUrl.toString())
     onSuccess()
   }
@@ -143,7 +143,7 @@ class MockUserRepository : UserRepository {
     if (!checkUser(currentUserId, onFailure)) return
     if (!checkUser(targetUserId, onFailure)) return
 
-    val targetUser = users[targetUserId]!!
+    val targetUser = users.getValue(targetUserId)
     users[targetUserId] =
         targetUser.copy(friendRequests = targetUser.friendRequests + currentUserId)
     onSuccess()
@@ -159,8 +159,8 @@ class MockUserRepository : UserRepository {
     if (!checkUser(currentUserId, onFailure)) return
     if (!checkUser(friendUserId, onFailure)) return
 
-    val currentUser = users[currentUserId]!!
-    val friendUser = users[friendUserId]!!
+    val currentUser = users.getValue(currentUserId)
+    val friendUser = users.getValue(friendUserId)
 
     users[currentUserId] =
         currentUser.copy(
@@ -180,8 +180,8 @@ class MockUserRepository : UserRepository {
     if (!checkUser(currentUserId, onFailure)) return
     if (!checkUser(friendUserId, onFailure)) return
 
-    val currentUser = users[currentUserId]!!
-    val friendUser = users[friendUserId]!!
+    val currentUser = users.getValue(currentUserId)
+    val friendUser = users.getValue(friendUserId)
 
     users[currentUserId] = currentUser.copy(friends = currentUser.friends - friendUserId)
     users[friendUserId] = friendUser.copy(friends = friendUser.friends - currentUserId)
@@ -198,7 +198,7 @@ class MockUserRepository : UserRepository {
     if (!checkUser(currentUserId, onFailure)) return
     if (!checkUser(friendUserId, onFailure)) return
 
-    val currentUser = users[currentUserId]!!
+    val currentUser = users.getValue(currentUserId)
     users[currentUserId] =
         currentUser.copy(friendRequests = currentUser.friendRequests - friendUserId)
     onSuccess()
@@ -213,7 +213,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
     users[userId] = user.copy(ongoingChallenges = user.ongoingChallenges + challengeId)
     onSuccess()
   }
@@ -231,7 +231,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
     val challenges = user.ongoingChallenges.map { Challenge(it) }
     onSuccess(challenges)
   }
@@ -245,7 +245,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
     users[userId] = user.copy(ongoingChallenges = user.ongoingChallenges - challengeId)
     onSuccess()
   }
@@ -258,7 +258,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
     onSuccess(user.lastLoginDate)
   }
 
@@ -271,7 +271,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
     users[userId] = user.copy(lastLoginDate = date)
     onSuccess()
   }
@@ -282,7 +282,7 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    val user = users.getValue(userId)
     users[userId] = user.copy(currentStreak = user.currentStreak + 1)
     onSuccess()
   }

--- a/app/src/main/java/com/github/se/signify/model/user/MockUserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/MockUserRepository.kt
@@ -17,15 +17,19 @@ class MockUserRepository : UserRepository {
     shouldFail = true
   }
 
+  fun clearUsers() {
+    users.clear()
+  }
+
+  fun addUser(user: User) {
+    users[user.uid] = user
+  }
+
   fun setUsers(users: List<User>) {
     this.users.clear()
     for (user in users) {
       addUser(user)
     }
-  }
-
-  fun addUser(user: User) {
-    users[user.uid] = user
   }
 
   fun removeUser(userId: String) {

--- a/app/src/main/java/com/github/se/signify/model/user/MockUserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/MockUserRepository.kt
@@ -293,9 +293,15 @@ class MockUserRepository : UserRepository {
       onFailure: (Exception) -> Unit
   ) {
     if (!checkFailure(onFailure)) return
-    if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]!!
+    // This was done to match the implementation of the UserRepositoryFireStore.
+    // TODO: Make this fail on invalid userIds
+    val user = users[userId]
+    if (user == null) {
+      onSuccess(0)
+      return
+    }
+
     onSuccess(user.currentStreak)
   }
 

--- a/app/src/main/java/com/github/se/signify/model/user/MockUserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/MockUserRepository.kt
@@ -37,7 +37,7 @@ class MockUserRepository : UserRepository {
   }
 
   override fun init(onSuccess: () -> Unit) {
-    if (checkFailure {}) return
+    if (!checkFailure {}) return
 
     onSuccess()
   }
@@ -47,8 +47,8 @@ class MockUserRepository : UserRepository {
       onSuccess: (List<String>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     onSuccess(user.friends)
@@ -59,8 +59,8 @@ class MockUserRepository : UserRepository {
       onSuccess: (List<String>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     onSuccess(user.friendRequests)
@@ -71,8 +71,8 @@ class MockUserRepository : UserRepository {
       onSuccess: (User) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     onSuccess(user)
@@ -83,8 +83,8 @@ class MockUserRepository : UserRepository {
       onSuccess: (String) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
 
@@ -99,8 +99,8 @@ class MockUserRepository : UserRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     users[userId] = user.copy(name = newName)
@@ -112,8 +112,8 @@ class MockUserRepository : UserRepository {
       onSuccess: (String?) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     onSuccess(user.profileImageUrl)
@@ -125,8 +125,8 @@ class MockUserRepository : UserRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     users[userId] = user.copy(profileImageUrl = newProfilePictureUrl.toString())
@@ -139,9 +139,9 @@ class MockUserRepository : UserRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(currentUserId, onFailure)) return
-    if (checkUser(targetUserId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(currentUserId, onFailure)) return
+    if (!checkUser(targetUserId, onFailure)) return
 
     val targetUser = users[targetUserId]!!
     users[targetUserId] =
@@ -155,9 +155,9 @@ class MockUserRepository : UserRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(currentUserId, onFailure)) return
-    if (checkUser(friendUserId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(currentUserId, onFailure)) return
+    if (!checkUser(friendUserId, onFailure)) return
 
     val currentUser = users[currentUserId]!!
     val friendUser = users[friendUserId]!!
@@ -176,9 +176,9 @@ class MockUserRepository : UserRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(currentUserId, onFailure)) return
-    if (checkUser(friendUserId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(currentUserId, onFailure)) return
+    if (!checkUser(friendUserId, onFailure)) return
 
     val currentUser = users[currentUserId]!!
     val friendUser = users[friendUserId]!!
@@ -194,9 +194,9 @@ class MockUserRepository : UserRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(currentUserId, onFailure)) return
-    if (checkUser(friendUserId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(currentUserId, onFailure)) return
+    if (!checkUser(friendUserId, onFailure)) return
 
     val currentUser = users[currentUserId]!!
     users[currentUserId] =
@@ -210,8 +210,8 @@ class MockUserRepository : UserRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     users[userId] = user.copy(ongoingChallenges = user.ongoingChallenges + challengeId)
@@ -228,8 +228,8 @@ class MockUserRepository : UserRepository {
       onSuccess: (List<Challenge>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     val challenges = user.ongoingChallenges.map { Challenge(it) }
@@ -242,8 +242,8 @@ class MockUserRepository : UserRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     users[userId] = user.copy(ongoingChallenges = user.ongoingChallenges - challengeId)
@@ -255,8 +255,8 @@ class MockUserRepository : UserRepository {
       onSuccess: (String?) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     onSuccess(user.lastLoginDate)
@@ -268,8 +268,8 @@ class MockUserRepository : UserRepository {
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     users[userId] = user.copy(lastLoginDate = date)
@@ -279,8 +279,8 @@ class MockUserRepository : UserRepository {
   // This was simplified to not use the current date. It does not match the implementation of
   // `UserRepositoryFireStore`.
   override fun updateStreak(userId: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     users[userId] = user.copy(currentStreak = user.currentStreak + 1)
@@ -292,8 +292,8 @@ class MockUserRepository : UserRepository {
       onSuccess: (Long) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    if (checkFailure(onFailure)) return
-    if (checkUser(userId, onFailure)) return
+    if (!checkFailure(onFailure)) return
+    if (!checkUser(userId, onFailure)) return
 
     val user = users[userId]!!
     onSuccess(user.currentStreak)

--- a/app/src/main/java/com/github/se/signify/model/user/UserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/UserRepository.kt
@@ -3,6 +3,8 @@ package com.github.se.signify.model.user
 import android.net.Uri
 import com.github.se.signify.model.challenge.Challenge
 
+const val USER_NOT_FOUND_MESSAGE = "User not found"
+
 interface UserRepository {
 
   fun init(onSuccess: () -> Unit)
@@ -78,6 +80,8 @@ interface UserRepository {
       onFailure: (Exception) -> Unit
   )
 
+  // TODO: This should only return the challenge IDs. The challenges themselves should be fetched
+  // from the `ChallengeRepository`.
   fun getOngoingChallenges(
       userId: String,
       onSuccess: (List<Challenge>) -> Unit,

--- a/app/src/main/java/com/github/se/signify/model/user/UserRepositoryFireStore.kt
+++ b/app/src/main/java/com/github/se/signify/model/user/UserRepositoryFireStore.kt
@@ -104,7 +104,7 @@ class UserRepositoryFireStore(
               onFailure(e)
             }
           } else {
-            onFailure(Exception("User not found"))
+            onFailure(Exception(USER_NOT_FOUND_MESSAGE))
           }
         }
         .addOnFailureListener { e -> onFailure(e) }

--- a/app/src/test/java/com/github/se/signify/model/user/MockUserRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/user/MockUserRepositoryTest.kt
@@ -1,0 +1,441 @@
+package com.github.se.signify.model.user
+
+import android.net.Uri
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class MockUserRepositoryTest {
+
+  private lateinit var mockUserRepository: MockUserRepository
+
+  private val doNotFail: (Exception) -> Unit = { fail("Should not fail") }
+  private val doNotSucceed: () -> Unit = { fail("Should not succeed") }
+  private val doNotSucceedAny: (Any?) -> Unit = { doNotSucceed() }
+
+  private val blankUser =
+      User(
+          uid = "blankUserId",
+          name = "",
+          email = "",
+          profileImageUrl = "",
+          friendRequests = emptyList(),
+          friends = emptyList(),
+          ongoingChallenges = emptyList(),
+          pastChallenges = emptyList(),
+          lastLoginDate = "",
+          currentStreak = 0,
+          highestStreak = 0)
+  private val activeUser =
+      User(
+          uid = "userId",
+          name = "name",
+          email = "email",
+          profileImageUrl = "profileImageUrl",
+          friendRequests = listOf("friendRequest1, friendRequest2"),
+          friends = listOf("friend1, friend2"),
+          ongoingChallenges = listOf("ongoingChallenge1, ongoingChallenge2"),
+          pastChallenges = listOf("pastChallenge1, pastChallenge2"),
+          lastLoginDate = "lastLoginDate",
+          currentStreak = 1,
+          highestStreak = 1)
+  private val otherUser =
+      User(
+          uid = "otherUserId",
+          name = "otherName",
+          email = "otherEmail",
+          profileImageUrl = "otherProfileImageUrl",
+          friendRequests = listOf("otherFriendRequest1, otherFriendRequest2"),
+          friends = listOf("otherFriend1, otherFriend2"),
+          ongoingChallenges = listOf("otherOngoingChallenge1, otherOngoingChallenge2"),
+          pastChallenges = listOf("otherPastChallenge1, otherPastChallenge2"),
+          lastLoginDate = "otherLastLoginDate",
+          currentStreak = 2,
+          highestStreak = 2)
+  private val users = listOf(blankUser, activeUser, otherUser)
+  private val profilePictureUrl = Uri.parse("http://example.com/profile.jpg")
+
+  @Before
+  fun setUp() {
+    mockUserRepository = MockUserRepository()
+    mockUserRepository.setUsers(users)
+    mockUserRepository.succeed()
+  }
+
+  @Test
+  fun succeedWorks() {
+    var success = 0
+    val onSuccess: () -> Unit = { success += 1 }
+    val onSuccessAny: (Any?) -> Unit = { onSuccess() }
+
+    mockUserRepository.init(onSuccess)
+    mockUserRepository.getFriendsList(blankUser.uid, onSuccessAny, doNotFail)
+    mockUserRepository.getRequestsFriendsList(blankUser.uid, onSuccessAny, doNotFail)
+    mockUserRepository.getUserById(blankUser.uid, { success += 1 }, doNotFail)
+    mockUserRepository.getUserName(blankUser.uid, onSuccessAny, doNotFail)
+    mockUserRepository.updateUserName(blankUser.uid, "newName", onSuccess, doNotFail)
+    mockUserRepository.getProfilePictureUrl(blankUser.uid, onSuccessAny, doNotFail)
+    mockUserRepository.updateProfilePictureUrl(
+        blankUser.uid, profilePictureUrl, onSuccess, doNotFail)
+    mockUserRepository.sendFriendRequest(blankUser.uid, otherUser.uid, onSuccess, doNotFail)
+    mockUserRepository.acceptFriendRequest(blankUser.uid, otherUser.uid, onSuccess, doNotFail)
+    mockUserRepository.removeFriend(blankUser.uid, otherUser.uid, onSuccess, doNotFail)
+    mockUserRepository.declineFriendRequest(blankUser.uid, otherUser.uid, onSuccess, doNotFail)
+    mockUserRepository.addOngoingChallenge(blankUser.uid, "challengeId", onSuccess, doNotFail)
+    mockUserRepository.getOngoingChallenges(blankUser.uid, onSuccessAny, doNotFail)
+    mockUserRepository.removeOngoingChallenge(blankUser.uid, "challengeId", onSuccess, doNotFail)
+    mockUserRepository.getInitialQuestAccessDate(blankUser.uid, onSuccessAny, doNotFail)
+    mockUserRepository.setInitialQuestAccessDate(blankUser.uid, "2024-01-01", onSuccess, doNotFail)
+    mockUserRepository.updateStreak(blankUser.uid, onSuccess, doNotFail)
+    mockUserRepository.getStreak(blankUser.uid, onSuccessAny, doNotFail)
+
+    assertEquals(19, success)
+  }
+
+  @Test
+  fun failWorks() {
+    var failure = 0
+    val onFailure: (Exception) -> Unit = { failure += 1 }
+
+    mockUserRepository.fail()
+
+    mockUserRepository.getFriendsList(blankUser.uid, doNotSucceedAny, onFailure)
+    mockUserRepository.getRequestsFriendsList(blankUser.uid, doNotSucceedAny, onFailure)
+    mockUserRepository.getUserById(blankUser.uid, doNotSucceedAny, onFailure)
+    mockUserRepository.getUserName(blankUser.uid, doNotSucceedAny, onFailure)
+    mockUserRepository.updateUserName(blankUser.uid, "newName", doNotSucceed, onFailure)
+    mockUserRepository.getProfilePictureUrl(blankUser.uid, doNotSucceedAny, onFailure)
+    mockUserRepository.updateProfilePictureUrl(
+        blankUser.uid, profilePictureUrl, doNotSucceed, onFailure)
+    mockUserRepository.sendFriendRequest(blankUser.uid, otherUser.uid, doNotSucceed, onFailure)
+    mockUserRepository.acceptFriendRequest(blankUser.uid, otherUser.uid, doNotSucceed, onFailure)
+    mockUserRepository.removeFriend(blankUser.uid, otherUser.uid, doNotSucceed, onFailure)
+    mockUserRepository.declineFriendRequest(blankUser.uid, otherUser.uid, doNotSucceed, onFailure)
+    mockUserRepository.addOngoingChallenge(blankUser.uid, "challengeId", doNotSucceed, onFailure)
+    mockUserRepository.getOngoingChallenges(blankUser.uid, doNotSucceedAny, onFailure)
+    mockUserRepository.removeOngoingChallenge(blankUser.uid, "challengeId", doNotSucceed, onFailure)
+    mockUserRepository.getInitialQuestAccessDate(blankUser.uid, doNotSucceedAny, onFailure)
+    mockUserRepository.setInitialQuestAccessDate(
+        blankUser.uid, "2024-01-01", doNotSucceed, onFailure)
+    mockUserRepository.updateStreak(blankUser.uid, doNotSucceed, onFailure)
+    mockUserRepository.getStreak(blankUser.uid, doNotSucceedAny, onFailure)
+
+    assertEquals(18, failure)
+  }
+
+  @Test
+  fun failsOnInvalidUserId() {
+    val userId = "invalidUserId"
+    var failure = 0
+    val onFailure: (Exception) -> Unit = { failure += 1 }
+
+    mockUserRepository.init(doNotSucceed)
+    mockUserRepository.getFriendsList(userId, doNotSucceedAny, onFailure)
+    mockUserRepository.getRequestsFriendsList(userId, doNotSucceedAny, onFailure)
+    mockUserRepository.getUserById(userId, doNotSucceedAny, onFailure)
+    mockUserRepository.getUserName(userId, doNotSucceedAny, onFailure)
+    mockUserRepository.updateUserName(userId, "newName", doNotSucceed, onFailure)
+    mockUserRepository.getProfilePictureUrl(userId, doNotSucceedAny, onFailure)
+    mockUserRepository.updateProfilePictureUrl(userId, profilePictureUrl, doNotSucceed, onFailure)
+    mockUserRepository.sendFriendRequest(userId, otherUser.uid, doNotSucceed, onFailure)
+    mockUserRepository.acceptFriendRequest(userId, otherUser.uid, doNotSucceed, onFailure)
+    mockUserRepository.removeFriend(userId, otherUser.uid, doNotSucceed, onFailure)
+    mockUserRepository.declineFriendRequest(userId, otherUser.uid, doNotSucceed, onFailure)
+    mockUserRepository.addOngoingChallenge(userId, "challengeId", doNotSucceed, onFailure)
+    mockUserRepository.getOngoingChallenges(userId, doNotSucceedAny, onFailure)
+    mockUserRepository.removeOngoingChallenge(userId, "challengeId", doNotSucceed, onFailure)
+    mockUserRepository.getInitialQuestAccessDate(userId, doNotSucceedAny, onFailure)
+    mockUserRepository.setInitialQuestAccessDate(userId, "2024-01-01", doNotSucceed, onFailure)
+    mockUserRepository.updateStreak(userId, doNotSucceed, onFailure)
+    mockUserRepository.getStreak(userId, doNotSucceedAny, onFailure)
+  }
+
+  @Test
+  fun clearUsersWorks() {
+    mockUserRepository.clearUsers()
+
+    users.forEach { user ->
+      mockUserRepository.getUserById(user.uid, { response -> assertNull(response) }, doNotFail)
+    }
+  }
+
+  @Test
+  fun addUserWorks() {
+    mockUserRepository.addUser(blankUser)
+
+    mockUserRepository.getUserById(
+        blankUser.uid, { response -> assertNotNull(response) }, doNotFail)
+  }
+
+  @Test
+  fun setUsersWorks() {
+    mockUserRepository.setUsers(listOf(blankUser, activeUser))
+
+    mockUserRepository.getUserById(
+        blankUser.uid, { response -> assertNotNull(response) }, doNotFail)
+    mockUserRepository.getUserById(
+        activeUser.uid, { response -> assertNotNull(response) }, doNotFail)
+    mockUserRepository.getUserById(
+        otherUser.uid, doNotSucceedAny, { response -> assertNull(response) })
+  }
+
+  @Test
+  fun removeUserWorks() {
+    mockUserRepository.removeUser(blankUser.uid)
+    mockUserRepository.removeUser(activeUser.uid)
+
+    mockUserRepository.getUserById(blankUser.uid, { response -> assertNull(response) }, doNotFail)
+    mockUserRepository.getUserById(activeUser.uid, { response -> assertNull(response) }, doNotFail)
+    mockUserRepository.getUserById(
+        otherUser.uid, { response -> assertNotNull(response) }, doNotFail)
+  }
+
+  @Test
+  fun getFriendsListWorks() {
+    mockUserRepository.getFriendsList(
+        blankUser.uid, { friends -> assertTrue(friends.isEmpty()) }, doNotFail)
+
+    mockUserRepository.getFriendsList(
+        activeUser.uid,
+        { friends -> assertEquals(activeUser.friends.toSet(), friends.toSet()) },
+        doNotFail)
+  }
+
+  @Test
+  fun getRequestsFriendsListWorks() {
+    mockUserRepository.getRequestsFriendsList(
+        blankUser.uid, { requests -> assertTrue(requests.isEmpty()) }, doNotFail)
+
+    mockUserRepository.getRequestsFriendsList(
+        activeUser.uid,
+        { requests -> assertEquals(activeUser.friendRequests.toSet(), requests.toSet()) },
+        doNotFail)
+  }
+
+  @Test
+  fun getUserByIdWorks() {
+    mockUserRepository.getUserById(blankUser.uid, { assertEquals(blankUser, it) }, doNotFail)
+
+    mockUserRepository.getUserById(activeUser.uid, { assertEquals(activeUser, it) }, doNotFail)
+  }
+
+  @Test
+  fun getUserNameWorks() {
+    mockUserRepository.getUserName(blankUser.uid, { assertNull(it) }, doNotFail)
+
+    mockUserRepository.getUserName(activeUser.uid, { assertEquals(activeUser.name, it) }, doNotFail)
+  }
+
+  @Test
+  fun updateUserNameWorks() {
+    val newName = "newName"
+    mockUserRepository.updateUserName(
+        activeUser.uid,
+        newName,
+        {
+          mockUserRepository.getUserName(activeUser.uid, { assertEquals(newName, it) }, doNotFail)
+        },
+        doNotFail)
+  }
+
+  @Test
+  fun getProfilePictureUrlWorks() {
+    mockUserRepository.getProfilePictureUrl(blankUser.uid, { assertNull(it) }, doNotFail)
+
+    mockUserRepository.getProfilePictureUrl(
+        activeUser.uid, { assertEquals(activeUser.profileImageUrl, it) }, doNotFail)
+  }
+
+  @Test
+  fun updateProfilePictureUrlWorks() {
+    mockUserRepository.updateProfilePictureUrl(
+        activeUser.uid,
+        profilePictureUrl,
+        {
+          mockUserRepository.getProfilePictureUrl(
+              activeUser.uid, { assertEquals(profilePictureUrl.toString(), it) }, doNotFail)
+        },
+        doNotFail)
+  }
+
+  @Test
+  fun sendFriendRequestWorks() {
+    mockUserRepository.sendFriendRequest(
+        activeUser.uid,
+        otherUser.uid,
+        {
+          mockUserRepository.getRequestsFriendsList(
+              otherUser.uid, { assertTrue(it.contains(activeUser.uid)) }, doNotFail)
+        },
+        doNotFail)
+  }
+
+  @Test
+  fun acceptFriendRequestWorks() {
+    val receiver =
+        User(
+            uid = "receiverId",
+            friendRequests = listOf(blankUser.uid),
+        )
+
+    mockUserRepository.addUser(receiver)
+
+    mockUserRepository.acceptFriendRequest(
+        receiver.uid,
+        blankUser.uid,
+        {
+          mockUserRepository.getFriendsList(
+              receiver.uid, { assertTrue(it.contains(blankUser.uid)) }, doNotFail)
+          mockUserRepository.getFriendsList(
+              blankUser.uid, { assertTrue(it.contains(receiver.uid)) }, doNotFail)
+          mockUserRepository.getRequestsFriendsList(
+              receiver.uid, { assertFalse(it.contains(blankUser.uid)) }, doNotFail)
+        },
+        doNotFail)
+  }
+
+  @Test
+  fun removeFriendWorks() {
+    val firstUserId = "firstUserId"
+    val secondUserId = "secondUserId"
+    val firstUser =
+        User(
+            uid = "firstUserId",
+            friends = listOf(secondUserId),
+        )
+    val secondUser =
+        User(
+            uid = "secondUserId",
+            friends = listOf(firstUserId),
+        )
+
+    mockUserRepository.addUser(firstUser)
+    mockUserRepository.addUser(secondUser)
+
+    mockUserRepository.removeFriend(
+        firstUserId,
+        secondUserId,
+        {
+          mockUserRepository.getFriendsList(
+              firstUserId, { assertFalse(it.contains(secondUserId)) }, doNotFail)
+          mockUserRepository.getFriendsList(
+              secondUserId, { assertFalse(it.contains(firstUserId)) }, doNotFail)
+        },
+        doNotFail)
+  }
+
+  @Test
+  fun declineFriendRequestWorks() {
+    val receiver =
+        User(
+            uid = "receiverId",
+            friendRequests = listOf(blankUser.uid),
+        )
+
+    mockUserRepository.addUser(receiver)
+
+    mockUserRepository.declineFriendRequest(
+        receiver.uid,
+        blankUser.uid,
+        {
+          mockUserRepository.getRequestsFriendsList(
+              receiver.uid, { assertFalse(it.contains(blankUser.uid)) }, doNotFail)
+        },
+        doNotFail)
+  }
+
+  // This is a shallow test, as getting challenges should be changed to return a list of challenge
+  // IDs
+  @Test
+  fun addOngoingChallengeWorks() {
+    val challengeId = "challengeId"
+    mockUserRepository.addOngoingChallenge(
+        activeUser.uid,
+        challengeId,
+        {
+          mockUserRepository.getOngoingChallenges(
+              activeUser.uid,
+              { challenges -> assertTrue(challenges.any { it.challengeId == challengeId }) },
+              doNotFail)
+        },
+        doNotFail)
+  }
+
+  @Test
+  fun getOngoingChallengesWorks() {
+    mockUserRepository.getOngoingChallenges(blankUser.uid, { assertTrue(it.isEmpty()) }, doNotFail)
+
+    mockUserRepository.getOngoingChallenges(
+        activeUser.uid,
+        { challenges ->
+          assertEquals(
+              activeUser.ongoingChallenges.toSet(), challenges.map { it.challengeId }.toSet())
+        },
+        doNotFail)
+  }
+
+  @Test
+  fun removeOngoingChallengeWorks() {
+    val challengeId = "challengeId"
+    val user =
+        User(
+            uid = "userId",
+            ongoingChallenges = listOf(challengeId),
+        )
+
+    mockUserRepository.addUser(user)
+
+    mockUserRepository.removeOngoingChallenge(
+        user.uid,
+        challengeId,
+        {
+          mockUserRepository.getOngoingChallenges(
+              user.uid,
+              { challenges -> assertFalse(challenges.any { it.challengeId == challengeId }) },
+              doNotFail)
+        },
+        doNotFail)
+  }
+
+  @Test
+  fun getInitialQuestAccessDateWorks() {
+    mockUserRepository.getInitialQuestAccessDate(blankUser.uid, { assertNull(it) }, doNotFail)
+
+    mockUserRepository.getInitialQuestAccessDate(
+        activeUser.uid, { assertEquals(activeUser.lastLoginDate, it) }, doNotFail)
+  }
+
+  @Test
+  fun setInitialQuestAccessDateWorks() {
+    val date = "2024-01-01"
+    mockUserRepository.setInitialQuestAccessDate(
+        activeUser.uid,
+        date,
+        {
+          mockUserRepository.getInitialQuestAccessDate(
+              activeUser.uid, { assertEquals(date, it) }, doNotFail)
+        },
+        doNotFail)
+  }
+
+  @Test
+  fun updateStreakWorks() {
+    mockUserRepository.updateStreak(
+        activeUser.uid,
+        {
+          mockUserRepository.getStreak(
+              activeUser.uid,
+              { streak -> assertEquals(activeUser.currentStreak + 1, streak) },
+              doNotFail)
+        },
+        doNotFail)
+  }
+
+  @Test
+  fun getStreakWorks() {
+    mockUserRepository.getStreak(blankUser.uid, { assertNull(it) }, doNotFail)
+
+    mockUserRepository.getStreak(
+        activeUser.uid, { assertEquals(activeUser.currentStreak, it) }, doNotFail)
+  }
+}


### PR DESCRIPTION
## Additions

A new `MockUserRepository.kt` fake implements the interface `UserRepository.kt`. This fake should be used in testing to replace the `UserRepositoryFireStore.kt` class. This new mock almost perfectly matches the behavior of `UserRepositoryFireStore.kt` used in production.

## Tests

Basic tests for the class achieve perfect line coverage, barring a single check that should not exist. 

There is always space for some more complex tests. But I don't think this mock carries too much risk of complex failure cases.

## Known bugs

As mentioned above, the mock requires a weird check in `getStreak()` due to an inconsistency in existing code. I've marked this as a task in the scrum board.

The interface `UserRepository.kt` defines an `updateStreak()` method. With no documentation on it, and questionable design, I could not follow the logic of its implementation `UserRepositoryFireStore.kt`. Thus, in the mock, I've simply made this method increment a user's streak by 1 for now. We might want to fix this at a later date if we want to mock streaks in some system test.

The interface `UserRepository.kt` defines an `getOngoingChallenges()` method. This method currently returns `Challenge`s. It should be refactored to return challenge IDs instead. The user repository should not be responsible for fetching challenges. Thus is was impossible to reasonably mock this method. I've decided to return empty `Challenge`s for now.

## Future changes

While mocking `UserRepository.kt`, I have encountered a couple issues, some mentionned above. I have marked these with comments. Some of the design choices in the creation of the original user repository are questionable, and should be changed.

As mentioned above, `UserRepository.getOngoingChallenges()` is currently expected to fetch challenges from the challenge repository. This is a major design mistake as both repositories must be decoupled. This method must be refactored. I have marked this as a task in the scrum board.
