### PR TITLE
Fix blinking when navigating to the current screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/common/ScreensTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/common/ScreensTest.kt
@@ -21,6 +21,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.never
 
 class ScreensTest {
   @Test
@@ -172,6 +173,48 @@ class ScreensTest {
           navigationActions = navigationActions, selected = LIST_TOP_LEVEL_DESTINATION.first())
     }
     composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
+  }
+
+  @Test
+  fun bottomNavigationMenuNavigates() {
+    val navigationActions = mock(NavigationActions::class.java)
+    val topLevelDestination = LIST_TOP_LEVEL_DESTINATION.first()
+    composeTestRule.setContent {
+      BottomNavigationMenu(
+          onTabSelect = { navigationActions.navigateTo(it) },
+          topLevelDestinations = LIST_TOP_LEVEL_DESTINATION,
+          selected = LIST_TOP_LEVEL_DESTINATION[1])
+    }
+
+    composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("Tab_${topLevelDestination.route}")
+        .assertIsDisplayed()
+        .performClick()
+
+    // Assert that the click action was never triggered
+    verify(navigationActions).navigateTo(topLevelDestination)
+  }
+
+  @Test
+  fun bottomNavigationMenuDisablesCurrentDestination() {
+    val navigationActions = mock(NavigationActions::class.java)
+    val topLevelDestination = LIST_TOP_LEVEL_DESTINATION.first()
+    composeTestRule.setContent {
+      BottomNavigationMenu(
+          onTabSelect = { navigationActions.navigateTo(it) },
+          topLevelDestinations = LIST_TOP_LEVEL_DESTINATION,
+          selected = topLevelDestination)
+    }
+
+    composeTestRule.onNodeWithTag("BottomNavigationMenu").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("Tab_${topLevelDestination.route}")
+        .assertIsDisplayed()
+        .performClick()
+
+    // Assert that the click action was never triggered
+    verify(navigationActions, never()).navigateTo(topLevelDestination)
   }
 
   @Test

--- a/app/src/main/java/com/github/se/signify/model/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/signify/model/navigation/NavigationActions.kt
@@ -21,8 +21,6 @@ open class NavigationActions(
           destination.route
         }
 
-    if (currentRoute() == route) return
-
     navController.navigate(route) {
       // Pop up to the start destination of the graph to
       // avoid building up a large stack of destinations

--- a/app/src/main/java/com/github/se/signify/model/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/signify/model/navigation/NavigationActions.kt
@@ -21,6 +21,8 @@ open class NavigationActions(
           destination.route
         }
 
+    if (currentRoute() == route) return
+
     navController.navigate(route) {
       // Pop up to the start destination of the graph to
       // avoid building up a large stack of destinations
@@ -59,6 +61,8 @@ open class NavigationActions(
         } else {
           screen.route
         }
+
+    if (currentRoute() == route) return
 
     navController.navigate(route)
   }

--- a/app/src/main/java/com/github/se/signify/ui/common/Screens.kt
+++ b/app/src/main/java/com/github/se/signify/ui/common/Screens.kt
@@ -311,7 +311,8 @@ fun BottomNavigationMenu(
           selected = topLevelDestination == selected,
           enabled = topLevelDestination != selected,
           onClick = { onTabSelect(topLevelDestination) },
-          modifier = Modifier.clip(RoundedCornerShape(50.dp)),
+          modifier =
+              Modifier.clip(RoundedCornerShape(50.dp)).testTag("Tab_${topLevelDestination.route}"),
           colors =
               NavigationBarItemDefaults.colors(
                   selectedIconColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/github/se/signify/ui/common/Screens.kt
+++ b/app/src/main/java/com/github/se/signify/ui/common/Screens.kt
@@ -309,6 +309,7 @@ fun BottomNavigationMenu(
                 modifier = Modifier.testTag("TabIcon_${topLevelDestination.route}"))
           }, // Load the drawable icons
           selected = topLevelDestination == selected,
+          enabled = topLevelDestination != selected,
           onClick = { onTabSelect(topLevelDestination) },
           modifier = Modifier.clip(RoundedCornerShape(50.dp)),
           colors =

--- a/app/src/main/java/com/github/se/signify/ui/common/Screens.kt
+++ b/app/src/main/java/com/github/se/signify/ui/common/Screens.kt
@@ -317,6 +317,7 @@ fun BottomNavigationMenu(
                   selectedIconColor = MaterialTheme.colorScheme.primary,
                   indicatorColor = Color.Transparent,
                   unselectedIconColor = MaterialTheme.colorScheme.onSurface,
+                  disabledIconColor = MaterialTheme.colorScheme.primary,
               ))
     }
   }

