### PR TITLE
Fix the tutorial to be centered for all the devices sizes

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/tutorial/ProvideElementPositionsTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/tutorial/ProvideElementPositionsTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.Density
@@ -59,7 +59,7 @@ class ProvideElementPositionsTest {
     val density = Density(1f)
 
     // Mocking coordinates and size
-    `when`(mockCoordinates.positionInWindow()).thenReturn(Offset(50f, 100f))
+    `when`(mockCoordinates.positionInRoot()).thenReturn(Offset(50f, 100f))
     `when`(mockCoordinates.size).thenReturn(IntSize(200, 400))
 
     // Save a position
@@ -69,7 +69,7 @@ class ProvideElementPositionsTest {
     val expectedPosition =
         ElementPosition(
             x = 50.dp,
-            y = 76.dp, // 100 px - 24.dp padding
+            y = 100.dp, // No padding in this example
             width = 200.dp,
             height = 400.dp)
 
@@ -88,13 +88,13 @@ class ProvideElementPositionsTest {
     val density = Density(1f)
 
     // Mock initial position
-    `when`(mockCoordinates.positionInWindow()).thenReturn(Offset(30f, 60f))
+    `when`(mockCoordinates.positionInRoot()).thenReturn(Offset(30f, 60f))
     `when`(mockCoordinates.size).thenReturn(IntSize(100, 200))
     saveElementPosition(
         "testKey", mockCoordinates, density, positions ?: error("Positions not initialized"))
 
     // Mock updated position
-    `when`(mockCoordinates.positionInWindow()).thenReturn(Offset(90f, 120f))
+    `when`(mockCoordinates.positionInRoot()).thenReturn(Offset(90f, 120f))
     `when`(mockCoordinates.size).thenReturn(IntSize(300, 600))
     saveElementPosition(
         "testKey", mockCoordinates, density, positions ?: error("Positions not initialized"))
@@ -102,7 +102,7 @@ class ProvideElementPositionsTest {
     val expectedPosition =
         ElementPosition(
             x = 90.dp,
-            y = 96.dp, // 120 px - 24.dp padding
+            y = 120.dp, // No padding in this example
             width = 300.dp,
             height = 600.dp)
 

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -78,7 +78,7 @@ class MainActivity : ComponentActivity() {
     val savedLanguage = sharedPreferencesLanguage.getBoolean(prefKeyLanguage, false)
 
     // Tutorial versioning logic
-    val currentTutorialVersion = 2 // Update this when the tutorial changes
+    val currentTutorialVersion = 3 // Update this when the tutorial changes
     val savedTutorialVersion = sharedPreferencesTheme.getInt(prefKeyTutorialVersion, 0)
 
     val isTutorialCompleted =

--- a/app/src/main/java/com/github/se/signify/ui/screens/tutorial/ElementPosition.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/tutorial/ElementPosition.kt
@@ -5,9 +5,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 
 data class ElementPosition(val x: Dp, val y: Dp, val width: Dp, val height: Dp)
 
@@ -44,15 +43,12 @@ fun saveElementPosition(
     density: androidx.compose.ui.unit.Density,
     map: MutableMap<String, ElementPosition>
 ) {
-  val position = coordinates.positionInWindow()
+  val position = coordinates.positionInRoot()
   val size = coordinates.size
   map[key] =
       ElementPosition(
           x = with(density) { position.x.toDp() },
-          y =
-              with(density) {
-                position.y.toDp() - 24.dp
-              }, // take into account the top padding of the screen
+          y = with(density) { position.y.toDp() },
           width = with(density) { size.width.toDp() },
           height = with(density) { size.height.toDp() })
 }

--- a/app/src/main/java/com/github/se/signify/ui/screens/tutorial/TutorialOverlay.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/tutorial/TutorialOverlay.kt
@@ -35,7 +35,7 @@ fun TutorialOverlay(
     Column(
         modifier =
             Modifier.align(Alignment.BottomCenter)
-                .padding(start = 32.dp, end = 32.dp, bottom = 150.dp),
+                .padding(start = 32.dp, end = 32.dp, bottom = 32.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/app/src/main/java/com/github/se/signify/ui/screens/tutorial/TutorialScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/tutorial/TutorialScreen.kt
@@ -117,7 +117,7 @@ fun TutorialScreen(navigationActions: NavigationActions, onFinish: () -> Unit) {
 fun SkipButton(
     onSkip: () -> Unit, // Action to perform when the button is clicked
 ) {
-  Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.TopEnd) {
+  Box(modifier = Modifier.fillMaxSize().padding(top = 24.dp), contentAlignment = Alignment.TopEnd) {
     TextButton(onClick = onSkip, modifier = Modifier.testTag("SkipTutorialButton")) {
       Text(
           text = stringResource(R.string.skip_tutorial),


### PR DESCRIPTION
### Pull Request : Update Positioning Logic for Tutorial Overlay and Adjust Related UI Elements

**Description:**

This PR includes the following changes to improve the positioning and layout of the tutorial across all devices:

1. **Refactored `ElementPosition.kt`:**  
   - Updated the logic to use `positionInRoot()` instead of `positionInWindow()` to ensure the tutorial is properly centered on all devices, regardless of system-level offsets (e.g., status bar or navigation bar).

2. **Updated Tests in `ProvideElementPositionsTest.kt`:**  
   - Adjusted the unit tests to align with the new logic using `positionInRoot()`. The mocks and assertions now account for the updated positioning behavior.

3. **Reduced Bottom Padding in `TutorialOverlay.kt`:**  
   - Reduced the bottom padding of the tutorial message for a more balanced and visually appealing layout.

4. **Modified Skip Button Placement in `TutorialScreen.kt`:**  
   - Adjusted the positioning of the "Skip Tutorial" button to improve its accessibility and alignment with the updated layout.

These changes ensure a consistent and improved user experience for the tutorial across all devices.

**Testing:**  
- Verified with the help of Nassim that the tutorial is now correctly centered on devices with different screen sizes and configurations. 
- Updated tests to cover the new behavior. All tests pass successfully.

**Screenshots :**  
<img width="313" alt="Capture d’écran 2024-12-18 à 17 35 57" src="https://github.com/user-attachments/assets/92bd21e7-67a3-4b6a-98d6-63729c45f29f" />

---

Let me know if you need further refinements!