### PR TITLE
Add updateStatsEvent StateFlow to StatsViewModel

### DIFF
--- a/app/src/main/java/com/github/se/signify/model/stats/StatsViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/stats/StatsViewModel.kt
@@ -13,11 +13,11 @@ class StatsViewModel(
 ) : ViewModel() {
 
   sealed class UpdateStatsEvent {
-    object Loading : UpdateStatsEvent()
+    data object Loading : UpdateStatsEvent()
 
-    object Idle : UpdateStatsEvent()
+    data object Idle : UpdateStatsEvent()
 
-    object Success : UpdateStatsEvent()
+    data object Success : UpdateStatsEvent()
 
     data class Failure(val message: String) : UpdateStatsEvent()
   }
@@ -80,66 +80,134 @@ class StatsViewModel(
   private fun logError(m: String, e: Exception) = Log.e(logTag, "$m: ${e.message}")
 
   fun getLettersLearned() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.getLettersLearned(
         userSession.getUserId()!!,
-        onSuccess = { letters -> _lettersLearned.value = letters },
-        onFailure = { e -> logError("Error fetching letters learned:", e) })
+        onSuccess = { letters ->
+          _lettersLearned.value = letters
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error fetching letters learned:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
+        })
   }
 
   fun getEasyExerciseStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.getEasyExerciseStats(
         userSession.getUserId()!!,
-        onSuccess = { easyStats -> _easy.value = easyStats },
-        onFailure = { e -> logError("Error fetching easy exercise stats:", e) })
+        onSuccess = { easyStats ->
+          _easy.value = easyStats
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error fetching easy exercise stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
+        })
   }
 
   fun getMediumExerciseStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.getMediumExerciseStats(
         userSession.getUserId()!!,
-        onSuccess = { mediumStats -> _medium.value = mediumStats },
-        onFailure = { e -> logError("Error fetching medium exercise stats:", e) })
+        onSuccess = { mediumStats ->
+          _medium.value = mediumStats
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error fetching medium exercise stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
+        })
   }
 
   fun getHardExerciseStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.getHardExerciseStats(
         userSession.getUserId()!!,
-        onSuccess = { hardStats -> _hard.value = hardStats },
-        onFailure = { e -> logError("Error fetching hard exercise stats:", e) })
+        onSuccess = { hardStats ->
+          _hard.value = hardStats
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error fetching hard exercise stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
+        })
   }
 
   fun getDailyQuestStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.getDailyQuestStats(
         userSession.getUserId()!!,
-        onSuccess = { dailyQuest -> _daily.value = dailyQuest },
-        onFailure = { e -> logError("Error fetching daily quest stats:", e) })
+        onSuccess = { dailyQuest ->
+          _daily.value = dailyQuest
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error fetching daily quest stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
+        })
   }
 
   fun getWeeklyQuestStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.getWeeklyQuestStats(
         userSession.getUserId()!!,
-        onSuccess = { weeklyQuest -> _weekly.value = weeklyQuest },
-        onFailure = { e -> logError("Error fetching weekly quest stats:", e) })
+        onSuccess = { weeklyQuest ->
+          _weekly.value = weeklyQuest
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error fetching weekly quest stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
+        })
   }
 
   fun getCompletedChallengeStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
     repository.getCompletedChallengeStats(
         userSession.getUserId()!!,
-        onSuccess = { completedChallenge -> _completed.value = completedChallenge },
-        onFailure = { e -> logError("Error fetching completed challenge Stats:", e) })
+        onSuccess = { completedChallenge ->
+          _completed.value = completedChallenge
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error fetching completed challenge Stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
+        })
   }
 
   fun getCreatedChallengeStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
     repository.getCreatedChallengeStats(
         userSession.getUserId()!!,
-        onSuccess = { createdChallenge -> _created.value = createdChallenge },
-        onFailure = { e -> logError("Error fetching created challenge Stats:", e) })
+        onSuccess = { createdChallenge ->
+          _created.value = createdChallenge
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error fetching created challenge Stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
+        })
   }
 
   fun getWonChallengeStats() {
     repository.getWonChallengeStats(
         userSession.getUserId()!!,
-        onSuccess = { wonChallenge -> _won.value = wonChallenge },
-        onFailure = { e -> logError("Error fetching won challenge Stats:", e) })
+        onSuccess = { wonChallenge ->
+          _won.value = wonChallenge
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error fetching won challenge Stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
+        })
   }
 
   fun updateLettersLearned(newLetter: Char) {

--- a/app/src/main/java/com/github/se/signify/model/stats/StatsViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/stats/StatsViewModel.kt
@@ -26,8 +26,11 @@ class StatsViewModel(
     _updateStatsEvent.value = UpdateStatsEvent.Idle
   }
 
+  private val UNKNOWN_ERROR_MESSAGE = "Unknown error"
+
   private val _updateStatsEvent = MutableStateFlow<UpdateStatsEvent>(UpdateStatsEvent.Idle)
   val updateStatsEvent: StateFlow<UpdateStatsEvent> = _updateStatsEvent
+
   private val _lettersLearned = MutableStateFlow<List<Char>>(emptyList())
   val lettersLearned: StateFlow<List<Char>> = _lettersLearned
 
@@ -151,7 +154,7 @@ class StatsViewModel(
         },
         onFailure = { e ->
           logError("Error updating letters learned:", e)
-          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
         })
   }
 