--- a/app/src/test/java/com/github/se/signify/model/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/navigation/NavigationActionsTest.kt
@@ -3,7 +3,6 @@ package com.github.se.signify.model.navigation
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
 import com.github.se.signify.model.authentication.MockUserSession
-import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -13,6 +12,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class NavigationActionsTest {
 
@@ -105,6 +105,28 @@ class NavigationActionsTest {
   }
 
   @Test
+  fun navigateToSameTopLevelDestinationDoesNotNavigate() {
+    val destination = TopLevelDestinations.HOME
+    userSession.loggedIn = true
+
+    whenever(navController.currentDestination?.route).thenReturn(Route.HOME)
+
+    navigationActions.navigateTo(destination)
+    verify(navController, never()).navigate(any<String>(), any<NavOptionsBuilder.() -> Unit>())
+  }
+
+  @Test
+  fun navigateToSameScreenDoesNotNavigate() {
+    val screen = Screen.DO_NOT_REQUIRE_AUTH
+    userSession.loggedIn = true
+
+    whenever(navController.currentDestination?.route).thenReturn(screen.route)
+
+    navigationActions.navigateTo(screen)
+    verify(navController, never()).navigate(any<String>(), anyOrNull(), anyOrNull())
+  }
+
+  @Test
   fun goBack() {
     navigationActions.goBack()
 
@@ -113,10 +135,8 @@ class NavigationActionsTest {
 
   @Test
   fun currentRoute() {
-    assertNull(navigationActions.currentRoute())
-    navigationActions.navigateTo(Screen.DO_NOT_REQUIRE_AUTH)
-    assertNull(navigationActions.currentRoute())
+    navigationActions.currentRoute()
 
-    verify(navController, times(2)).currentDestination
+    verify(navController).currentDestination?.route
   }
 }

--- a/app/src/test/java/com/github/se/signify/model/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/navigation/NavigationActionsTest.kt
@@ -10,9 +10,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 
 class NavigationActionsTest {
 
@@ -102,17 +100,6 @@ class NavigationActionsTest {
     navigationActions.navigateTo(screen)
     verify(navController, never()).navigate(eq(screen.route), anyOrNull(), anyOrNull())
     verify(navController).navigate(eq(Screen.UNAUTHENTICATED.route), anyOrNull(), anyOrNull())
-  }
-
-  @Test
-  fun navigateToSameScreenDoesNotNavigate() {
-    val screen = Screen.DO_NOT_REQUIRE_AUTH
-    userSession.loggedIn = true
-
-    whenever(navController.currentDestination?.route).thenReturn(screen.route)
-
-    navigationActions.navigateTo(screen)
-    verify(navController, never()).navigate(any<String>(), anyOrNull(), anyOrNull())
   }
 
   @Test

--- a/app/src/test/java/com/github/se/signify/model/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/navigation/NavigationActionsTest.kt
@@ -105,17 +105,6 @@ class NavigationActionsTest {
   }
 
   @Test
-  fun navigateToSameTopLevelDestinationDoesNotNavigate() {
-    val destination = TopLevelDestinations.HOME
-    userSession.loggedIn = true
-
-    whenever(navController.currentDestination?.route).thenReturn(Route.HOME)
-
-    navigationActions.navigateTo(destination)
-    verify(navController, never()).navigate(any<String>(), any<NavOptionsBuilder.() -> Unit>())
-  }
-
-  @Test
   fun navigateToSameScreenDoesNotNavigate() {
     val screen = Screen.DO_NOT_REQUIRE_AUTH
     userSession.loggedIn = true


### PR DESCRIPTION
## Changes

- The bottom navigation bar now disables the current destination.
- `NavigationActions` now prevent navigating to the current screen.

## Tests

Regression tests were added to `Screens.BottomNavigationMenu()`.

I didn't manage to test the guard clause added to `NavigationActions` because `NavController` is really difficult to mock.