### PR TITLE
Sprint Mode 

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.se.signify.model.authentication.UserSession
 import com.github.se.signify.model.challenge.Challenge
+import com.github.se.signify.model.challenge.ChallengeMode
 import com.github.se.signify.model.common.user.UserRepository
 import com.github.se.signify.model.navigation.NavigationActions
 import kotlinx.coroutines.runBlocking
@@ -90,7 +91,7 @@ class ChallengeHistoryScreenTest {
   }
 
   @Test
-  fun pastChallengeCard_displaysCorrectDetails() {
+  fun pastChallengeCard_displaysCorrectDetailsChrono() {
     val challenge =
         Challenge(
             challengeId = "challenge1",
@@ -98,7 +99,7 @@ class ChallengeHistoryScreenTest {
             player2 = "opponent1",
             player1Times = mutableListOf(1000L, 2000L),
             player2Times = mutableListOf(1500L, 2500L),
-            mode = "Sprint",
+            mode = "CHRONO",
             winner = "testUserId")
 
     composeTestRule.setContent {
@@ -107,9 +108,33 @@ class ChallengeHistoryScreenTest {
 
     // Verify the challenge details are displayed correctly
     composeTestRule.onNodeWithText("Opponent: opponent1").assertIsDisplayed()
-    composeTestRule.onNodeWithText("Mode: Sprint").assertIsDisplayed()
-    composeTestRule.onNodeWithText("testUserId Score: 3 s").assertIsDisplayed()
-    composeTestRule.onNodeWithText("opponent1 Score: 4 s").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Mode: ${ChallengeMode.CHRONO}").assertIsDisplayed()
+    composeTestRule.onNodeWithText("testUserId Score: 3.0 s").assertIsDisplayed()
+    composeTestRule.onNodeWithText("opponent1 Score: 4.0 s").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Winner: testUserId").assertIsDisplayed()
+  }
+
+  @Test
+  fun pastChallengeCard_displaysCorrectDetailsSprint() {
+    val challenge =
+        Challenge(
+            challengeId = "challenge1",
+            player1 = "testUserId",
+            player2 = "opponent1",
+            player1WordsCompleted = mutableListOf(1, 2, 2),
+            player2WordsCompleted = mutableListOf(1, 1, 2),
+            mode = ChallengeMode.SPRINT.toString(),
+            winner = "testUserId")
+
+    composeTestRule.setContent {
+      PastChallengeCard(challenge = challenge, userSession = userSession)
+    }
+
+    // Verify the challenge details are displayed correctly
+    composeTestRule.onNodeWithText("Opponent: opponent1").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Mode: ${ChallengeMode.SPRINT}").assertIsDisplayed()
+    composeTestRule.onNodeWithText("testUserId Score: 5.0 words").assertIsDisplayed()
+    composeTestRule.onNodeWithText("opponent1 Score: 4.0 words").assertIsDisplayed()
     composeTestRule.onNodeWithText("Winner: testUserId").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreenTest.kt
@@ -106,7 +106,7 @@ class ChallengeHistoryScreenTest {
             player2 = "opponent1",
             player1Times = mutableListOf(1000L, 2000L),
             player2Times = mutableListOf(1500L, 2500L),
-            mode = "CHRONO",
+            mode = ChallengeMode.CHRONO.toString(),
             winner = "testUserId")
 
     composeTestRule.setContent {
@@ -143,5 +143,109 @@ class ChallengeHistoryScreenTest {
     composeTestRule.onNodeWithText("testUserId Score: 5.0 words").assertIsDisplayed()
     composeTestRule.onNodeWithText("opponent1 Score: 4.0 words").assertIsDisplayed()
     composeTestRule.onNodeWithText("Winner: testUserId").assertIsDisplayed()
+  }
+
+  @Test
+  fun calculatePlayerResult_returnsCorrectResultForSprintMode() {
+    val challenge =
+        Challenge(
+            challengeId = "challenge1",
+            player1WordsCompleted = mutableListOf(3, 2, 1),
+            player2WordsCompleted = mutableListOf(4, 3, 2),
+            mode = ChallengeMode.SPRINT.toString())
+
+    val player1Result = calculatePlayerResult(challenge, isPlayer1 = true)
+    val player2Result = calculatePlayerResult(challenge, isPlayer1 = false)
+
+    assert(player1Result == 6.0) // Sum of 3, 2, 1
+    assert(player2Result == 9.0) // Sum of 4, 3, 2
+  }
+
+  @Test
+  fun calculatePlayerResult_returnsCorrectResultForChronoMode() {
+    val challenge =
+        Challenge(
+            challengeId = "challenge1",
+            player1Times = mutableListOf(1000L, 2000L, 3000L),
+            player2Times = mutableListOf(1500L, 2500L, 3500L),
+            mode = ChallengeMode.CHRONO.toString())
+
+    val player1Result = calculatePlayerResult(challenge, isPlayer1 = true)
+    val player2Result = calculatePlayerResult(challenge, isPlayer1 = false)
+
+    assert(player1Result == 6.0) // Sum of times in seconds: 1000+2000+3000 = 6.0 seconds
+    assert(player2Result == 7.5) // Sum of times in seconds: 1500+2500+3500 = 7.5 seconds
+  }
+
+  // Test `determineWinner`
+  @Test
+  fun determineWinner_returnsCorrectWinnerForSprintMode() {
+    val winner =
+        determineWinner(
+            mode = ChallengeMode.SPRINT.toString(),
+            player1 = "player1",
+            player2 = "player2",
+            player1Result = 15.0,
+            player2Result = 10.0)
+
+    assert(winner == "player1") // Higher score wins
+  }
+
+  @Test
+  fun determineWinner_returnsDrawForSprintMode() {
+    val winner =
+        determineWinner(
+            mode = ChallengeMode.SPRINT.toString(),
+            player1 = "player1",
+            player2 = "player2",
+            player1Result = 12.0,
+            player2Result = 12.0)
+
+    assert(winner == "Draw") // Same score
+  }
+
+  @Test
+  fun determineWinner_returnsCorrectWinnerForChronoMode() {
+    val winner =
+        determineWinner(
+            mode = ChallengeMode.CHRONO.toString(),
+            player1 = "player1",
+            player2 = "player2",
+            player1Result = 5.0,
+            player2Result = 10.0)
+
+    assert(winner == "player1") // Lower time wins
+  }
+
+  @Test
+  fun determineWinner_returnsDrawForChronoMode() {
+    val winner =
+        determineWinner(
+            mode = ChallengeMode.CHRONO.toString(),
+            player1 = "player1",
+            player2 = "player2",
+            player1Result = 7.0,
+            player2Result = 7.0)
+
+    assert(winner == "Draw") // Same time
+  }
+
+  // Test `PlayerScoreText`
+  @Test
+  fun playerScoreText_displaysCorrectScoreForSprintMode() {
+    composeTestRule.setContent {
+      PlayerScoreText(player = "player1", result = 12.0, mode = ChallengeMode.SPRINT.toString())
+    }
+
+    composeTestRule.onNodeWithText("player1 Score: 12.0 words").assertIsDisplayed()
+  }
+
+  @Test
+  fun playerScoreText_displaysCorrectScoreForChronoMode() {
+    composeTestRule.setContent {
+      PlayerScoreText(player = "player1", result = 5.5, mode = ChallengeMode.CHRONO.toString())
+    }
+
+    composeTestRule.onNodeWithText("player1 Score: 5.5 s").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/SprintChallengeGameScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/SprintChallengeGameScreenTest.kt
@@ -1,0 +1,278 @@
+package com.github.se.signify.ui.screens.challenge
+
+import android.Manifest
+import android.content.Context
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import com.github.se.signify.model.authentication.MockUserSession
+import com.github.se.signify.model.challenge.Challenge
+import com.github.se.signify.model.challenge.MockChallengeRepository
+import com.github.se.signify.model.dependencyInjection.AppDependencyProvider
+import com.github.se.signify.model.home.hand.HandLandmarkViewModel
+import com.github.se.signify.model.navigation.NavigationActions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class SprintChallengeGameScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @get:Rule
+  val cameraPermissionRule: GrantPermissionRule =
+      GrantPermissionRule.grant(Manifest.permission.CAMERA)
+
+  private lateinit var mockNavigationActions: NavigationActions
+  private lateinit var mockChallengeRepository: MockChallengeRepository
+  private lateinit var handLandmarkViewModel: HandLandmarkViewModel
+  private lateinit var context: Context
+  private val testChallengeId = "testChallengeId"
+  private val currentUserId = "player1"
+  private val testChallenge =
+      Challenge(
+          challengeId = testChallengeId,
+          player1 = "player1",
+          player2 = "player2",
+          mode = "SPRINT",
+          round = 5,
+          roundWords = listOf("apple", "banana"),
+          player1RoundCompleted = mutableListOf(false, false),
+          player2RoundCompleted = mutableListOf(false, false),
+          player1WordsCompleted = mutableListOf(1, 2),
+          player2WordsCompleted = mutableListOf(2, 1),
+          gameStatus = "in_progress")
+
+  @Before
+  fun setup() {
+
+    mockNavigationActions = mock(NavigationActions::class.java)
+    mockChallengeRepository = MockChallengeRepository()
+    context = mock(Context::class.java)
+
+    val handLandMarkImplementation = AppDependencyProvider.handLandMarkRepository()
+    handLandmarkViewModel = HandLandmarkViewModel(handLandMarkImplementation, context)
+
+    // Mock the repository to provide a test challenge
+    mockChallengeRepository.setChallenges(
+        listOf(
+            Challenge(
+                challengeId = testChallengeId,
+                player1 = "user1",
+                player2 = "user2",
+                mode = "SPRINT",
+                round = 1,
+                roundWords = listOf("apple", "banana", "cherry"),
+                player1RoundCompleted = mutableStateListOf(false, false, false),
+                player2RoundCompleted = mutableStateListOf(false, false, false),
+                player1WordsCompleted = mutableStateListOf(),
+                player2WordsCompleted = mutableStateListOf(),
+                gameStatus = "in_progress")))
+  }
+
+  @Test
+  fun sprintChallengeGameScreen_displaysComponentsCorrectly() {
+    composeTestRule.setContent {
+      SprintChallengeGameScreen(
+          navigationActions = mockNavigationActions,
+          userSession = MockUserSession(),
+          challengeRepository = mockChallengeRepository,
+          handLandMarkViewModel = handLandmarkViewModel,
+          challengeId = testChallengeId)
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Assert that the main components are displayed
+    composeTestRule.onNodeWithTag("TimerTextSprint").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("WordDisplayBoxSprint").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("CurrentGestureBox").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("CompletedWordsCounterSprint").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("CameraBoxSprint").assertIsDisplayed()
+  }
+
+  @Test
+  fun sprintChallengeGameScreen_displaysLoadingText_whenChallengeIsNull() {
+    // Update the repository to provide no challenges
+    mockChallengeRepository.setChallenges(emptyList())
+
+    composeTestRule.setContent {
+      SprintChallengeGameScreen(
+          navigationActions = mockNavigationActions,
+          userSession = MockUserSession(),
+          challengeRepository = mockChallengeRepository,
+          handLandMarkViewModel = handLandmarkViewModel,
+          challengeId = testChallengeId)
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Assert that the loading text is displayed
+    composeTestRule.onNodeWithTag("LoadingChallengeTextSprint").assertIsDisplayed()
+  }
+
+  @Test
+  fun sprintChallengeGameScreen_updatesTimerCorrectly() {
+    composeTestRule.setContent {
+      SprintChallengeGameScreen(
+          navigationActions = mockNavigationActions,
+          userSession = MockUserSession(),
+          challengeRepository = mockChallengeRepository,
+          handLandMarkViewModel = handLandmarkViewModel,
+          challengeId = testChallengeId)
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Assert that the timer starts with the correct initial value
+    composeTestRule.onNodeWithTag("TimerTextSprint").assertTextEquals("Time Left: 60 seconds")
+  }
+
+  @Test
+  fun sprintChallengeGameScreen_updatesWordDisplayOnGestureRecognition() {
+    // Mock the gesture detection to simulate user input
+    whenever(handLandmarkViewModel.getSolution()).thenReturn("A")
+
+    composeTestRule.setContent {
+      SprintChallengeGameScreen(
+          navigationActions = mockNavigationActions,
+          userSession = MockUserSession(),
+          challengeRepository = mockChallengeRepository,
+          handLandMarkViewModel = handLandmarkViewModel,
+          challengeId = testChallengeId)
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Assert that the word display updates correctly
+    composeTestRule.onNodeWithTag("WordDisplayBoxSprint").assertIsDisplayed()
+  }
+
+  @Test
+  fun sprintChallengeGameScreen_displaysGestureIconCorrectly() {
+    composeTestRule.setContent {
+      SprintChallengeGameScreen(
+          navigationActions = mockNavigationActions,
+          userSession = MockUserSession(),
+          challengeRepository = mockChallengeRepository,
+          handLandMarkViewModel = handLandmarkViewModel,
+          challengeId = testChallengeId)
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Assert that the current gesture box is displayed with the correct icon
+    composeTestRule.onNodeWithTag("CurrentGestureBox").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("CurrentGestureIcon").assertIsDisplayed()
+  }
+
+  @Test
+  fun sprintChallengeGameScreen_resetsWordAfterCompletionA() {
+    composeTestRule.setContent {
+      SprintChallengeGameScreen(
+          navigationActions = mockNavigationActions,
+          userSession = MockUserSession(),
+          challengeRepository = mockChallengeRepository,
+          handLandMarkViewModel = handLandmarkViewModel,
+          challengeId = testChallengeId)
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Simulate a word being completed
+    whenever(handLandmarkViewModel.getSolution()).thenReturn("B")
+    composeTestRule.waitForIdle()
+
+    // Assert that the current word is reset after completion
+    composeTestRule.onNodeWithTag("WordDisplayBoxSprint").assertIsDisplayed()
+  }
+
+  @Test
+  fun sprintChallengeGameScreen_resetsWordAfterCompletion() {
+    composeTestRule.setContent {
+      SprintChallengeGameScreen(
+          navigationActions = mockNavigationActions,
+          userSession = MockUserSession(),
+          challengeRepository = mockChallengeRepository,
+          handLandMarkViewModel = handLandmarkViewModel,
+          challengeId = testChallengeId)
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Simulate a word being completed
+    whenever(handLandmarkViewModel.getSolution()).thenReturn("A")
+    composeTestRule.waitForIdle()
+
+    // Assert that the current word is reset after completion
+    composeTestRule.onNodeWithTag("WordDisplayBoxSprint").assertIsDisplayed()
+  }
+
+  @Test
+  fun updateSprintChallenge_updatesPlayer1RoundCompleted_whenPlayer1CompletesRound() {
+    updateSprintChallenge(
+        context, currentUserId, mockChallengeRepository, testChallenge, 3, mockNavigationActions)
+
+    val updatedChallenge = mockChallengeRepository.getChallenge(testChallenge.challengeId)
+    assert(updatedChallenge?.player1RoundCompleted?.contains(true) == true)
+  }
+
+  @Test
+  fun updateSprintChallenge_updatesPlayer2RoundCompleted_whenPlayer2CompletesRound() {
+    updateSprintChallenge(
+        context, "player2", mockChallengeRepository, testChallenge, 2, mockNavigationActions)
+
+    val updatedChallenge = mockChallengeRepository.getChallenge(testChallenge.challengeId)
+    assert(updatedChallenge?.player2RoundCompleted?.contains(true) == true)
+  }
+
+  @Test
+  fun updateSprintChallenge_addsWordsCompletedToPlayer1_whenPlayer1CompletesWord() {
+    updateSprintChallenge(
+        context, currentUserId, mockChallengeRepository, testChallenge, 5, mockNavigationActions)
+
+    val updatedChallenge = mockChallengeRepository.getChallenge(testChallenge.challengeId)
+    assert(updatedChallenge?.player1WordsCompleted?.contains(5) == true)
+  }
+
+  @Test
+  fun updateSprintChallenge_addsWordsCompletedToPlayer2_whenPlayer2CompletesWord() {
+    updateSprintChallenge(
+        context, "player2", mockChallengeRepository, testChallenge, 4, mockNavigationActions)
+
+    val updatedChallenge = mockChallengeRepository.getChallenge(testChallenge.challengeId)
+    assert(updatedChallenge?.player2WordsCompleted?.contains(4) == true)
+  }
+
+  @Test
+  fun updateSprintChallenge_setsGameStatusToCompleted_whenRoundIsSix() {
+    val challengeAtRoundSix = testChallenge.copy(round = 6)
+    updateSprintChallenge(
+        context,
+        currentUserId,
+        mockChallengeRepository,
+        challengeAtRoundSix,
+        3,
+        mockNavigationActions)
+
+    val updatedChallenge = mockChallengeRepository.getChallenge(challengeAtRoundSix.challengeId)
+    assert(updatedChallenge?.gameStatus == "completed")
+  }
+
+  @Test
+  fun updateSprintChallenge_setsGameStatusToInProgress_whenRoundIsNotSix() {
+    updateSprintChallenge(
+        context, currentUserId, mockChallengeRepository, testChallenge, 3, mockNavigationActions)
+
+    val updatedChallenge = mockChallengeRepository.getChallenge(testChallenge.challengeId)
+    assert(updatedChallenge?.gameStatus == "in_progress")
+  }
+}

--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/SprintChallengeGameScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/challenge/SprintChallengeGameScreenTest.kt
@@ -219,7 +219,7 @@ class SprintChallengeGameScreenTest {
   @Test
   fun updateSprintChallenge_updatesPlayer1RoundCompleted_whenPlayer1CompletesRound() {
     updateSprintChallenge(
-        context, currentUserId, mockChallengeRepository, testChallenge, 3, mockNavigationActions)
+        currentUserId, mockChallengeRepository, testChallenge, 3, mockNavigationActions)
 
     val updatedChallenge = mockChallengeRepository.getChallenge(testChallenge.challengeId)
     assert(updatedChallenge?.player1RoundCompleted?.contains(true) == true)
@@ -228,7 +228,7 @@ class SprintChallengeGameScreenTest {
   @Test
   fun updateSprintChallenge_updatesPlayer2RoundCompleted_whenPlayer2CompletesRound() {
     updateSprintChallenge(
-        context, "player2", mockChallengeRepository, testChallenge, 2, mockNavigationActions)
+        "player2", mockChallengeRepository, testChallenge, 2, mockNavigationActions)
 
     val updatedChallenge = mockChallengeRepository.getChallenge(testChallenge.challengeId)
     assert(updatedChallenge?.player2RoundCompleted?.contains(true) == true)
@@ -237,7 +237,7 @@ class SprintChallengeGameScreenTest {
   @Test
   fun updateSprintChallenge_addsWordsCompletedToPlayer1_whenPlayer1CompletesWord() {
     updateSprintChallenge(
-        context, currentUserId, mockChallengeRepository, testChallenge, 5, mockNavigationActions)
+        currentUserId, mockChallengeRepository, testChallenge, 5, mockNavigationActions)
 
     val updatedChallenge = mockChallengeRepository.getChallenge(testChallenge.challengeId)
     assert(updatedChallenge?.player1WordsCompleted?.contains(5) == true)
@@ -246,7 +246,7 @@ class SprintChallengeGameScreenTest {
   @Test
   fun updateSprintChallenge_addsWordsCompletedToPlayer2_whenPlayer2CompletesWord() {
     updateSprintChallenge(
-        context, "player2", mockChallengeRepository, testChallenge, 4, mockNavigationActions)
+        "player2", mockChallengeRepository, testChallenge, 4, mockNavigationActions)
 
     val updatedChallenge = mockChallengeRepository.getChallenge(testChallenge.challengeId)
     assert(updatedChallenge?.player2WordsCompleted?.contains(4) == true)
@@ -256,12 +256,7 @@ class SprintChallengeGameScreenTest {
   fun updateSprintChallenge_setsGameStatusToCompleted_whenRoundIsSix() {
     val challengeAtRoundSix = testChallenge.copy(round = 6)
     updateSprintChallenge(
-        context,
-        currentUserId,
-        mockChallengeRepository,
-        challengeAtRoundSix,
-        3,
-        mockNavigationActions)
+        currentUserId, mockChallengeRepository, challengeAtRoundSix, 3, mockNavigationActions)
 
     val updatedChallenge = mockChallengeRepository.getChallenge(challengeAtRoundSix.challengeId)
     assert(updatedChallenge?.gameStatus == "completed")
@@ -270,7 +265,7 @@ class SprintChallengeGameScreenTest {
   @Test
   fun updateSprintChallenge_setsGameStatusToInProgress_whenRoundIsNotSix() {
     updateSprintChallenge(
-        context, currentUserId, mockChallengeRepository, testChallenge, 3, mockNavigationActions)
+        currentUserId, mockChallengeRepository, testChallenge, 3, mockNavigationActions)
 
     val updatedChallenge = mockChallengeRepository.getChallenge(testChallenge.challengeId)
     assert(updatedChallenge?.gameStatus == "in_progress")

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -35,6 +35,7 @@ import com.github.se.signify.ui.screens.challenge.ChallengeScreen
 import com.github.se.signify.ui.screens.challenge.ChronoChallengeGameScreen
 import com.github.se.signify.ui.screens.challenge.CreateAChallengeScreen
 import com.github.se.signify.ui.screens.challenge.NewChallengeScreen
+import com.github.se.signify.ui.screens.challenge.SprintChallengeGameScreen
 import com.github.se.signify.ui.screens.home.ASLRecognition
 import com.github.se.signify.ui.screens.home.ExerciseScreen
 import com.github.se.signify.ui.screens.home.FeedbackScreen
@@ -201,6 +202,19 @@ fun SignifyAppPreview(
                 userSession = dependencyProvider.userSession(),
                 challengeRepository = dependencyProvider.challengeRepository(),
                 handLandmarkViewModel = handLandmarkViewModel,
+                challengeId = challengeId)
+          }
+      composable(
+          route = Screen.SPRINT_CHALLENGE.route,
+          arguments = listOf(navArgument("challengeId") { type = NavType.StringType })) {
+              backStackEntry ->
+            val challengeId =
+                backStackEntry.arguments?.getString("challengeId") ?: return@composable
+            SprintChallengeGameScreen(
+                navigationActions = navigationActions,
+                userSession = dependencyProvider.userSession(),
+                challengeRepository = dependencyProvider.challengeRepository(),
+                handLandMarkViewModel = handLandmarkViewModel,
                 challengeId = challengeId)
           }
       composable(Screen.CREATE_CHALLENGE.route) {

--- a/app/src/main/java/com/github/se/signify/model/challenge/Challenge.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/Challenge.kt
@@ -13,6 +13,8 @@ data class Challenge(
         mutableListOf(false, false, false), // Track if player 1 completed each round
     var player2RoundCompleted: List<Boolean> =
         mutableListOf(false, false, false), // Track if player 2 completed each round
+    var player1WordsCompleted: MutableList<Int> = mutableListOf(),
+    var player2WordsCompleted: MutableList<Int> = mutableListOf(),
     var gameStatus: String =
         "not_started", // Possible values: "not_started", "in_progress", "completed"
     var winner: String? = null

--- a/app/src/main/java/com/github/se/signify/model/challenge/FirestoreChallengeRepository.kt
+++ b/app/src/main/java/com/github/se/signify/model/challenge/FirestoreChallengeRepository.kt
@@ -26,6 +26,8 @@ class FirestoreChallengeRepository(private val db: FirebaseFirestore) : Challeng
             roundWords = roundWords,
             player1Times = mutableListOf(),
             player2Times = mutableListOf(),
+            player1RoundCompleted = mutableListOf(false, false, false),
+            player2RoundCompleted = mutableListOf(false, false, false),
             gameStatus = "not_started")
 
     val batch = db.batch()

--- a/app/src/main/java/com/github/se/signify/model/navigation/Screen.kt
+++ b/app/src/main/java/com/github/se/signify/model/navigation/Screen.kt
@@ -21,6 +21,7 @@ enum class Screen(val route: String, val requiresAuth: Boolean = true) {
   CREATE_CHALLENGE("CreateChallenge Screen"),
   CHALLENGE_HISTORY("ChallengeHistory Screen"),
   CHRONO_CHALLENGE("ChronoChallenge Screen/{challengeId}"),
+  SPRINT_CHALLENGE("SprintChallenge Screen/{challengeId}"),
   TUTORIAL("Tutorial Screen", false),
 
   // For testing purposes

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/ChallengeHistoryScreen.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.signify.R
 import com.github.se.signify.model.authentication.UserSession
 import com.github.se.signify.model.challenge.Challenge
+import com.github.se.signify.model.challenge.ChallengeMode
 import com.github.se.signify.model.common.user.UserRepository
 import com.github.se.signify.model.common.user.UserViewModel
 import com.github.se.signify.model.navigation.NavigationActions
@@ -147,15 +148,36 @@ fun ChallengeHistoryScreen(
 @Composable
 fun PastChallengeCard(challenge: Challenge, userSession: UserSession) {
   val currentUserId = userSession.getUserId()
-  val player1Score = challenge.player1Times.sum().div(1000)
-  val player2Score = challenge.player2Times.sum().div(1000)
   val opponent = if (challenge.player1 == currentUserId) challenge.player2 else challenge.player1
   val mode = challenge.mode
-  val winner = challenge.winner ?: "No Winner"
+  val player1Result =
+      when (challenge.mode) {
+        ChallengeMode.SPRINT.toString() ->
+            challenge.player1WordsCompleted.sum().toDouble() // Cast to Double
+        else -> challenge.player1Times.sum() / 1000.0 // Ensure division returns Double
+      }
 
+  val player2Result =
+      when (challenge.mode) {
+        ChallengeMode.SPRINT.toString() ->
+            challenge.player2WordsCompleted.sum().toDouble() // Cast to Double
+        else -> challenge.player2Times.sum() / 1000.0 // Ensure division returns Double
+      }
+
+  val winner =
+      when (challenge.mode) {
+        ChallengeMode.SPRINT.toString() -> {
+          if (player1Result > player2Result) challenge.player1
+          else if (player2Result == player1Result) "Draw" else challenge.player2
+        }
+        else -> {
+          if (player1Result < player2Result) challenge.player1
+          else if (player2Result == player1Result) "Draw" else challenge.player2
+        }
+      }
   Log.d(
       "PastChallengeCard",
-      "Rendering card with Opponent=$opponent, Mode=$mode, Player1Score=$player1Score, Player2Score=$player2Score, Winner=$winner")
+      "Rendering card with Opponent=$opponent, Mode=$mode, Player1Score=$player1Result, Player2Score=$player2Result, Winner=$winner")
 
   Card(
       modifier =
@@ -167,8 +189,28 @@ fun PastChallengeCard(challenge: Challenge, userSession: UserSession) {
     Column(Modifier.padding(16.dp)) {
       Text(text = "Opponent: $opponent", fontSize = 16.sp)
       Text(text = "Mode: $mode", fontSize = 16.sp)
-      Text(text = "${challenge.player1} Score: $player1Score s", fontSize = 16.sp)
-      Text(text = "${challenge.player2} Score: $player2Score s", fontSize = 16.sp)
+      Text(
+          text =
+              when (challenge.mode) {
+                ChallengeMode.CHRONO.toString() -> {
+                  "${challenge.player1} Score: $player1Result s"
+                }
+                else -> {
+                  "${challenge.player1} Score: $player1Result words"
+                }
+              },
+          fontSize = 16.sp)
+      Text(
+          text =
+              when (challenge.mode) {
+                ChallengeMode.CHRONO.toString() -> {
+                  "${challenge.player2} Score: $player2Result s"
+                }
+                else -> {
+                  "${challenge.player2} Score: $player2Result words"
+                }
+              },
+          fontSize = 16.sp)
       Text(text = "Winner: $winner", fontSize = 16.sp)
     }
   }

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
@@ -49,6 +49,8 @@ import com.github.se.signify.model.navigation.Screen
 import com.github.se.signify.ui.common.AnnexScreenScaffold
 import com.github.se.signify.ui.common.TextButton
 
+private const val msToSecondsDivision = 1000
+
 @Composable
 fun NewChallengeScreen(
     navigationActions: NavigationActions,
@@ -137,24 +139,18 @@ fun NewChallengeScreen(
                                 // Determine the winner
                                 done = true
 
+                                val player1Result =
+                                    calculatePlayerResult(challenge, isPlayer1 = true)
+                                val player2Result =
+                                    calculatePlayerResult(challenge, isPlayer1 = false)
+
                                 val winner =
-                                    when (challenge.mode) {
-                                      ChallengeMode.SPRINT.toString() -> {
-                                        val player1Result = challenge.player1WordsCompleted.sum()
-                                        val player2Result = challenge.player2WordsCompleted.sum()
-                                        if (player1Result > player2Result) challenge.player1
-                                        else if (player2Result == player1Result) "Draw"
-                                        else challenge.player2
-                                      }
-                                      ChallengeMode.CHRONO.toString() -> {
-                                        val player1Result = challenge.player1Times.sum() / 1000
-                                        val player2Result = challenge.player2Times.sum() / 1000
-                                        if (player1Result < player2Result) challenge.player1
-                                        else if (player2Result == player1Result) "Draw"
-                                        else challenge.player2
-                                      }
-                                      else -> ""
-                                    }
+                                    determineWinner(
+                                        challenge.mode,
+                                        challenge.player1,
+                                        challenge.player2,
+                                        player1Result,
+                                        player2Result)
 
                                 // Update the challenge in pastChallenges
                                 userViewModel.removeOngoingChallenge(
@@ -226,7 +222,7 @@ fun OngoingChallengeCard(
   val displayText =
       if (isChallengeCompleted) {
         when (challenge.mode) {
-          "SPRINT" -> {
+          ChallengeMode.SPRINT.toString() -> {
             val totalWords =
                 if (currentUserId == challenge.player1) {
                   challenge.player1WordsCompleted.sum()
@@ -235,12 +231,12 @@ fun OngoingChallengeCard(
                 }
             "Your Total Words: $totalWords"
           }
-          "CHRONO" -> {
+          ChallengeMode.CHRONO.toString() -> {
             val totalTime =
                 if (currentUserId == challenge.player1) {
-                  challenge.player1Times.sum() / 1000
+                  challenge.player1Times.sum() / msToSecondsDivision
                 } else {
-                  challenge.player2Times.sum() / 1000
+                  challenge.player2Times.sum() / msToSecondsDivision
                 }
             "Your Total Time: ${totalTime}s"
           }

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
@@ -1,7 +1,6 @@
 package com.github.se.signify.ui.screens.challenge
 
 import android.annotation.SuppressLint
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -41,6 +40,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.signify.R
 import com.github.se.signify.model.authentication.UserSession
 import com.github.se.signify.model.challenge.Challenge
+import com.github.se.signify.model.challenge.ChallengeMode
 import com.github.se.signify.model.challenge.ChallengeRepository
 import com.github.se.signify.model.challenge.ChallengeViewModel
 import com.github.se.signify.model.common.user.UserRepository
@@ -69,6 +69,7 @@ fun NewChallengeScreen(
   }
 
   val ongoingChallenges by userViewModel.ongoingChallenges.collectAsState()
+  var done = false
 
   AnnexScreenScaffold(
       navigationActions = navigationActions,
@@ -132,13 +133,28 @@ fun NewChallengeScreen(
                                   challenge.player1RoundCompleted.all { it } &&
                                       challenge.player2RoundCompleted.all { it }
 
-                              if (isBothCompleted) {
+                              if (isBothCompleted && !done) {
                                 // Determine the winner
-                                val player1Time = challenge.player1Times.sum()
-                                val player2Time = challenge.player2Times.sum()
+                                done = true
+
                                 val winner =
-                                    if (player1Time < player2Time) challenge.player1
-                                    else challenge.player2
+                                    when (challenge.mode) {
+                                      ChallengeMode.SPRINT.toString() -> {
+                                        val player1Result = challenge.player1WordsCompleted.sum()
+                                        val player2Result = challenge.player2WordsCompleted.sum()
+                                        if (player1Result > player2Result) challenge.player1
+                                        else if (player2Result == player1Result) "Draw"
+                                        else challenge.player2
+                                      }
+                                      ChallengeMode.CHRONO.toString() -> {
+                                        val player1Result = challenge.player1Times.sum() / 1000
+                                        val player2Result = challenge.player2Times.sum() / 1000
+                                        if (player1Result < player2Result) challenge.player1
+                                        else if (player2Result == player1Result) "Draw"
+                                        else challenge.player2
+                                      }
+                                      else -> ""
+                                    }
 
                                 // Update the challenge in pastChallenges
                                 userViewModel.removeOngoingChallenge(
@@ -168,11 +184,13 @@ fun NewChallengeScreen(
                                     challengeViewModel.deleteChallenge(challenge.challengeId)
                                   },
                                   onPlayClick = {
-                                    Log.d(
-                                        "Navigation",
-                                        "Navigating with challengeId: ${challenge.challengeId}")
+                                    val destination =
+                                        when (challenge.mode) {
+                                          ChallengeMode.CHRONO.toString() -> Screen.CHRONO_CHALLENGE
+                                          else -> Screen.SPRINT_CHALLENGE
+                                        }
                                     navigationActions.navigateTo(
-                                        Screen.CHRONO_CHALLENGE,
+                                        destination,
                                         params = mapOf("challengeId" to challenge.challengeId))
                                   },
                                   userSession = userSession,
@@ -205,14 +223,32 @@ fun OngoingChallengeCard(
       }
 
   // Calculate the personal total time if the challenge is completed
-  val totalTime =
+  val displayText =
       if (isChallengeCompleted) {
-        if (currentUserId == challenge.player1) {
-          challenge.player1Times.sum() / 1000
-        } else {
-          challenge.player2Times.sum() / 1000
+        when (challenge.mode) {
+          "SPRINT" -> {
+            val totalWords =
+                if (currentUserId == challenge.player1) {
+                  challenge.player1WordsCompleted.sum()
+                } else {
+                  challenge.player2WordsCompleted.sum()
+                }
+            "Your Total Words: $totalWords"
+          }
+          "CHRONO" -> {
+            val totalTime =
+                if (currentUserId == challenge.player1) {
+                  challenge.player1Times.sum() / 1000
+                } else {
+                  challenge.player2Times.sum() / 1000
+                }
+            "Your Total Time: ${totalTime}s"
+          }
+          else -> ""
         }
-      } else null
+      } else {
+        null
+      }
 
   Card(
       modifier =
@@ -247,12 +283,9 @@ fun OngoingChallengeCard(
                 text = "${stringResource(R.string.mode_text)}: ${challenge.mode}",
                 fontSize = 14.sp,
                 color = MaterialTheme.colorScheme.onSurface)
-            if (isChallengeCompleted) {
-              val totalTimeText = stringResource(R.string.total_time_text)
+            if (displayText != null) {
               Text(
-                  text = "$totalTimeText ${totalTime}s",
-                  fontSize = 14.sp,
-                  color = MaterialTheme.colorScheme.onSurface)
+                  text = displayText, fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurface)
             }
           }
 

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
@@ -1,7 +1,5 @@
 package com.github.se.signify.ui.screens.challenge
 
-import android.annotation.SuppressLint
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -71,7 +69,6 @@ fun NewChallengeScreen(
     userViewModel.getFriendsList()
     userViewModel.getOngoingChallenges()
   }
-
 
   val ongoingChallenges by userViewModel.ongoingChallenges.collectAsState()
   var done = false

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/NewChallengeScreen.kt
@@ -69,8 +69,6 @@ fun NewChallengeScreen(
     userViewModel.getFriendsList()
     userViewModel.getOngoingChallenges()
   }
-
-  val ongoingChallenges by userViewModel.ongoingChallenges.collectAsState()
   var done = false
 
   AnnexScreenScaffold(

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/SprintChallengeGameScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/SprintChallengeGameScreen.kt
@@ -1,2 +1,276 @@
 package com.github.se.signify.ui.screens.challenge
 
+import android.annotation.SuppressLint
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.se.signify.model.authentication.UserSession
+import com.github.se.signify.model.challenge.Challenge
+import com.github.se.signify.model.challenge.ChallengeRepository
+import com.github.se.signify.model.home.hand.HandLandmarkViewModel
+import com.github.se.signify.model.navigation.NavigationActions
+import com.github.se.signify.model.navigation.Screen
+import com.github.se.signify.ui.common.AnnexScreenScaffold
+import com.github.se.signify.ui.common.CameraBox
+import kotlinx.coroutines.delay
+
+@Composable
+fun SprintChallengeGameScreen(
+    navigationActions: NavigationActions,
+    userSession: UserSession,
+    challengeRepository: ChallengeRepository,
+    handLandMarkViewModel: HandLandmarkViewModel,
+    challengeId: String
+) {
+  val context = LocalContext.current
+  val currentUserId = userSession.getUserId() ?: return
+
+  // State variables
+  var currentChallenge by remember { mutableStateOf<Challenge?>(null) }
+  var currentWord by remember { mutableStateOf("") }
+  var currentLetterIndex by remember { mutableIntStateOf(0) }
+  var completedWordCount by remember { mutableIntStateOf(0) }
+  var timeLeft by remember { mutableIntStateOf(60) }
+  var isGameActive by remember { mutableStateOf(false) }
+
+  // Fetch challenge
+  LaunchedEffect(challengeId) {
+    challengeRepository.getChallengeById(
+        challengeId = challengeId,
+        onSuccess = { challenge ->
+          currentChallenge = challenge
+          if (challenge.roundWords.isNotEmpty()) {
+            currentWord = challenge.roundWords.random()
+            isGameActive = true
+          } else {
+            Toast.makeText(context, "No words available for this sprint", Toast.LENGTH_SHORT).show()
+          }
+        },
+        onFailure = {
+          Toast.makeText(context, "Failed to load challenge", Toast.LENGTH_SHORT).show()
+        })
+  }
+
+  // Timer logic
+  LaunchedEffect(isGameActive) {
+    if (isGameActive) {
+      while (timeLeft > 0) {
+        delay(1000L)
+        timeLeft--
+      }
+      isGameActive = false
+      updateSprintChallenge(
+          context = context,
+          currentUserId = currentUserId,
+          challengeRepository = challengeRepository,
+          challenge = currentChallenge,
+          wordsCompleted = completedWordCount,
+          navigationActions = navigationActions)
+    }
+  }
+
+  // Gesture recognition updates
+  val landmarksState by handLandMarkViewModel.landMarks().collectAsState()
+  val detectedGesture = handLandMarkViewModel.getSolution()
+
+  LaunchedEffect(landmarksState) {
+    if (!landmarksState.isNullOrEmpty() && isGameActive) {
+      val currentLetter = currentWord.getOrNull(currentLetterIndex)?.uppercaseChar()
+      if (currentLetter != null &&
+          detectedGesture.equals(currentLetter.toString(), ignoreCase = true)) {
+        currentLetterIndex++
+        if (currentLetterIndex == currentWord.length) {
+          completedWordCount++
+          currentWord = currentChallenge?.roundWords?.random() ?: ""
+          currentLetterIndex = 0
+        }
+      }
+    }
+  }
+
+  // UI rendering
+  if (currentChallenge == null) {
+    DisplayLoadingTextSprint()
+    return
+  }
+
+  AnnexScreenScaffold(navigationActions = navigationActions, testTag = "SprintChallengeScreen") {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top) {
+          SprintTimer(timeLeft = timeLeft)
+
+          Spacer(modifier = Modifier.height(16.dp))
+
+          SprintWordDisplay(currentWord = currentWord, currentLetterIndex = currentLetterIndex)
+
+          Spacer(modifier = Modifier.height(16.dp))
+
+          CurrentGestureDisplay(currentWord, currentLetterIndex)
+
+          Spacer(modifier = Modifier.height(16.dp))
+
+          Text(
+              text = "Words Completed: $completedWordCount",
+              fontSize = 20.sp,
+              modifier = Modifier.testTag("CompletedWordsCounterSprint"))
+
+          Spacer(modifier = Modifier.height(32.dp))
+
+          CameraBox(handLandmarkViewModel = handLandMarkViewModel, testTag = "CameraBoxSprint")
+        }
+  }
+}
+
+@SuppressLint("DiscouragedApi")
+@Composable
+fun CurrentGestureDisplay(currentWord: String, currentLetterIndex: Int) {
+  val context = LocalContext.current
+  val currentLetter = currentWord.getOrNull(currentLetterIndex)?.uppercaseChar() ?: 'A'
+  val imageName = "letter_${currentLetter.lowercase()}"
+  val imageResId = context.resources.getIdentifier(imageName, "drawable", context.packageName)
+
+  if (imageResId != 0) {
+    Box(
+        modifier =
+            Modifier.fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .height(150.dp)
+                .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(16.dp))
+                .border(2.dp, MaterialTheme.colorScheme.outline, shape = RoundedCornerShape(16.dp))
+                .testTag("CurrentGestureBox"),
+        contentAlignment = Alignment.Center) {
+          Icon(
+              painter = painterResource(id = imageResId),
+              contentDescription = "Gesture Image",
+              tint = MaterialTheme.colorScheme.onSurface,
+              modifier = Modifier.size(120.dp).testTag("CurrentGestureIcon"))
+        }
+  }
+}
+
+@Composable
+fun SprintTimer(timeLeft: Int) {
+  Text(
+      text = "Time Left: $timeLeft seconds",
+      fontSize = 24.sp,
+      modifier = Modifier.testTag("TimerTextSprint"))
+}
+
+@Composable
+fun SprintWordDisplay(currentWord: String, currentLetterIndex: Int) {
+  Box(
+      modifier =
+          Modifier.fillMaxWidth()
+              .height(150.dp)
+              .padding(horizontal = 16.dp)
+              .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(16.dp))
+              .border(2.dp, MaterialTheme.colorScheme.outline, shape = RoundedCornerShape(16.dp))
+              .testTag("WordDisplayBoxSprint")) {
+        Text(
+            text = buildForegroundTextSprint(currentWord, currentLetterIndex),
+            style = TextStyle(fontSize = 36.sp),
+            modifier = Modifier.align(Alignment.Center).testTag("CurrentWordTextSprint"))
+      }
+}
+
+@Composable
+fun buildForegroundTextSprint(currentWord: String, currentLetterIndex: Int): AnnotatedString {
+  val clampedIndex = currentLetterIndex.coerceAtMost(currentWord.length - 1)
+  return buildAnnotatedString {
+    append(currentWord.substring(0, clampedIndex))
+    if (clampedIndex < currentWord.length) {
+      withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.secondary)) {
+        append(currentWord[clampedIndex].uppercase())
+      }
+    }
+    if (clampedIndex + 1 < currentWord.length) {
+      append(currentWord.substring(clampedIndex + 1))
+    }
+  }
+}
+
+@Composable
+fun DisplayLoadingTextSprint() {
+  Text("Loading challenge...", modifier = Modifier.testTag("LoadingChallengeTextSprint"))
+}
+
+fun updateSprintChallenge(
+    context: Context,
+    currentUserId: String,
+    challengeRepository: ChallengeRepository,
+    challenge: Challenge?,
+    wordsCompleted: Int,
+    navigationActions: NavigationActions
+) {
+  challenge?.let {
+    val updatedChallenge =
+        it.copy(
+            gameStatus = if (it.round == 6) "completed" else "in_progress",
+            round = it.round + 1,
+            player1RoundCompleted =
+                it.player1RoundCompleted.toMutableList().apply {
+                  if (currentUserId == it.player1) {
+                    val nextIndex = this.indexOfFirst { roundCompleted -> !roundCompleted }
+                    if (nextIndex != -1)
+                        this[nextIndex] = true // Mark the next incomplete round as complete
+                  }
+                },
+            player2RoundCompleted =
+                it.player2RoundCompleted.toMutableList().apply {
+                  if (currentUserId == it.player2) {
+                    val nextIndex = this.indexOfFirst { roundCompleted -> !roundCompleted }
+                    if (nextIndex != -1)
+                        this[nextIndex] = true // Mark the next incomplete round as complete
+                  }
+                },
+            player1WordsCompleted =
+                if (currentUserId == it.player1) {
+                  it.player1WordsCompleted.toMutableList().apply { add(wordsCompleted) }
+                } else it.player1WordsCompleted,
+            player2WordsCompleted =
+                if (currentUserId == it.player2) {
+                  it.player2WordsCompleted.toMutableList().apply { add(wordsCompleted) }
+                } else it.player2WordsCompleted)
+
+    challengeRepository.updateChallenge(
+        updatedChallenge = updatedChallenge,
+        onSuccess = { navigationActions.navigateTo(Screen.CHALLENGE) },
+        onFailure = {})
+  }
+}

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/SprintChallengeGameScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/SprintChallengeGameScreen.kt
@@ -1,7 +1,6 @@
 package com.github.se.signify.ui.screens.challenge
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -94,7 +93,6 @@ fun SprintChallengeGameScreen(
       }
       isGameActive = false
       updateSprintChallenge(
-          context = context,
           currentUserId = currentUserId,
           challengeRepository = challengeRepository,
           challenge = currentChallenge,
@@ -231,7 +229,6 @@ fun DisplayLoadingTextSprint() {
 }
 
 fun updateSprintChallenge(
-    context: Context,
     currentUserId: String,
     challengeRepository: ChallengeRepository,
     challenge: Challenge?,

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/SprintChallengeGameScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/SprintChallengeGameScreen.kt
@@ -1,0 +1,2 @@
+package com.github.se.signify.ui.screens.challenge
+


### PR DESCRIPTION
### **Description**  
This PR introduces a **Sprint Mode** in the challenge feature, where two players compete in a **Best of 3 (BO3)** format. The goal of this mode is for players to input as many words as possible within **1 minute per round**. The winner is determined based on the total number of words completed across all three rounds.  

**Key Features:**  
1. **Sprint Challenge Gameplay**:  
   - Each round lasts for 1 minute.  
   - The player who completes the most words after 3 rounds wins the challenge.  

2. **Automatic Challenge Cleanup**:  
   - Once the second player completes their rounds, the challenge is automatically removed from the **ongoing challenges**.  
   - Results are accessible in the **History Screen** for both players.  

3. **Database Updates**:  
   - Added two new fields to the `challenge` collection to track each player's results:  
     - `player1WordsCompleted`  
     - `player2WordsCompleted`  

4. **Navigation**:  
   - Added a route to navigate to the **Sprint Mode** screen.  

---

### **Testing**  
- Verified the functionality of the Sprint Mode rounds and result calculation.  
- Ensured navigation to Sprint Mode works as expected.  
- Confirmed challenges are deleted from the ongoing challenges after completion and appear correctly in the History Screen.

---

### **Screenshots**  
![image](https://github.com/user-attachments/assets/fb1ca997-7fce-4535-98f2-c6c12a1b9e0c)

---
