### PR TITLE
Fix friends crash

### DIFF
--- a/app/src/main/java/com/github/se/signify/model/common/user/FirestoreUserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/common/user/FirestoreUserRepository.kt
@@ -130,7 +130,12 @@ class FirestoreUserRepository(
 
       if (documentSnapshot != null && documentSnapshot.exists()) {
         val userName = documentSnapshot[usernamePath] as? String
-        onSuccess(userName ?: "unknown")
+        if (!userName.isNullOrEmpty()) {
+          onSuccess(userName)
+        } else {
+          // Handle case where usernamePath is null or empty
+          onFailure(NoSuchElementException("Username is missing or empty for ID: $userId"))
+        }
       } else {
         // Call onFailure when user's document is not found
         onFailure(NoSuchElementException("User not found for ID: $userId"))

--- a/app/src/main/java/com/github/se/signify/model/common/user/MockUserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/common/user/MockUserRepository.kt
@@ -92,15 +92,12 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users[userId]
-    if (user != null) {
-      // Ensure user.name is non-nullable before passing it to onSuccess
-      user.name?.let { onSuccess(it) }
-          ?: onFailure(NoSuchElementException("Username is missing for user ID: $userId"))
-    } else {
-      // Handle the case where the user is not found
-      onFailure(NoSuchElementException("User not found for ID: $userId"))
-    }
+    val user =
+        users[userId] ?: return onFailure(NoSuchElementException("User not found for ID: $userId"))
+
+    // Ensure user.name is non-nullable before passing it to onSuccess
+    user.name?.let { onSuccess(it) }
+        ?: onFailure(NoSuchElementException("Username is missing for user ID: $userId"))
   }
 
   override fun updateUserName(
@@ -355,6 +352,7 @@ class MockUserRepository : UserRepository {
     users[userId] = user.copy(pastChallenges = user.pastChallenges + challengeId) // Add challenge
   }
 
+  @Suppress("UNCHECKED_CAST")
   override fun updateUserField(
       userId: String,
       fieldName: String,

--- a/app/src/main/java/com/github/se/signify/model/common/user/MockUserRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/common/user/MockUserRepository.kt
@@ -92,11 +92,15 @@ class MockUserRepository : UserRepository {
     if (!checkFailure(onFailure)) return
     if (!checkUser(userId, onFailure)) return
 
-    val user = users.getValue(userId)
-
-    // This was done to match the implementation of the UserRepositoryFireStore
-    // TODO: Make this non-nullable
-    onSuccess(user.name ?: "unknown")
+    val user = users[userId]
+    if (user != null) {
+      // Ensure user.name is non-nullable before passing it to onSuccess
+      user.name?.let { onSuccess(it) }
+          ?: onFailure(NoSuchElementException("Username is missing for user ID: $userId"))
+    } else {
+      // Handle the case where the user is not found
+      onFailure(NoSuchElementException("User not found for ID: $userId"))
+    }
   }
 
   override fun updateUserName(

--- a/app/src/main/java/com/github/se/signify/model/common/user/SaveUserToFirestore.kt
+++ b/app/src/main/java/com/github/se/signify/model/common/user/SaveUserToFirestore.kt
@@ -15,7 +15,13 @@ fun saveUserToFirestore() {
   val currentUser = auth.currentUser
 
   if (currentUser != null) {
-    val email = currentUser.email ?: "unknown"
+    val email = currentUser.email
+
+    if (email.isNullOrBlank()) {
+      Log.e(logTag, "Cannot save user: email is null or blank")
+      return
+    }
+
     val userId = email.split("@")[0]
     val name = currentUser.displayName
 

--- a/app/src/main/java/com/github/se/signify/model/common/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/common/user/UserViewModel.kt
@@ -24,7 +24,7 @@ open class UserViewModel(
   private val _friendsRequests = MutableStateFlow<List<String>>(emptyList())
   val friendsRequests: StateFlow<List<String>> = _friendsRequests
 
-  private val _userName = MutableStateFlow("")
+  private val _userName = MutableStateFlow(" ")
   val userName: StateFlow<String> = _userName
 
   private val _profilePictureUrl = MutableStateFlow<String?>(null)

--- a/app/src/main/java/com/github/se/signify/model/common/user/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/signify/model/common/user/UserViewModel.kt
@@ -24,7 +24,7 @@ open class UserViewModel(
   private val _friendsRequests = MutableStateFlow<List<String>>(emptyList())
   val friendsRequests: StateFlow<List<String>> = _friendsRequests
 
-  private val _userName = MutableStateFlow("unknown")
+  private val _userName = MutableStateFlow("")
   val userName: StateFlow<String> = _userName
 
   private val _profilePictureUrl = MutableStateFlow<String?>(null)

--- a/app/src/test/java/com/github/se/signify/model/common/user/FirestoreUserRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/common/user/FirestoreUserRepositoryTest.kt
@@ -1406,11 +1406,7 @@ class FirestoreUserRepositoryTest {
 
     // Act
     firestoreUserRepository.getUserName(
-        currentUserId,
-        onSuccess = {
-          fail("onSuccess should not be called when the username is missing or empty")
-        },
-        onFailure = onFailure)
+        currentUserId, onSuccess = { fail(noSuccess) }, onFailure = onFailure)
 
     // Assert
     assertTrue(failureCallbackCalled)
@@ -1444,11 +1440,7 @@ class FirestoreUserRepositoryTest {
 
     // Act
     firestoreUserRepository.getUserName(
-        currentUserId,
-        onSuccess = {
-          fail("onSuccess should not be called when the username is missing or empty")
-        },
-        onFailure = onFailure)
+        currentUserId, onSuccess = { fail(noSuccess) }, onFailure = onFailure)
 
     // Assert
     assertTrue(failureCallbackCalled)
@@ -1480,9 +1472,7 @@ class FirestoreUserRepositoryTest {
 
     // Act
     firestoreUserRepository.getUserName(
-        currentUserId,
-        onSuccess = onSuccess,
-        onFailure = { fail("onFailure should not be called when the userName is valid") })
+        currentUserId, onSuccess = onSuccess, onFailure = { fail(noFailure) })
 
     // Assert
     assertTrue(successCallbackCalled)

--- a/app/src/test/java/com/github/se/signify/model/common/user/FirestoreUserRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/common/user/FirestoreUserRepositoryTest.kt
@@ -1377,4 +1377,76 @@ class FirestoreUserRepositoryTest {
     shadowOf(Looper.getMainLooper()).idle()
     assertEquals(0, result)
   }
+
+  @Suppress("UNCHECKED_CAST")
+  @Test
+  fun getUserName_shouldHandleEmptyUserName() {
+    val expectedException =
+        NoSuchElementException("Username is missing or empty for ID: $currentUserId")
+
+    // Arrange: Mock Firestore behavior
+    `when`(mockCollectionReference.document(currentUserId)).thenReturn(mockCurrentUserDocRef)
+    `when`(mockUserDocumentSnapshot.exists()).thenReturn(true) // Document exists
+    `when`(mockUserDocumentSnapshot["name"]).thenReturn(null) // No userName field
+
+    // Simulate Firestore snapshot
+    `when`(mockCurrentUserDocRef.addSnapshotListener(any<EventListener<DocumentSnapshot>>()))
+        .thenAnswer { invocation ->
+          val listener = invocation.arguments[0] as EventListener<DocumentSnapshot>
+          listener.onEvent(mockUserDocumentSnapshot, null) // Pass snapshot with missing userName
+          null
+        }
+
+    var failureCallbackCalled = false
+    val onFailure: (Exception) -> Unit = { exception ->
+      failureCallbackCalled = true
+      assertTrue(exception is NoSuchElementException)
+      assertEquals(expectedException.message, exception.message)
+    }
+
+    // Act
+    firestoreUserRepository.getUserName(
+        currentUserId,
+        onSuccess = {
+          fail("onSuccess should not be called when the username is missing or empty")
+        },
+        onFailure = onFailure)
+
+    // Assert
+    assertTrue(failureCallbackCalled)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  @Test
+  fun getUserName_shouldReturnValidUserName() {
+    val expectedUserName = "TestUser"
+
+    // Arrange: Mock Firestore behavior
+    `when`(mockCollectionReference.document(currentUserId)).thenReturn(mockCurrentUserDocRef)
+    `when`(mockUserDocumentSnapshot.exists()).thenReturn(true) // Document exists
+    `when`(mockUserDocumentSnapshot["name"]).thenReturn(expectedUserName) // Valid userName
+
+    // Simulate Firestore snapshot
+    `when`(mockCurrentUserDocRef.addSnapshotListener(any<EventListener<DocumentSnapshot>>()))
+        .thenAnswer { invocation ->
+          val listener = invocation.arguments[0] as EventListener<DocumentSnapshot>
+          listener.onEvent(mockUserDocumentSnapshot, null) // Pass snapshot with valid userName
+          null
+        }
+
+    var successCallbackCalled = false
+    val onSuccess: (String) -> Unit = { userName ->
+      successCallbackCalled = true
+      assertEquals(expectedUserName, userName)
+    }
+
+    // Act
+    firestoreUserRepository.getUserName(
+        currentUserId,
+        onSuccess = onSuccess,
+        onFailure = { fail("onFailure should not be called when the userName is valid") })
+
+    // Assert
+    assertTrue(successCallbackCalled)
+  }
 }

--- a/app/src/test/java/com/github/se/signify/model/common/user/MockUserRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/common/user/MockUserRepositoryTest.kt
@@ -77,7 +77,8 @@ class MockUserRepositoryTest {
     mockUserRepository.getFriendsList(blankUser.uid, onSuccessAny, doNotFail)
     mockUserRepository.getRequestsFriendsList(blankUser.uid, onSuccessAny, doNotFail)
     mockUserRepository.getUserById(blankUser.uid, { success += 1 }, doNotFail)
-    mockUserRepository.getUserName(blankUser.uid, onSuccessAny, doNotFail)
+    mockUserRepository.getUserName(
+        blankUser.uid, doNotSucceedAny, { assertTrue(it is NoSuchElementException) })
     mockUserRepository.updateUserName(blankUser.uid, "newName", onSuccess, doNotFail)
     mockUserRepository.getProfilePictureUrl(blankUser.uid, onSuccessAny, doNotFail)
     mockUserRepository.updateProfilePictureUrl(
@@ -95,7 +96,7 @@ class MockUserRepositoryTest {
     mockUserRepository.getStreak(blankUser.uid, onSuccessAny, doNotFail)
 
     shadowOf(Looper.getMainLooper()).idle()
-    assertEquals(19, success)
+    assertEquals(18, success)
   }
 
   @Test
@@ -230,7 +231,9 @@ class MockUserRepositoryTest {
 
   @Test
   fun getUserNameWorks() {
-    mockUserRepository.getUserName(blankUser.uid, { assertEquals("unknown", it) }, doNotFail)
+    mockUserRepository.getUserName(blankUser.uid, doNotSucceedAny) {
+      assertTrue(it is NoSuchElementException)
+    }
 
     mockUserRepository.getUserName(activeUser.uid, { assertEquals(activeUser.name, it) }, doNotFail)
   }

--- a/app/src/test/java/com/github/se/signify/model/common/user/MockUserRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/common/user/MockUserRepositoryTest.kt
@@ -687,4 +687,22 @@ class MockUserRepositoryTest {
     shadowOf(Looper.getMainLooper()).idle()
     assertEquals(0, result)
   }
+
+  @Test
+  fun getUserNameFailsWhenUserNotFound() {
+    val invalidUserId = "nonExistingUserId"
+    val expectedMessage = "User not found"
+    var capturedException: Exception? = null
+
+    // Invoke the getUserName function
+    mockUserRepository.getUserName(
+        userId = invalidUserId,
+        onSuccess = { fail("Should not succeed for invalid user ID") },
+        onFailure = { exception -> capturedException = exception })
+
+    // Assertions
+    shadowOf(Looper.getMainLooper()).idle() // Ensure all async tasks are completed
+    assertNotNull("Expected an exception to be captured", capturedException)
+    assertEquals("Exception message should match", expectedMessage, capturedException?.message)
+  }
 }

--- a/app/src/test/java/com/github/se/signify/model/common/user/SaveUserToFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/common/user/SaveUserToFirestoreTest.kt
@@ -42,6 +42,8 @@ class SaveUserToFirestoreTest {
   @Mock private lateinit var mockDocumentSnapshot: DocumentSnapshot
   @Mock private lateinit var mockGetTask: Task<DocumentSnapshot>
 
+  private val errorMessage = "Cannot save user: email is null or blank"
+
   @Suppress("UNCHECKED_CAST")
   @Before
   fun setUp() {
@@ -154,8 +156,7 @@ class SaveUserToFirestoreTest {
       saveUserToFirestore()
 
       // Verify Log.e is called with the correct message
-      logMock.verify(
-          { Log.e(eq("FireStore"), eq("Cannot save user: email is null or blank")) }, times(1))
+      logMock.verify({ Log.e(eq("FireStore"), eq(errorMessage)) }, times(1))
 
       // Ensure Firestore is NOT accessed
       verify(mockFirestore, never()).collection(any())
@@ -190,8 +191,7 @@ class SaveUserToFirestoreTest {
       saveUserToFirestore()
 
       // Verify Log.e is called with the correct message
-      logMock.verify(
-          { Log.e(eq("FireStore"), eq("Cannot save user: email is null or blank")) }, times(1))
+      logMock.verify({ Log.e(eq("FireStore"), eq(errorMessage)) }, times(1))
 
       // Ensure Firestore is NOT accessed
       verify(mockFirestore, never()).collection(any())


### PR DESCRIPTION
### Pull Request : Remove "unknown" default handling and improve user validation

#### **Description**:
This pull request addresses an issue where parts of the code defaulted to `"unknown"` when a user was not logged in. This behavior caused an `"unknown"` user to be created in the database, leading to crashes when attempting to add the `"unknown"` account as a friend. The following changes have been made:

1. **Removed all uses of the `"unknown"` default value**:
   - Operations now fail instead of defaulting to `"unknown"`.
   - Proper error handling is implemented to handle missing or invalid user data.

2. **Ensured invalid `userId`s are handled safely**:
   - Introduced checks for null, blank, or invalid `userId`s.
   - Improved error logging and flow to prevent crashes.

#### **Files Changed**:
- **`FirestoreUserRepository.kt`**: Updated `getUserName` to remove `"unknown"` fallback and handle errors properly.
- **`MockUserRepository.kt`**: Adjusted mock logic to align with the updated behavior of failing for invalid or missing users.
- **`SaveUserToFirestore.kt`**: Removed the `"unknown"` fallback for user email or name, added proper validation, and ensured no invalid users are saved to Firestore.
- **`UserViewModel.kt`**: Updated to align with the new handling of user data and avoid crashes.

3. **Test Updates**:
- **`SaveUserToFirestoreTest.kt`**:  
  - Added tests to verify proper logging and behavior when `email` is `null` or blank.  
  - Ensured Firestore operations are skipped when user validation fails.

- **`FirestoreUserRepositoryTest.kt`**:  
  - Updated tests to validate that errors are handled correctly and `"unknown"` is no longer used.

- **`MockUserRepositoryTest.kt`**:  
  - Adjusted existing test cases to reflect the removal of `"unknown"`.  
  - Added edge case tests for invalid or missing user data.


#### **Issue Fixed**:
- Fixes the bug where the app crashes when attempting to add an `"unknown"` user as a friend.