@@ -166,7 +169,7 @@ class StatsViewModel(
         },
         onFailure = { e ->
           logError("Error updating easy exercise stats:", e)
-          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
         })
   }
 
@@ -181,7 +184,7 @@ class StatsViewModel(
         },
         onFailure = { e ->
           logError("Error updating medium exercise stats:", e)
-          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
         })
   }
 
@@ -196,7 +199,7 @@ class StatsViewModel(
         },
         onFailure = { e ->
           logError("Error updating hard exercise stats:", e)
-          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
         })
   }
 
@@ -211,7 +214,7 @@ class StatsViewModel(
         },
         onFailure = { e ->
           logError("Error updating daily quest stats:", e)
-          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
         })
   }
 
@@ -226,7 +229,7 @@ class StatsViewModel(
         },
         onFailure = { e ->
           logError("Error updating weekly quest stats:", e)
-          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
         })
   }
 
@@ -241,7 +244,7 @@ class StatsViewModel(
         },
         onFailure = { e ->
           logError("Error updating completed challenge stats:", e)
-          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
         })
   }
 
@@ -256,7 +259,7 @@ class StatsViewModel(
         },
         onFailure = { e ->
           logError("Error updating created challenge stats:", e)
-          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
         })
   }
 
@@ -271,7 +274,7 @@ class StatsViewModel(
         },
         onFailure = { e ->
           logError("Error updating won challenge stats:", e)
-          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: UNKNOWN_ERROR_MESSAGE)
         })
   }
 }

