### PR TITLE
Add outline to the profile picture and update figma

### DIFF
--- a/app/src/main/java/com/github/se/signify/ui/common/Profile.kt
+++ b/app/src/main/java/com/github/se/signify/ui/common/Profile.kt
@@ -2,6 +2,7 @@ package com.github.se.signify.ui.common
 
 import android.net.Uri
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -37,18 +38,28 @@ fun ProfilePicture(profilePictureUrl: String?) {
         modifier =
             Modifier.size(120.dp)
                 .clip(CircleShape)
+                .border(
+                    2.dp, MaterialTheme.colorScheme.primary, CircleShape) // Add a border outline
                 .background(MaterialTheme.colorScheme.background)
                 .testTag("ProfilePicture"),
-        contentScale = ContentScale.Crop) // Crop the image to fit within the bounds
+        contentScale = ContentScale.Crop // Crop the image to fit within the bounds
+        )
   } else {
     // Default placeholder for no image
     Icon(
         imageVector = Icons.Default.Person,
         contentDescription = "Default Profile Picture",
-        modifier = Modifier.size(120.dp).testTag("DefaultProfilePicture"),
+        modifier =
+            Modifier.size(120.dp)
+                .clip(CircleShape)
+                .border(
+                    2.dp, MaterialTheme.colorScheme.primary, CircleShape) // Add a border outline
+                .background(MaterialTheme.colorScheme.background)
+                .testTag("DefaultProfilePicture"),
         tint = MaterialTheme.colorScheme.onBackground)
   }
 }
+
 /**
  * A recap of a user's account information.
  *


### PR DESCRIPTION
### Description:
- Added an outline to the profile picture in the app to enhance its visibility and design consistency.
  - The outline is styled using the primary color of the application for a cohesive look.
  - The implementation ensures both user-uploaded images and default placeholder icons have the outline applied.
- Updated the corresponding Figma design to reflect this change for future reference and alignment with the app's UI.

### Changes:
- Modified the `ProfilePicture` composable to include an outlined stroke around the profile picture.
- Synchronized the updated profile picture style with the Figma design for team consistency.

### Note:
This update ensures consistency across the app and design documentation, enhancing the user experience and alignment with the visual design.

![image](https://github.com/user-attachments/assets/f3f45df4-1e84-49a6-b59d-532aa47a8db0)
