### PR TITLE
Fix inconsistencies

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/SettingsScreenTest.kt
@@ -39,8 +39,6 @@ class SettingsScreenTest {
   private lateinit var context: Context
   private lateinit var contentResolver: ContentResolver
 
-  private val testUserID = "currentUserId"
-
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
@@ -76,9 +74,6 @@ class SettingsScreenTest {
 
     // Check if the delete profile picture icon is displayed
     composeTestRule.onNodeWithContentDescription("Delete Profile Picture").assertIsDisplayed()
-
-    // Check if the "Other settings" section is displayed
-    composeTestRule.onNodeWithText("Other settings:\nLanguage,\nTheme,\n...").assertIsDisplayed()
 
     // Check if the Cancel button is displayed
     composeTestRule.onNodeWithText("Cancel").assertIsDisplayed()

--- a/app/src/main/java/com/github/se/signify/model/common/user/FirestoreUserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/common/user/FirestoreUserRepository.kt
@@ -50,7 +50,8 @@ class FirestoreUserRepository(
         val friends = (documentSnapshot[friendsListPath] as? List<*>)?.filterIsInstance<String>()
         onSuccess(friends ?: emptyList())
       } else {
-        onSuccess(emptyList())
+        // Call onFailure when user's document is not found
+        onFailure(NoSuchElementException("User not found for ID: $userId"))
       }
     }
   }
@@ -75,7 +76,8 @@ class FirestoreUserRepository(
             (documentSnapshot[friendRequestsListPath] as? List<*>)?.filterIsInstance<String>()
         onSuccess(friendsRequests ?: emptyList())
       } else {
-        onSuccess(emptyList())
+        // Call onFailure when user's document is not found
+        onFailure(NoSuchElementException("User not found for ID: $userId"))
       }
     }
   }
@@ -128,7 +130,8 @@ class FirestoreUserRepository(
         val userName = documentSnapshot[usernamePath] as? String
         onSuccess(userName ?: "unknown")
       } else {
-        onSuccess("unknown")
+        // Call onFailure when user's document is not found
+        onFailure(NoSuchElementException("User not found for ID: $userId"))
       }
     }
   }
@@ -174,7 +177,8 @@ class FirestoreUserRepository(
         val profilePictureUrl = documentSnapshot[profilePicturePath] as? String
         onSuccess(profilePictureUrl)
       } else {
-        onSuccess(null)
+        // Call onFailure when user's document is not found
+        onFailure(NoSuchElementException("User not found for ID: $userId"))
       }
     }
   }
@@ -340,7 +344,8 @@ class FirestoreUserRepository(
         .get()
         .addOnSuccessListener { document ->
           if (!document.exists()) {
-            onSuccess(emptyList())
+            // Call onFailure when user's document is not found
+            onFailure(NoSuchElementException("User not found for ID: $userId"))
             return@addOnSuccessListener
           }
 
@@ -418,7 +423,8 @@ class FirestoreUserRepository(
             val initialDate = document.getString("initialQuestAccessDate")
             onSuccess(initialDate) // Pass the date to the success callback
           } else {
-            onSuccess(null) // No date set yet
+            // Call onFailure when user's document is not found
+            onFailure(NoSuchElementException("User not found for ID: $userId"))
           }
         }
         .addOnFailureListener { exception ->
@@ -519,7 +525,8 @@ class FirestoreUserRepository(
         val streak = documentSnapshot["currentStreak"] as Long
         onSuccess(streak)
       } else {
-        onSuccess(0)
+        // Call onFailure when user's document is not found
+        onFailure(NoSuchElementException("User not found for ID: $userId"))
       }
     }
   }

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
@@ -51,7 +51,6 @@ import com.github.se.signify.model.common.user.UserRepository
 import com.github.se.signify.model.common.user.UserViewModel
 import com.github.se.signify.model.navigation.NavigationActions
 import com.github.se.signify.ui.common.AnnexScreenScaffold