--- a/app/src/main/java/com/github/se/signify/model/stats/StatsViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/stats/StatsViewModel.kt
@@ -12,6 +12,22 @@ class StatsViewModel(
     private val repository: StatsRepository,
 ) : ViewModel() {
 
+  sealed class UpdateStatsEvent {
+    object Loading : UpdateStatsEvent()
+
+    object Idle : UpdateStatsEvent()
+
+    object Success : UpdateStatsEvent()
+
+    data class Failure(val message: String) : UpdateStatsEvent()
+  }
+
+  fun resetUpdateStatsEvent() {
+    _updateStatsEvent.value = UpdateStatsEvent.Idle
+  }
+
+  private val _updateStatsEvent = MutableStateFlow<UpdateStatsEvent>(UpdateStatsEvent.Idle)
+  val updateStatsEvent: StateFlow<UpdateStatsEvent> = _updateStatsEvent
   private val _lettersLearned = MutableStateFlow<List<Char>>(emptyList())
   val lettersLearned: StateFlow<List<Char>> = _lettersLearned
 
@@ -124,66 +140,138 @@ class StatsViewModel(
   }
 
   fun updateLettersLearned(newLetter: Char) {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.updateLettersLearned(
         userSession.getUserId()!!,
         newLetter,
-        onSuccess = { logSuccess("Letterss learned updated successfully.") },
-        onFailure = { e -> logError("Error updating letters learned:", e) })
+        onSuccess = {
+          logSuccess("Letters learned updated successfully.")
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error updating letters learned:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+        })
   }
 
   fun updateEasyExerciseStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.updateEasyExerciseStats(
         userSession.getUserId()!!,
-        onSuccess = { logSuccess("Easy exercise stats updated successfully.") },
-        onFailure = { e -> logError("Error updating easy exercise stats:", e) })
+        onSuccess = {
+          logSuccess("Easy exercise stats updated successfully.")
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error updating easy exercise stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+        })
   }
 
   fun updateMediumExerciseStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.updateMediumExerciseStats(
         userSession.getUserId()!!,
-        onSuccess = { logSuccess("Medium exercise stats updated successfully.") },
-        onFailure = { e -> logError("Error updating medium exercise stats:", e) })
+        onSuccess = {
+          logSuccess("Medium exercise stats updated successfully.")
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error updating medium exercise stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+        })
   }
 
   fun updateHardExerciseStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.updateHardExerciseStats(
         userSession.getUserId()!!,
-        onSuccess = { logSuccess("Hard exercise stats updated successfully.") },
-        onFailure = { e -> logError("Error updating hard exercise stats:", e) })
+        onSuccess = {
+          logSuccess("Hard exercise stats updated successfully.")
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error updating hard exercise stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+        })
   }
 
   fun updateDailyQuestStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.updateDailyQuestStats(
         userSession.getUserId()!!,
-        onSuccess = { logSuccess("Daily quest stats updated successfully.") },
-        onFailure = { e -> logError("Error updating daily quest stats:", e) })
+        onSuccess = {
+          logSuccess("Daily quest stats updated successfully.")
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error updating daily quest stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+        })
   }
 
   fun updateWeeklyQuestStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.updateWeeklyQuestStats(
         userSession.getUserId()!!,
-        onSuccess = { logSuccess("Weekly quest stats updated successfully.") },
-        onFailure = { e -> logError("Error updating weekly quest stats:", e) })
+        onSuccess = {
+          logSuccess("Weekly quest stats updated successfully.")
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error updating weekly quest stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+        })
   }
 
   fun updateCompletedChallengeStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.updateCompletedChallengeStats(
         userSession.getUserId()!!,
-        onSuccess = { logSuccess("Completed challenge stats updated successfully.") },
-        onFailure = { e -> logError("Error updating completed challenge stats:", e) })
+        onSuccess = {
+          logSuccess("Completed challenge stats updated successfully.")
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error updating completed challenge stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+        })
   }
 
   fun updateCreatedChallengeStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.updateCreatedChallengeStats(
         userSession.getUserId()!!,
-        onSuccess = { logSuccess("Created challenge stats updated successfully.") },
-        onFailure = { e -> logError("Error updating created challenge stats:", e) })
+        onSuccess = {
+          logSuccess("Created challenge stats updated successfully.")
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error updating created challenge stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+        })
   }
 
   fun updateWonChallengeStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.updateWonChallengeStats(
         userSession.getUserId()!!,
-        onSuccess = { logSuccess("Won challenge stats updated successfully.") },
-        onFailure = { e -> logError("Error updating won challenge stats:", e) })
+        onSuccess = {
+          logSuccess("Won challenge stats updated successfully.")
+          _updateStatsEvent.value = UpdateStatsEvent.Success
+        },
+        onFailure = { e ->
+          logError("Error updating won challenge stats:", e)
+          _updateStatsEvent.value = UpdateStatsEvent.Failure(e.message ?: "Unknown error")
+        })
   }
 }

