### PR TITLE
Fix back navigation to prevent rapid double-tap actions

### DIFF
--- a/app/src/main/java/com/github/se/signify/model/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/signify/model/navigation/NavigationActions.kt
@@ -1,5 +1,6 @@
 package com.github.se.signify.model.navigation
 
+import android.util.Log
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import com.github.se.signify.model.authentication.UserSession
@@ -8,6 +9,10 @@ open class NavigationActions(
     private val navController: NavHostController,
     private val userSession: UserSession,
 ) {
+
+  private var lastBackPressedTime: Long = 0L
+  private val BACK_PRESS_THRESHOLD = 500L // Time in milliseconds to prevent rapid back presses
+
   /**
    * Navigate to the specified top level destination.
    *
@@ -31,11 +36,6 @@ open class NavigationActions(
 
       // Avoid multiple copies of the same destination when reselecting same item
       launchSingleTop = true
-
-      // Restore state when reselecting a previously selected item
-      // if (destination.route != Route.AUTH) {
-      //  restoreState = true
-      // }
     }
   }
 
@@ -66,7 +66,15 @@ open class NavigationActions(
   }
 
   open fun goBack() {
-    navController.popBackStack()
+    val currentTime = System.currentTimeMillis()
+    if (currentTime - lastBackPressedTime < BACK_PRESS_THRESHOLD) {
+      return // Ignore rapid back presses
+    }
+    lastBackPressedTime = currentTime
+
+    if (!navController.popBackStack()) {
+      Log.d("Navigation", "No more screens to pop back to.")
+    }
   }
 
   open fun currentRoute(): String? {

--- a/app/src/main/java/com/github/se/signify/model/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/signify/model/navigation/NavigationActions.kt
@@ -1,7 +1,6 @@
 package com.github.se.signify.model.navigation
 
 import android.util.Log
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import com.github.se.signify.model.authentication.UserSession
 
@@ -27,9 +26,9 @@ open class NavigationActions(
         }
 
     navController.navigate(route) {
-      // Pop up to the start destination of the graph to
+      // Clear the stack at each navigation to the main screens
       // avoid building up a large stack of destinations
-      popUpTo(navController.graph.findStartDestination().id) {
+      popUpTo(0) {
         saveState = true
         inclusive = true
       }


### PR DESCRIPTION
### PR Description  
This PR addresses the issue with the back navigation button where rapid double-taps could cause unintended behavior. The following changes have been made:  

- Added a debounce mechanism to throttle back actions, preventing multiple triggers within 500ms.  
- Updated navigation logic to clear the entire back stack by setting the new route as the root.
- Logged a message when there are no more screens to pop in the navigation stack.  

These changes improve navigation reliability and user experience.