-import com.github.se.signify.ui.common.NotImplementedYet
 import com.github.se.signify.ui.common.ProfilePicture
 
 @Composable
@@ -94,23 +93,8 @@ fun SettingsScreen(
       navigationActions = navigationActions,
       testTag = "SettingsScreen",
   ) {
-    Spacer(modifier = Modifier.height(32.dp))
+    Spacer(modifier = Modifier.height(64.dp))
 
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(16.dp).clickable { onThemeChange(!isDarkTheme) },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween) {
-          val modeText =
-              if (isDarkTheme) stringResource(R.string.dark_mode_text)
-              else stringResource(R.string.light_mode_text)
-          Text(
-              text = modeText,
-              style = MaterialTheme.typography.bodyLarge,
-              color = MaterialTheme.colorScheme.onBackground)
-          Switch(checked = isDarkTheme, onCheckedChange = { onThemeChange(it) })
-        }
-    // Switch between English and French
-    LanguageSwitch(isFrench, onLanguageChange)
     // Editable Profile Picture
     Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
       Row(
@@ -149,7 +133,7 @@ fun SettingsScreen(
         ProfilePicture(selectedImageUrl)
       }
     }
-    Spacer(modifier = Modifier.height(32.dp))
+    Spacer(modifier = Modifier.height(64.dp))
 
     // Editable Username
     Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
@@ -187,11 +171,26 @@ fun SettingsScreen(
                         cursorColor = MaterialTheme.colorScheme.onBackground))
           }
     }
-    Spacer(modifier = Modifier.height(32.dp))
+    Spacer(modifier = Modifier.height(64.dp))
 
-    // Other Settings Section To be removed after all settings are completed !
-    NotImplementedYet(testTag = "OtherSettings", text = "Other settings:\nLanguage,\nTheme,\n...")
-    Spacer(modifier = Modifier.height(32.dp))
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(16.dp).clickable { onThemeChange(!isDarkTheme) },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween) {
+          val modeText =
+              if (isDarkTheme) stringResource(R.string.dark_mode_text)
+              else stringResource(R.string.light_mode_text)
+          Text(
+              text = modeText,
+              style = MaterialTheme.typography.bodyLarge,
+              color = MaterialTheme.colorScheme.onBackground)
+          Switch(checked = isDarkTheme, onCheckedChange = { onThemeChange(it) })
+        }
+    // Switch between English and French
+    LanguageSwitch(isFrench, onLanguageChange)
+
+    Spacer(modifier = Modifier.height(64.dp))
+
     val savedText = stringResource(R.string.saved_text)
     val saveText = stringResource(R.string.save_text)
     val cancelText = stringResource(R.string.cancel_text)
@@ -235,6 +234,7 @@ fun ActionButtons(onClickAction: () -> Unit, color: Color, text: String, modifie
             text = text, color = MaterialTheme.colorScheme.background, fontWeight = FontWeight.Bold)
       }
 }