--- a/app/src/main/java/com/github/se/signify/model/stats/StatsViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/stats/StatsViewModel.kt
@@ -185,6 +185,7 @@ class StatsViewModel(
 
   fun getCreatedChallengeStats() {
     _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.getCreatedChallengeStats(
         userSession.getUserId()!!,
         onSuccess = { createdChallenge ->
@@ -198,6 +199,8 @@ class StatsViewModel(
   }
 
   fun getWonChallengeStats() {
+    _updateStatsEvent.value = UpdateStatsEvent.Loading
+
     repository.getWonChallengeStats(
         userSession.getUserId()!!,
         onSuccess = { wonChallenge ->

--- a/app/src/test/java/com/github/se/signify/model/stats/StatsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/stats/StatsViewModelTest.kt
@@ -132,14 +132,14 @@ class StatsViewModelTest(
   }
 
   @Test
-  fun `getIntFunctions should handle success correctly`() {
+  fun getIntFunctionsShouldHandleSuccessCorrectly() {
     getAction()
     assertTrue(mockStatsRepository.wasMethodCalled(getStatName))
     assertEquals(expectedValueGet, stateFlowValue())
   }
 
   @Test
-  fun `getIntFunctions should handle failure correctly`() {
+  fun getIntFunctionsShouldHandleFailureCorrectly() {
     mockStatsRepository.shouldSucceed = false
     getAction()
     assertTrue(mockStatsRepository.wasMethodCalled(getStatName))
@@ -147,7 +147,7 @@ class StatsViewModelTest(
   }
 
   @Test
-  fun `resetUpdateStatsEvent should set state to Idle`() {
+  fun resetUpdateStatsEventShouldSetStateToIdle() {
     updateAction()
 
     assertNotEquals(StatsViewModel.UpdateStatsEvent.Idle, statsViewModel.updateStatsEvent.value)
@@ -158,7 +158,7 @@ class StatsViewModelTest(
   }
 
   @Test
-  fun `update state should transition from Idle to Success on update function call`() {
+  fun updateStateShouldTransitionFromIdleToSuccessOnUpdateFunctionCall() {
     val initialState = statsViewModel.updateStatsEvent.value
 
     assertEquals(StatsViewModel.UpdateStatsEvent.Idle, initialState)
@@ -170,7 +170,7 @@ class StatsViewModelTest(
   }
 
   @Test
-  fun `update state should transition from Idle to Failure on update function call`() {
+  fun updateStateShouldTransitionFromIdleToFailureOnUpdateFunctionCall() {
     mockStatsRepository.shouldSucceed = false
 
     val initialState = statsViewModel.updateStatsEvent.value
@@ -183,7 +183,7 @@ class StatsViewModelTest(
   }
 
   @Test
-  fun `updateIntFunctions should handle success correctly`() {
+  fun updateIntFunctionsShouldHandleSuccessCorrectly() {
     updateAction()
 
     assertTrue(mockStatsRepository.wasMethodCalled(updateStatName))
@@ -194,7 +194,7 @@ class StatsViewModelTest(
   }
 
   @Test
-  fun `updateIntFunctions should handle failure correctly`() {
+  fun updateIntFunctionsShouldHandleFailureCorrectly() {
     mockStatsRepository.shouldSucceed = false
 
     updateAction()

--- a/app/src/test/java/com/github/se/signify/model/stats/StatsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/stats/StatsViewModelTest.kt
@@ -19,7 +19,7 @@ class StatsViewModelTest(
     private val updateAction: () -> Unit,
     private val expectedValueGet: Int,
     private val expectedValueUpdate: Int,
-    private val stateFlowValue: () -> Int,
+    private val stateFlowValue: () -> Int
 ) {
   companion object {
     private lateinit var mockUserSession: UserSession


### PR DESCRIPTION

---

**Introduce StateFlow for update call results in `StatsViewModel` and Enhance Error Handling**

### Description

After a PR in which the `ExerciseScreen` was improved and now makes an `updateStats` call to the ViewModel, I noticed that it didn't have access to the result of this operation—specifically whether it failed or succeeded. It assumed success and reset its state automatically.

This PR introduces a `StateFlow` (`updateStatsEvent`) in `StatsViewModel` that screens can observe to react accordingly. For example, they can display a loading indicator or handle success/failure appropriately. Additionally, a `resetUpdateStatsEvent` function is added to allow screens to reset the state explicitly.

### Changes
- Added `updateStatsEvent` as a `StateFlow` in `StatsViewModel`.
- Added `resetUpdateStatsEvent` function to reset the state to `Idle`.
- Wrote unit tests for the new `StateFlow` and reset functionality.
---
