### PR TITLE
Fix navigation bar highlighting

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/common/ScreensTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/common/ScreensTest.kt
@@ -36,7 +36,8 @@ class ScreensTest {
             Text(text = "Little text for the column", modifier = Modifier.testTag("Text"))
           })
     }
-    composeTestRule.onNodeWithTag("TopLine").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("TopBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("MainScreenScaffold").assertIsDisplayed()
     composeTestRule.onNodeWithTag("HelpButton").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/signify/ui/common/ScreensTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/common/ScreensTest.kt
@@ -29,6 +29,7 @@ class ScreensTest {
       val navigationActions = mock(NavigationActions::class.java)
       MainScreenScaffold(
           navigationActions = navigationActions,
+          topLevelDestination = LIST_TOP_LEVEL_DESTINATION.first(),
           testTag = "MainScreenScaffold",
           helpText = HelpText(title = "HelpTitle", content = "HelpText"),
           content = {
@@ -122,8 +123,8 @@ class ScreensTest {
     composeTestRule.setContent {
       BottomNavigationMenu(
           onTabSelect = { navigationActions.navigateTo(it) },
-          tabList = LIST_TOP_LEVEL_DESTINATION,
-          selectedItem = LIST_TOP_LEVEL_DESTINATION.first().route)
+          topLevelDestinations = LIST_TOP_LEVEL_DESTINATION,
+          selected = LIST_TOP_LEVEL_DESTINATION.first())
     }
 
     composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
@@ -165,7 +166,10 @@ class ScreensTest {
   @Test
   fun bottomBarDisplaysBottomNavigationMenu() {
     val navigationActions = mock(NavigationActions::class.java)
-    composeTestRule.setContent { BottomBar(navigationActions = navigationActions) }
+    composeTestRule.setContent {
+      BottomBar(
+          navigationActions = navigationActions, selected = LIST_TOP_LEVEL_DESTINATION.first())
+    }
     composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
   }
 

--- a/app/src/main/java/com/github/se/signify/ui/common/Screens.kt
+++ b/app/src/main/java/com/github/se/signify/ui/common/Screens.kt
@@ -75,7 +75,7 @@ fun MainScreenScaffold(
     helpText: HelpText? = null,
     topBarButtons: List<@Composable () -> Unit> = emptyList(),
     floatingActionButton: @Composable () -> Unit = {},
-    content: @Composable() (ColumnScope.() -> Unit)
+    content: @Composable (ColumnScope.() -> Unit)
 ) {
   Scaffold(
       floatingActionButton = { floatingActionButton() },
@@ -124,7 +124,8 @@ fun TopBar(buttons: List<@Composable () -> Unit>, helpText: HelpText?) {
     TopLine()
 
     Row(
-        modifier = Modifier.fillMaxWidth().padding(12.dp),
+        modifier =
+            Modifier.fillMaxWidth().padding(12.dp).background(MaterialTheme.colorScheme.surface),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -179,7 +180,7 @@ fun TopLine() {
   Box(
       modifier =
           Modifier.fillMaxWidth()
-              .height(5.dp)
+              .height(3.dp)
               .background(MaterialTheme.colorScheme.primary)
               .testTag("TopLine"))
 }
@@ -279,14 +280,14 @@ fun BackButton(navigationActions: NavigationActions) {
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 fun BottomBar(navigationActions: NavigationActions, selected: TopLevelDestination) {
   Column {
-    SeparatorLine()
+    TopLine()
     BottomNavigationMenu(
         onTabSelect = { route -> navigationActions.navigateTo(route) },
         topLevelDestinations = LIST_TOP_LEVEL_DESTINATION,
         selected = selected,
     )
+    SeparatorLine()
   }
-  SeparatorLine()
 }
 
 @Composable
@@ -298,24 +299,24 @@ fun BottomNavigationMenu(
 ) {
   NavigationBar(
       modifier = Modifier.fillMaxWidth().height(60.dp).testTag("BottomNavigationMenu"),
-      containerColor = MaterialTheme.colorScheme.primaryContainer) {
-        topLevelDestinations.forEach { topLevelDestination ->
-          NavigationBarItem(
-              icon = {
-                Icon(
-                    painterResource(id = topLevelDestination.icon),
-                    contentDescription = null,
-                    modifier = Modifier.testTag("TabIcon_${topLevelDestination.route}"))
-              }, // Load the drawable icons
-              selected = topLevelDestination == selected,
-              onClick = { onTabSelect(topLevelDestination) },
-              modifier = Modifier.clip(RoundedCornerShape(50.dp)),
-              colors =
-                  NavigationBarItemDefaults.colors(
-                      selectedIconColor = MaterialTheme.colorScheme.primary,
-                      indicatorColor = Color.Transparent,
-                      unselectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                  ))
-        }
-      }
+  ) {
+    topLevelDestinations.forEach { topLevelDestination ->
+      NavigationBarItem(
+          icon = {
+            Icon(
+                painterResource(id = topLevelDestination.icon),
+                contentDescription = null,
+                modifier = Modifier.testTag("TabIcon_${topLevelDestination.route}"))
+          }, // Load the drawable icons
+          selected = topLevelDestination == selected,
+          onClick = { onTabSelect(topLevelDestination) },
+          modifier = Modifier.clip(RoundedCornerShape(50.dp)),
+          colors =
+              NavigationBarItemDefaults.colors(
+                  selectedIconColor = MaterialTheme.colorScheme.primary,
+                  indicatorColor = Color.Transparent,
+                  unselectedIconColor = MaterialTheme.colorScheme.onSurface,
+              ))
+    }
+  }
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/auth/UnauthenticatedScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/auth/UnauthenticatedScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.sp
 import com.github.se.signify.R
 import com.github.se.signify.model.navigation.NavigationActions
 import com.github.se.signify.model.navigation.Screen
+import com.github.se.signify.model.navigation.TopLevelDestinations
 import com.github.se.signify.ui.common.HelpText
 import com.github.se.signify.ui.common.MainScreenScaffold
 import com.github.se.signify.ui.common.TextButton
@@ -43,6 +44,7 @@ fun UnauthenticatedScreen(navigationActions: NavigationActions) {
 
   MainScreenScaffold(
       navigationActions = navigationActions,
+      topLevelDestination = TopLevelDestinations.HOME,
       testTag = "UnauthenticatedScreen",
       helpText =
           HelpText(title = offModeText, content = stringResource(R.string.help_offline_mode_text)),

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.dp
 import com.github.se.signify.R
 import com.github.se.signify.model.navigation.NavigationActions
 import com.github.se.signify.model.navigation.Screen
+import com.github.se.signify.model.navigation.TopLevelDestinations
 import com.github.se.signify.ui.common.HelpText
 import com.github.se.signify.ui.common.MainScreenScaffold
 import com.github.se.signify.ui.common.SquareButton
@@ -20,6 +21,7 @@ import com.github.se.signify.ui.common.SquareButton
 fun ChallengeScreen(navigationActions: NavigationActions) {
   MainScreenScaffold(
       navigationActions = navigationActions,
+      topLevelDestination = TopLevelDestinations.CHALLENGE,
       testTag = "ChallengeScreen",
       helpText =
           HelpText(

--- a/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/home/HomeScreen.kt
@@ -54,6 +54,7 @@ import com.github.se.signify.model.home.exercise.ExerciseLevel
 import com.github.se.signify.model.home.exercise.ExerciseLevelName
 import com.github.se.signify.model.navigation.NavigationActions
 import com.github.se.signify.model.navigation.Screen
+import com.github.se.signify.model.navigation.TopLevelDestinations
 import com.github.se.signify.ui.common.BasicButton
 import com.github.se.signify.ui.common.HelpText
 import com.github.se.signify.ui.common.LetterDictionary
@@ -77,6 +78,7 @@ fun HomeScreen(navigationActions: NavigationActions) {
   val letterText = stringResource(id = R.string.letter_text)
   MainScreenScaffold(
       navigationActions = navigationActions,
+      topLevelDestination = TopLevelDestinations.HOME,
       testTag = "HomeScreen",
       helpText =
           HelpText(

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/ProfileScreen.kt
@@ -24,6 +24,7 @@ import com.github.se.signify.model.common.user.UserRepository
 import com.github.se.signify.model.common.user.UserViewModel
 import com.github.se.signify.model.navigation.NavigationActions
 import com.github.se.signify.model.navigation.Screen
+import com.github.se.signify.model.navigation.TopLevelDestinations
 import com.github.se.signify.model.profile.stats.StatsRepository
 import com.github.se.signify.model.profile.stats.StatsViewModel
 import com.github.se.signify.ui.common.AccountInformation
@@ -49,6 +50,7 @@ fun ProfileScreen(
 
   MainScreenScaffold(
       navigationActions = navigationActions,
+      topLevelDestination = TopLevelDestinations.PROFILE,
       testTag = "ProfileScreen",
       helpText =
           HelpText(


### PR DESCRIPTION
## Overview

The navigation bar no longer highlights the current destination.
It turns out this issue was deeper than just changing some colors.

## Changes

- `MainScreenScaffold()` now takes a screen's `TopLevelDestination` to determine which bottom bar item to highlight.
- The bottom bar now correctly highlights the current destination.
Note, the unauthenticated screen counts as "home" for now.
- Some minor visual adjustments to `BottomBar()` were made to match its design on Figma.

Here's the new look of the bottom bar,
![image](https://github.com/user-attachments/assets/8e5aa2f3-0d3d-48a1-8cc1-48dcc1ab0914)