+
 /**
  * A composable function that provides a toggle to switch between French (FR) and English (EN).
  *

--- a/app/src/test/java/com/github/se/signify/model/common/user/FirestoreUserRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/common/user/FirestoreUserRepositoryTest.kt
@@ -8,6 +8,7 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.EventListener
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
@@ -985,5 +986,185 @@ class FirestoreUserRepositoryTest {
     assertTrue(failureCallbackCalled)
     // Verifies that the `update` operation was called with the expected data
     verify(mockCurrentUserDocRef).update(updatedDataCaptor.firstValue)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  @Test
+  fun getFriendsList_shouldHandleUserDocNotExist() {
+    val expectedException = NoSuchElementException("User not found for ID: $currentUserId")
+
+    // Arrange: Mock Firestore behavior
+    `when`(mockCollectionReference.document(currentUserId)).thenReturn(mockCurrentUserDocRef)
+    `when`(mockUserDocumentSnapshot.exists()).thenReturn(false) // Document does not exist
+
+    // Mock addSnapshotListener with a compatible EventListener
+    `when`(mockCurrentUserDocRef.addSnapshotListener(any<EventListener<DocumentSnapshot>>()))
+        .thenAnswer { invocation ->
+          val listener = invocation.arguments[0] as EventListener<DocumentSnapshot>
+          listener.onEvent(mockUserDocumentSnapshot, null) // Simulate snapshot received
+          null
+        }
+
+    var failureCallbackCalled = false
+    val onFailure: (Exception) -> Unit = { exception ->
+      failureCallbackCalled = true
+      assertTrue(exception is NoSuchElementException)
+      assertEquals(expectedException.message, exception.message)
+    }
+
+    // Act
+    firestoreUserRepository.getFriendsList(
+        currentUserId,
+        onSuccess = {
+          fail("onSuccess should not be called when the user document does not exist")
+        },
+        onFailure = onFailure)
+
+    // Assert
+    assertTrue(failureCallbackCalled)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  @Test
+  fun getRequestsFriendsList_shouldHandleUserDocNotExist() {
+    val expectedException = NoSuchElementException("User not found for ID: $currentUserId")
+
+    // Arrange: Mock Firestore behavior
+    `when`(mockCollectionReference.document(currentUserId)).thenReturn(mockCurrentUserDocRef)
+    `when`(mockUserDocumentSnapshot.exists()).thenReturn(false) // Document does not exist
+
+    // Mock addSnapshotListener with a compatible EventListener
+    `when`(mockCurrentUserDocRef.addSnapshotListener(any<EventListener<DocumentSnapshot>>()))
+        .thenAnswer { invocation ->
+          val listener = invocation.arguments[0] as EventListener<DocumentSnapshot>
+          listener.onEvent(mockUserDocumentSnapshot, null) // Simulate snapshot received
+          null
+        }
+
+    var failureCallbackCalled = false
+    val onFailure: (Exception) -> Unit = { exception ->
+      failureCallbackCalled = true
+      assertTrue(exception is NoSuchElementException)
+      assertEquals(expectedException.message, exception.message)
+    }
+
+    // Act
+    firestoreUserRepository.getRequestsFriendsList(
+        currentUserId,
+        onSuccess = {
+          fail("onSuccess should not be called when the user document does not exist")
+        },
+        onFailure = onFailure)
+
+    // Assert
+    assertTrue(failureCallbackCalled)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  @Test
+  fun getUserName_shouldHandleUserDocNotExist() {
+    val expectedException = NoSuchElementException("User not found for ID: $currentUserId")
+
+    // Arrange: Mock Firestore behavior
+    `when`(mockCollectionReference.document(currentUserId)).thenReturn(mockCurrentUserDocRef)
+    `when`(mockUserDocumentSnapshot.exists()).thenReturn(false) // Document does not exist
+
+    // Mock addSnapshotListener with a compatible EventListener
+    `when`(mockCurrentUserDocRef.addSnapshotListener(any<EventListener<DocumentSnapshot>>()))
+        .thenAnswer { invocation ->
+          val listener = invocation.arguments[0] as EventListener<DocumentSnapshot>
+          listener.onEvent(mockUserDocumentSnapshot, null) // Simulate snapshot received
+          null
+        }
+
+    var failureCallbackCalled = false
+    val onFailure: (Exception) -> Unit = { exception ->
+      failureCallbackCalled = true
+      assertTrue(exception is NoSuchElementException)
+      assertEquals(expectedException.message, exception.message)
+    }
+
+    // Act
+    firestoreUserRepository.getUserName(
+        currentUserId,
+        onSuccess = {
+          fail("onSuccess should not be called when the user document does not exist")
+        },
+        onFailure = onFailure)
+
+    // Assert
+    assertTrue(failureCallbackCalled)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  @Test
+  fun getProfilePictureUrl_shouldHandleUserDocNotExist() {
+    val expectedException = NoSuchElementException("User not found for ID: $currentUserId")
+
+    // Arrange: Mock Firestore behavior
+    `when`(mockCollectionReference.document(currentUserId)).thenReturn(mockCurrentUserDocRef)
+    `when`(mockUserDocumentSnapshot.exists()).thenReturn(false) // Document does not exist
+
+    // Mock addSnapshotListener with a compatible EventListener
+    `when`(mockCurrentUserDocRef.addSnapshotListener(any<EventListener<DocumentSnapshot>>()))
+        .thenAnswer { invocation ->
+          val listener = invocation.arguments[0] as EventListener<DocumentSnapshot>
+          listener.onEvent(mockUserDocumentSnapshot, null) // Simulate snapshot received
+          null
+        }
+
+    var failureCallbackCalled = false
+    val onFailure: (Exception) -> Unit = { exception ->
+      failureCallbackCalled = true
+      assertTrue(exception is NoSuchElementException)
+      assertEquals(expectedException.message, exception.message)
+    }
+
+    // Act
+    firestoreUserRepository.getProfilePictureUrl(
+        currentUserId,
+        onSuccess = {
+          fail("onSuccess should not be called when the user document does not exist")
+        },
+        onFailure = onFailure)
+
+    // Assert
+    assertTrue(failureCallbackCalled)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  @Test
+  fun getStreak_shouldHandleUserDocNotExist() {
+    val expectedException = NoSuchElementException("User not found for ID: $currentUserId")
+
+    // Arrange: Mock Firestore behavior
+    `when`(mockCollectionReference.document(currentUserId)).thenReturn(mockCurrentUserDocRef)
+    `when`(mockUserDocumentSnapshot.exists()).thenReturn(false) // Document does not exist
+
+    // Mock addSnapshotListener with a compatible EventListener
+    `when`(mockCurrentUserDocRef.addSnapshotListener(any<EventListener<DocumentSnapshot>>()))
+        .thenAnswer { invocation ->
+          val listener = invocation.arguments[0] as EventListener<DocumentSnapshot>
+          listener.onEvent(mockUserDocumentSnapshot, null) // Simulate snapshot received
+          null
+        }
+
+    var failureCallbackCalled = false
+    val onFailure: (Exception) -> Unit = { exception ->
+      failureCallbackCalled = true
+      assertTrue(exception is NoSuchElementException)
+      assertEquals(expectedException.message, exception.message)
+    }
+
+    // Act
+    firestoreUserRepository.getStreak(
+        currentUserId,
+        onSuccess = {
+          fail("onSuccess should not be called when the user document does not exist")
+        },
+        onFailure = onFailure)
+
+    // Assert
+    assertTrue(failureCallbackCalled)
   }
 }


### PR DESCRIPTION
### Pull Request Description: Fix Settings Screen, Add Switch Button to Figma, and Standardize `UserRepository` Failure Handling

#### Summary
This PR addresses two separate issues:
1. Updates the **Settings Screen** to align its design with the Figma prototype, including adding the switch button.
2. Standardizes failure handling across methods in `UserRepository` to ensure consistent behavior when a user is not found.

Although these issues are unrelated, both required minimal changes, and given the number of open PRs, I opted to include them in a single PR to reduce overhead.

---

### Changes Made

#### **Settings Screen Updates**
- Moved the options section below the profile editing section to match the Figma prototype.
- Added the **switch button** as defined to the Figma design.
- Removed the unused `NotImplementedYet` box.

#### **UserRepository Failure Handling**
- Updated all methods to call `onFailure()` when a user is not found.
- Updated corresponding tests to reflect the new behavior.
- Ensured uniform failure handling across all methods in `UserRepository`.

---

<img width="316" alt="Capture d’écran 2024-12-11 à 17 57 57" src="https://github.com/user-attachments/assets/f0ac3f7d-f8e3-48d6-ab8b-7b04b3bee4a9" />


Let me know if any adjustments are needed!