### PR TITLE
Remove button outlines

### DIFF
--- a/app/src/main/java/com/github/se/signify/ui/common/Buttons.kt
+++ b/app/src/main/java/com/github/se/signify/ui/common/Buttons.kt
@@ -12,16 +12,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -83,11 +82,8 @@ fun TextButton(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
 ) {
-  OutlinedButton(
+  Button(
       onClick = onClick,
-      border =
-          ButtonDefaults.outlinedButtonBorder.copy(
-              width = 2.dp, brush = SolidColor(MaterialTheme.colorScheme.background)),
       colors = ButtonDefaults.buttonColors(backgroundColor),
       enabled = enabled,
       modifier = modifier.fillMaxWidth().height(40.dp).testTag(testTag),

--- a/app/src/main/java/com/github/se/signify/ui/common/Practice.kt
+++ b/app/src/main/java/com/github/se/signify/ui/common/Practice.kt
@@ -2,7 +2,6 @@ package com.github.se.signify.ui.common
 
 import android.util.Log
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -84,9 +83,7 @@ fun LetterDictionary(
             Box(
                 contentAlignment = Alignment.Center,
                 modifier =
-                    Modifier.border(
-                            2.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(8.dp))
-                        .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(8.dp))
+                    Modifier.background(MaterialTheme.colorScheme.primary, RoundedCornerShape(8.dp))
                         .then(
                             if (clickable) Modifier.clickable { onClick(page, numbOfHeaders) }
                             else Modifier)

--- a/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/challenge/CreateAChallengeScreen.kt
@@ -125,7 +125,7 @@ fun FriendCard(friendId: String, content: @Composable () -> Unit) {
       modifier =
           Modifier.fillMaxWidth()
               .padding(8.dp)
-              .border(1.dp, Color.Gray, RoundedCornerShape(16.dp))
+              .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(16.dp))
               .testTag("FriendCard_$friendId"), // Add test tag for each friend card
       shape = RoundedCornerShape(16.dp),
   ) {


### PR DESCRIPTION
## Changes

All outlines were removed from buttons both in code and on Figma.

## Next steps

The `CreateAChallengeScreen`s mode picker dialog still looks weird. I wasted some time trying to change it's background to an opaque color, but didn't manage to set it to white, because the `@Composable` acts weird.  I'll let someone else try to fix it, if it is deemed necessary.