### PR TITLE
Remove "NA" Option from language dropdown menu

### DIFF
--- a/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/signify/ui/screens/profile/SettingsScreenTest.kt
@@ -191,7 +191,6 @@ class SettingsScreenTest {
 
     composeTestRule.onNodeWithText("English").assertIsDisplayed()
     composeTestRule.onNodeWithText("French").assertIsDisplayed()
-    composeTestRule.onNodeWithText("No other supported languages").assertIsDisplayed()
 
     composeTestRule.onNodeWithText("English").performClick()
     composeTestRule.onNodeWithTag("LanguageRow").assertTextEquals("EN")
@@ -199,10 +198,6 @@ class SettingsScreenTest {
     composeTestRule.onNodeWithTag("LanguageRow").performClick()
     composeTestRule.onNodeWithText("French").performClick()
     composeTestRule.onNodeWithTag("LanguageRow").assertTextEquals("FR")
-
-    composeTestRule.onNodeWithTag("LanguageRow").performClick()
-    composeTestRule.onNodeWithText("No other supported languages").performClick()
-    composeTestRule.onNodeWithTag("LanguageRow").assertTextEquals("N/A")
   }
 
   @Test

--- a/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/profile/SettingsScreen.kt
@@ -405,12 +405,6 @@ fun LanguageSwitch(isFrench: Boolean, onLanguageChange: (Boolean) -> Unit) {
                 onLanguageChange(true)
                 expanded = false
               })
-          DropdownMenuItem(
-              text = { Text(stringResource(R.string.no_other_supported_languages_text)) },
-              onClick = {
-                selectedLanguage = "N/A"
-                expanded = false
-              })
         }
   }
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -309,10 +309,9 @@
     <string name="skip_tutorial">Passer le tutoriel</string>
     <string name="completed_quest_text">Completé</string>
   
-     <string name="french_text">Français</string>
+    <string name="french_text">Français</string>
     <string name="english_text">Anglais</string>
-    <string name="no_other_supported_languages_text">Aucune autre langue n’est supportée</string>
-  
+
     <string name="logout_button_text">Se déconnecter</string>
     <string name="confirm_logout_title">Confirmer la déconnexion</string>
     <string name="confirm_logout_message">Êtes-vous sûr de vouloir vous déconnecter ?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,7 +317,6 @@ Let’s take a quick tour to help you get started with learning sign language ef
   
     <string name="french_text">French</string>
     <string name="english_text">English</string>
-    <string name="no_other_supported_languages_text">No other supported languages</string>
 
     <string name="logout_button_text">Logout</string>
     <string name="confirm_logout_title">Confirm Logout</string>


### PR DESCRIPTION
### Remove "NA" language option from dropdown menu and tests   

This PR removes the "NA" option from the language selection dropdown menu. The corresponding test for the "NA" option has also been deleted, as it is no longer relevant.  