### PR TITLE
Correct shared preference for language

### DIFF
--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -54,6 +54,9 @@ class MainActivity : ComponentActivity() {
 
   private lateinit var sharedPreferencesTheme: SharedPreferences
   private lateinit var sharedPreferencesLanguage: SharedPreferences
+  private lateinit var sharedPreferenceChangeListener:
+      SharedPreferences.OnSharedPreferenceChangeListener
+
   // Now when launching the MainActivity, the builder will know which dependency provider to use
   // (Test or Base)
   private val dependencyProvider by lazy { (application as BaseApplication).dependencyProvider }
@@ -76,6 +79,8 @@ class MainActivity : ComponentActivity() {
     // Load the saved theme state (default is false for light mode)
     val savedTheme = sharedPreferencesTheme.getBoolean(prefKeyIsDarkTheme, false)
     val savedLanguage = sharedPreferencesLanguage.getBoolean(prefKeyLanguage, false)
+
+    updateLanguage(this, if (savedLanguage) "fr" else "en")
 
     // Tutorial versioning logic
     val currentTutorialVersion = 2 // Update this when the tutorial changes
@@ -115,7 +120,7 @@ class MainActivity : ComponentActivity() {
                 isFrenchLanguage = isFrenchLanguage,
                 onLanguageChange = { isFrench ->
                   isFrenchLanguage = isFrench
-                  sharedPreferencesLanguage.edit().putBoolean(prefNameLanguage, isFrench).apply()
+                  sharedPreferencesLanguage.edit().putBoolean(prefKeyLanguage, isFrench).apply()
                   updateLanguage(this, if (isFrench) "fr" else "en")
                 })
           }

--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -54,9 +54,6 @@ class MainActivity : ComponentActivity() {
 
   private lateinit var sharedPreferencesTheme: SharedPreferences
   private lateinit var sharedPreferencesLanguage: SharedPreferences
-  private lateinit var sharedPreferenceChangeListener:
-      SharedPreferences.OnSharedPreferenceChangeListener
-
   // Now when launching the MainActivity, the builder will know which dependency provider to use
   // (Test or Base)
   private val dependencyProvider by lazy { (application as BaseApplication).dependencyProvider }


### PR DESCRIPTION
### Persist language preference across app sessions

This PR resolves an issue where the app would default to English at launch, regardless of the saved language preference.  

### Summary of Changes:  
1. **Fixed SharedPreferences Edit Call:**  
   - Corrected the `sharedPreferencesLanguage.edit()` call to properly update the `prefKeyLanguage`. This ensures the `savedLanguage` is correctly saved when changed through the settings screen.  

2. **Applied Language Preference at Launch:**  
   - Added a call to the `updateLanguage` function in `onCreate` to ensure the app applies the saved language preference (French/English) on launch.  

### Impact:  
- Users' language preferences are now correctly persisted and applied across sessions.  

### Testing:  
- Verified that the language preference is correctly applied at launch.  
- Tested switching between French and English via the settings screen and confirmed the preference persists across app restarts.  
