### PR TITLE
Change the unauthenticated screen to be an annex screen

### DIFF
--- a/app/src/main/java/com/github/se/signify/MainActivity.kt
+++ b/app/src/main/java/com/github/se/signify/MainActivity.kt
@@ -28,6 +28,7 @@ import com.github.se.signify.model.home.hand.HandLandmarkViewModel
 import com.github.se.signify.model.navigation.NavigationActions
 import com.github.se.signify.model.navigation.Route
 import com.github.se.signify.model.navigation.Screen
+import com.github.se.signify.model.navigation.TopLevelDestinations
 import com.github.se.signify.ui.screens.auth.LoginScreen
 import com.github.se.signify.ui.screens.auth.UnauthenticatedScreen
 import com.github.se.signify.ui.screens.challenge.ChallengeHistoryScreen
@@ -167,7 +168,7 @@ fun SignifyAppPreview(
             showTutorial = {
               // Navigate to Tutorial or Home depending on completion
               if (tutorialCompleted) {
-                navigationActions.navigateTo(Screen.HOME)
+                navigationActions.navigateTo(TopLevelDestinations.HOME)
               } else {
                 navigationActions.navigateTo(Screen.TUTORIAL)
               }

--- a/app/src/main/java/com/github/se/signify/model/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/signify/model/navigation/NavigationActions.kt
@@ -18,14 +18,12 @@ open class NavigationActions(
    * @param destination The top level destination to navigate to.
    */
   open fun navigateTo(destination: TopLevelDestination) {
-    val route =
-        if (destination.requiresAuth && !userSession.isLoggedIn()) {
-          Screen.UNAUTHENTICATED.route
-        } else {
-          destination.route
-        }
+    if (destination.requiresAuth && !userSession.isLoggedIn()) {
+      onUnauthenticated()
+      return
+    }
 
-    navController.navigate(route) {
+    navController.navigate(destination.route) {
       // Clear the stack at each navigation to the main screens
       // avoid building up a large stack of destinations
       popUpTo(0) {
@@ -48,6 +46,7 @@ open class NavigationActions(
       onUnauthenticated()
       return
     }
+
     val route =
         if (params != null) {
           var routeWithParams = screen.route

--- a/app/src/main/java/com/github/se/signify/ui/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/auth/LoginScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION") // We were told to use deprecated Google Authentication API
-
 package com.github.se.signify.ui.screens.auth
 
 /**
@@ -57,7 +55,7 @@ import com.github.se.signify.model.authentication.FirebaseAuthService
 import com.github.se.signify.model.authentication.MockAuthService
 import com.github.se.signify.model.common.user.saveUserToFirestore
 import com.github.se.signify.model.navigation.NavigationActions
-import com.github.se.signify.model.navigation.Screen
+import com.github.se.signify.model.navigation.TopLevelDestinations
 import com.github.se.signify.model.profile.stats.saveStatsToFirestore
 import com.google.android.gms.common.api.ApiException
 import com.google.firebase.auth.AuthResult
@@ -153,7 +151,7 @@ fun LoginScreen(
           GoogleSignInButton(
               onSignInClick = {
                 if (authService.isMocked()) {
-                  navigationActions.navigateTo(Screen.HOME)
+                  navigationActions.navigateTo(TopLevelDestinations.HOME)
                   //  /!\ Add mocks here Like quiz, challenge, etc. /!\
                 } else {
                   authLauncher.launch(authService.getSignInIntent(context, token))

--- a/app/src/main/java/com/github/se/signify/ui/screens/auth/UnauthenticatedScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/auth/UnauthenticatedScreen.kt
@@ -23,9 +23,8 @@ import androidx.compose.ui.unit.sp
 import com.github.se.signify.R
 import com.github.se.signify.model.navigation.NavigationActions
 import com.github.se.signify.model.navigation.Screen
-import com.github.se.signify.model.navigation.TopLevelDestinations
+import com.github.se.signify.ui.common.AnnexScreenScaffold
 import com.github.se.signify.ui.common.HelpText
-import com.github.se.signify.ui.common.MainScreenScaffold
 import com.github.se.signify.ui.common.TextButton
 
 /**
@@ -42,9 +41,8 @@ fun UnauthenticatedScreen(navigationActions: NavigationActions) {
   val offlineModeText = stringResource(R.string.offline_mode_text)
   val offModeText = stringResource(R.string.off_mode_text)
 
-  MainScreenScaffold(
+  AnnexScreenScaffold(
       navigationActions = navigationActions,
-      topLevelDestination = TopLevelDestinations.HOME,
       testTag = "UnauthenticatedScreen",
       helpText =
           HelpText(title = offModeText, content = stringResource(R.string.help_offline_mode_text)),

--- a/app/src/main/java/com/github/se/signify/ui/screens/tutorial/TutorialScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/tutorial/TutorialScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.signify.R
 import com.github.se.signify.model.navigation.NavigationActions
-import com.github.se.signify.model.navigation.Screen
+import com.github.se.signify.model.navigation.TopLevelDestinations
 import com.github.se.signify.ui.screens.home.HomeScreen
 
 private val overlayColor
@@ -96,7 +96,7 @@ fun TutorialScreen(navigationActions: NavigationActions, onFinish: () -> Unit) {
           highlightArea = currentStep.highlightArea,
           onNext = {
             if (isLastStep) {
-              navigationActions.navigateTo(Screen.HOME)
+              navigationActions.navigateTo(TopLevelDestinations.HOME)
               onFinish()
             } else {
               step++
@@ -107,7 +107,7 @@ fun TutorialScreen(navigationActions: NavigationActions, onFinish: () -> Unit) {
 
     SkipButton(
         onSkip = {
-          navigationActions.navigateTo(Screen.HOME)
+          navigationActions.navigateTo(TopLevelDestinations.HOME)
           onFinish()
         })
   }

--- a/app/src/main/java/com/github/se/signify/ui/screens/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/github/se/signify/ui/screens/welcome/WelcomeScreen.kt
@@ -33,6 +33,7 @@ import com.github.se.signify.R
 import com.github.se.signify.model.authentication.UserSession
 import com.github.se.signify.model.navigation.NavigationActions
 import com.github.se.signify.model.navigation.Screen
+import com.github.se.signify.model.navigation.TopLevelDestinations
 import kotlinx.coroutines.delay
 
 @Composable
@@ -43,13 +44,6 @@ fun WelcomeScreen(
 
   // Check if the user is authenticated
   val isAuthenticated = userSession.isLoggedIn()
-
-  // Dynamically set the start destination
-  val nextDestination =
-      when {
-        isAuthenticated -> Screen.HOME
-        else -> Screen.AUTH
-      }
 
   // List of image resource ids for hand sign animation
   val images =
@@ -83,7 +77,12 @@ fun WelcomeScreen(
       currentImage += 1
     }
     delay(2000) // Pause after the last image
-    navigationActions.navigateTo(nextDestination)
+
+    if (isAuthenticated) {
+      navigationActions.navigateTo(TopLevelDestinations.HOME)
+    } else {
+      navigationActions.navigateTo(Screen.AUTH)
+    }
   }
 
   Column(

--- a/app/src/test/java/com/github/se/signify/model/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/github/se/signify/model/navigation/NavigationActionsTest.kt
@@ -60,8 +60,7 @@ class NavigationActionsTest {
     navigationActions.navigateTo(destination)
     verify(navController, never())
         .navigate(eq(Route.PROFILE), anyOrNull<NavOptionsBuilder.() -> Unit>())
-    verify(navController)
-        .navigate(eq(Screen.UNAUTHENTICATED.route), anyOrNull<NavOptionsBuilder.() -> Unit>())
+    verify(navController).navigate(eq(Screen.UNAUTHENTICATED.route), anyOrNull(), anyOrNull())
   }
 
   @Test


### PR DESCRIPTION
## Motivation

A recent change stopped the user from leaving the `UnauthenticatedScreen()`.

Additionally, a bug remains where the user can press the system "back" button to navigate back to the login, welcome, or tutorial screens, if they do so before navigating to any other screen.

## Fixes

The `UnauthenticatedScreen()` is now an `AnnexScreen()`, which probably fits it better, and fixes the first bug above.

All instances of `navigationActions.navigateTo(Screen.HOME)` were replaced with `navigationActions.navigateTo(TopLevelDestinations.HOME)`. This fixes the the second bug.

## Notes

SonarCloud computes low test coverage on this PR, yet I've only changed lines that were already difficult to test. Also, this PR is only +23 lines.
I suggest you just ignore the report.